### PR TITLE
Add purchase landed costs extended

### DIFF
--- a/purchase_landed_costs_extended/__init__.py
+++ b/purchase_landed_costs_extended/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2010-2014 Elico Corp. All Rights Reserved.
+#    Augustin Cisterne-Kaas <augustin.cisterne-kaas@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+import purchase
+import report
+import wizard

--- a/purchase_landed_costs_extended/__openerp__.py
+++ b/purchase_landed_costs_extended/__openerp__.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2010-2014 Elico Corp. All Rights Reserved.
+#    Augustin Cisterne-Kaas <augustin.cisterne-kaas@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{'name': 'Purchase Landed Costs Extended',
+ 'version': '0.1',
+ 'category': 'Warehouse Management',
+ 'depends': ['purchase_landed_costs'],
+ 'author': 'Elico Corp',
+ 'license': 'AGPL-3',
+ 'website': 'https://www.elico-corp.com',
+ 'description': """
+
+""",
+ 'images': [],
+ 'demo': [],
+ 'data': ['purchase_view.xml',
+          'report/purchase_report_view.xml',
+          'wizard/landed_cost_position_invoice_view.xml',
+          'security/ir.model.access.csv'],
+ 'installable': True,
+ 'application': False}

--- a/purchase_landed_costs_extended/purchase.py
+++ b/purchase_landed_costs_extended/purchase.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2010-2014 Elico Corp. All Rights Reserved.
+#    Augustin Cisterne-Kaas <augustin.cisterne-kaas@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import orm, fields
+import openerp.addons.decimal_precision as dp
+
+
+class landed_cost_position(orm.Model):
+    _inherit = 'landed.cost.position'
+
+    def onchange_partner_id(self, cr, uid, ids, partner_id, context=None):
+        if not partner_id:
+            return {}
+        partner = self.pool.get('res.partner').browse(
+            cr, uid, partner_id, context=context)
+        pricelist = partner.property_product_pricelist_purchase
+        return {'value': {'currency_id': pricelist.currency_id.id}}
+
+    def onchange_amount_currency(self, cr, uid, ids,
+                                 amount_currency, currency_id,
+                                 date_po, context=None):
+        assert len(ids) < 2
+        parent_currency_id = None
+        if ids:
+            landed_cost = self.browse(cr, uid, ids[0], context=context)
+            parent_currency_id = landed_cost.po_currency_id.id
+        else:
+            parent_currency_id = self._default_currency(
+                cr, uid, context=context)
+        if not parent_currency_id or not amount_currency or not currency_id:
+            return {}
+        cur_obj = self.pool.get('res.currency')
+        amount = amount_currency
+        if currency_id != parent_currency_id:
+            ctx = context.copy()
+            ctx['date'] = date_po or False
+            amount = cur_obj.compute(cr, uid,
+                                     currency_id,
+                                     parent_currency_id,
+                                     amount,
+                                     context=ctx)
+        return {'value': {'amount': amount}}
+
+    def _default_currency(self, cr, uid, context=None):
+        context = context or {}
+        pricelist_id = context.get('pricelist_id', [])
+        pricelist = self.pool.get('product.pricelist').read(
+            cr, uid, pricelist_id, ['currency_id'])
+        parent_currency_id = None
+        if pricelist:
+            parent_currency_id = pricelist['currency_id'][0]
+        return parent_currency_id
+
+    _columns = {
+        'amount_currency': fields.float(
+            'Currency Amount',
+            digits_compute=dp.get_precision('Purchase Price'),
+            help="Landed cost expressed in Landed Cost line currency"),
+        'currency_id': fields.many2one(
+            'res.currency', 'Currency'),
+        'po_pricelist_id': fields.related(
+            'purchase_order_id', 'pricelist_id',
+            type='many2one',
+            relation='product.pricelist',
+            string='PO Pricelist',
+            store=True,
+            readonly=True,
+            help="PO pricelist"),
+        'po_currency_id': fields.related(
+            'po_pricelist_id', 'currency_id',
+            type='many2one',
+            relation='res.currency',
+            string='PO Currency',
+            store=True,
+            readonly=True,
+            help="PO Currency"),
+        'invoice_id': fields.many2one('account.invoice', 'Invoice'),
+        'active': fields.boolean('Active')
+    }
+
+    _defaults = {
+        'currency_id': _default_currency,
+        'active': True
+    }
+
+    def open_invoice(self, cr, uid, ids, context=None):
+        assert len(ids) == 1
+        lcp = self.browse(cr, uid, ids[0], context=context)
+        if not lcp.invoice_id:
+            return {}
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Form heading',
+            'view_mode': 'form',
+            'view_type': 'form',
+            'res_model': 'account.invoice',
+            'nodestroy': True,
+            'res_id': lcp.invoice_id.id,
+            'context': context
+        }
+
+
+class purchase_order(orm.Model):
+    _inherit = 'purchase.order'
+
+    def _generate_invoice_from_landed_cost(self, cr, uid, landed_cost,
+                                           context=None):
+        if landed_cost.invoice_id:
+            return landed_cost.invoice_id.id
+        inv_id = super(
+            purchase_order, self
+        )._generate_invoice_from_landed_cost(
+            cr, uid, landed_cost, context=context)
+        landed_cost.write({'invoice_id': inv_id}, context=context)
+        return inv_id
+
+    def _prepare_landed_cost_inv_line(self, cr, uid, account_id, inv_id,
+                                      landed_cost, context=None):
+        res = super(purchase_order, self)._prepare_landed_cost_inv_line(
+            cr, uid, account_id, inv_id, landed_cost, context=context)
+        res['price_unit'] = landed_cost.amount_currency
+        return res
+
+    def _prepare_landed_cost_inv(self, cr, uid, landed_cost, context=None):
+        res = super(purchase_order, self)._prepare_landed_cost_inv(
+            cr, uid, landed_cost, context=context)
+        res['currency_id'] = landed_cost.currency_id.id
+        return res
+
+    def wkf_approve_order(self, cr, uid, ids, context=None):
+        """ On PO approval, generate all invoices for all landed cost position.
+
+        Remember that only landed cost position with the checkbox
+        generate_invoice ticked are generated.
+
+        """
+        lcp_pool = self.pool.get('landed.cost.position')
+        line_ids = []
+        for order in self.browse(cr, uid, ids, context=context):
+            for po_line in order.order_line:
+                for line_cost in po_line.landed_cost_line_ids:
+                    if not line_cost.generate_invoice or line_cost.invoice_id:
+                        line_ids = line_cost.id
+        lcp_pool.write(cr, uid, line_ids, {'active': False})
+
+        res = super(purchase_order, self).wkf_approve_order(cr, uid, ids,
+                                                            context=context)
+        lcp_pool.write(cr, uid, line_ids, {'active': True})
+        return res

--- a/purchase_landed_costs_extended/purchase_view.xml
+++ b/purchase_landed_costs_extended/purchase_view.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="purchase_order_form" model="ir.ui.view">
+            <field name="name">purchase.order.form</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase_landed_costs.c2c_purchase_order_landed_cost_view" />
+            <field name="arch" type="xml" >
+                <field name="order_line" position="attributes">
+                    <attribute name="attrs">{'readonly': [('pricelist_id', '=', False)]}</attribute>
+                    <attribute name="context">{'pricelist_id': pricelist_id}</attribute>
+                </field>
+                <xpath expr="//field[@name='order_line']/tree" position="attributes">
+                    <attribute name="editable"></attribute>
+                </xpath>
+                <field name="landed_cost_line_ids" position="attributes">
+                    <attribute name="attrs">{'readonly': [('pricelist_id', '=', False)]}</attribute>
+                    <attribute name="context">{'pricelist_id': pricelist_id}</attribute>
+                </field>
+                <xpath expr="//field[@name='landed_cost_line_ids']/tree/field[@name='amount']" position="before">
+                    <field
+                        name="amount_currency"
+                        on_change="onchange_amount_currency(amount_currency, currency_id, date_po, context)"
+                    />
+                    <field
+                        name="currency_id"
+                        on_change="onchange_amount_currency(amount_currency, currency_id, date_po, context)"
+                    />           
+                </xpath>
+                <xpath expr="//field[@name='landed_cost_line_ids']/tree/field[@name='amount']" position="after">
+                    <field name="invoice_id" readonly="True" />
+                    <button name="open_invoice" type="object" attrs="{'invisible': [('invoice_id', '=', False)]}" string="Invoice" icon="gtk-open" />
+                    
+                    <field name="date_po" invisible="True" />        
+                </xpath>
+   
+                <xpath expr="//field[@name='landed_cost_line_ids']/tree/field[@name='partner_id']" position="attributes">
+                    <attribute name="on_change">onchange_partner_id(partner_id)</attribute>         
+                </xpath>
+            </field>
+        </record>
+
+        <record id="purchase_order_line_form" model="ir.ui.view">
+            <field name="name">purchase.order.line.form</field>
+            <field name="model">purchase.order.line</field>
+            <field name="inherit_id" ref="purchase_landed_costs.purchase_oder_line_landed_cost_view" />
+            <field name="arch" type="xml" >
+                <field name="product_id" position="attributes">
+                    <attribute name="attrs">{'readonly': [('state', '!=', 'draft')]}</attribute>
+                </field>
+                <field name="product_qty" position="attributes">
+                    <attribute name="attrs">{'readonly': [('state', '!=', 'draft')]}</attribute>
+                </field>
+                <field name="price_unit" position="attributes">
+                    <attribute name="attrs">{'readonly': [('state', '!=', 'draft')]}</attribute>
+                </field>
+                <field name="taxes_id" position="attributes">
+                    <attribute name="attrs">{'readonly': [('state', '!=', 'draft')]}</attribute>
+                </field>
+                <field name="date_planned" position="attributes">
+                    <attribute name="attrs">{'readonly': [('state', '!=', 'draft')]}</attribute>
+                </field>
+                <field name="name" position="attributes">
+                    <attribute name="attrs">{'readonly': [('state', '!=', 'draft')]}</attribute>
+                </field>
+                <field name="product_id" position="after">
+                    <field name="state" invisible="True" />
+                </field>
+                <field name="landed_cost_line_ids" position="attributes">
+                    <attribute name="context">{'pricelist_id': context['pricelist_id']}</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="c2c_landed_cost_tree">
+            <field name="name">c2clanded.cost.tree</field>
+            <field name="model">landed.cost.position</field>
+            <field name="inherit_id" ref="purchase_landed_costs.c2c_landed_cost_tree" />
+            <field name="arch" type="xml">
+                <field name="partner_id" position="attributes">
+                    <attribute name="on_change">onchange_partner_id(partner_id)</attribute>
+                </field>
+                <field name="amount" position="before">
+                    <field
+                        name="amount_currency"
+                        on_change="onchange_amount_currency(amount_currency, currency_id, date_po, context)"
+                    />
+                    <field
+                        name="currency_id"
+                        on_change="onchange_amount_currency(amount_currency, currency_id, date_po, context)"
+                    />
+                </field>
+                <field name="amount" position="after">
+                    <field name="invoice_id" readonly="True" />
+                    <button name="open_invoice" type="object" attrs="{'invisible': [('invoice_id', '=', False)]}" string="Invoice" icon="gtk-open" />
+                    <field name="date_po" invisible="True" />
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="c2c_landed_cost_form">
+            <field name="name">c2clanded.cost.form</field>
+            <field name="model">landed.cost.position</field>
+            <field name="inherit_id" ref="purchase_landed_costs.c2c_landed_cost_form" />
+            <field name="arch" type="xml">
+                <field name="partner_id" position="attributes">
+                    <attribute name="on_change">onchange_partner_id(partner_id)</attribute>
+                </field>
+                <field name="amount" position="before">
+                    <field
+                        name="amount_currency"
+                        on_change="onchange_amount_currency(amount_currency, currency_id, date_po, context)"
+                    />
+                    <field
+                        name="currency_id"
+                        on_change="onchange_amount_currency(amount_currency, currency_id, date_po, context)"
+                    />
+                </field>
+                <field name="amount" position="after">
+                    <field name="invoice_id" readonly="True" />
+                    <button name="open_invoice" type="object" attrs="{'invisible': [('invoice_id', '=', False)]}" string="Invoice" icon="gtk-open" />
+                    <field name="date_po" invisible="True" />
+                </field>
+            </field>
+        </record>
+
+
+
+        <record model="ir.ui.view" id="landed_cost_tree">
+          <field name="name">landed.cost.tree</field>
+          <field name="model">landed.cost.position</field>
+          <field name="priority">50</field>
+          <field name="type">tree</field>
+          <field name="arch" type="xml">
+            <tree string="Landing Costs" editable="bottom" create="false">
+                  <field name="purchase_order_id"/>
+                  <field name="generate_invoice"/>
+                  <field name="product_id" context="{'landed_cost_type':'per_unit'}" on_change="onchange_product_id(product_id)"/>
+                  <field name="account_id" invisible="1"/>
+                  <field name="partner_id" on_change="onchange_partner_id(partner_id)" />
+                  <field
+                      name="amount_currency"
+                      on_change="onchange_amount_currency(amount_currency, currency_id, date_po, context)"
+                  />
+                  <field
+                      name="currency_id"
+                      on_change="onchange_amount_currency(amount_currency, currency_id, date_po, context)"
+                  />
+                  <field name="amount"/>
+                  <field name="po_currency_id"/>
+                  <field name="distribution_type_id" domain="[('apply_on','=','line')]"  widget="selection"/>
+                  <field name="invoice_id" readonly="True" />
+                  <button name="open_invoice" type="object" attrs="{'invisible': [('invoice_id', '=', False)]}" string="Invoice" icon="gtk-open" />
+                  <field name="date_po" invisible="True" />
+            </tree>
+          </field>
+        </record>
+
+
+        <record id="po_landed_costs_extended" model="ir.actions.act_window">
+            <field name="name">Landed Costs</field>
+            <field name="res_model">landed.cost.position</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_id" ref="landed_cost_tree"></field>
+        </record>
+
+        <menuitem action="po_landed_costs_extended" id="menu_action_landed_cost" parent="purchase.menu_procurement_management_invoice" sequence="100"/>
+    </data>
+</openerp>

--- a/purchase_landed_costs_extended/report/__init__.py
+++ b/purchase_landed_costs_extended/report/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2010-2014 Elico Corp. All Rights Reserved.
+#    Augustin Cisterne-Kaas <augustin.cisterne-kaas@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+import purchase_report

--- a/purchase_landed_costs_extended/report/purchase_report.py
+++ b/purchase_landed_costs_extended/report/purchase_report.py
@@ -1,0 +1,399 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2010-2014 Elico Corp. All Rights Reserved.
+#    Augustin Cisterne-Kaas <augustin.cisterne-kaas@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+#
+# Please note that these reports are not multi-currency !!!
+#
+from openerp.osv import fields, orm
+from openerp import tools
+
+
+class purchase_landed_cost_report(orm.Model):
+    _name = "purchase.landed.cost.report"
+    _description = "Purchases Orders"
+    _auto = False
+    _columns = {
+        'date': fields.date(
+            'Order Date', readonly=True,
+            help="Date on which this document has been created"),
+        'name': fields.char('Year', size=64, required=False, readonly=True),
+        'day': fields.char('Day', size=128, readonly=True),
+        'state': fields.selection([
+            ('draft', 'Request for Quotation'),
+            ('confirmed', 'Waiting Supplier Ack'),
+            ('approved', 'Approved'),
+            ('except_picking', 'Shipping Exception'),
+            ('except_invoice', 'Invoice Exception'),
+            ('done', 'Done'),
+            ('cancel', 'Cancelled')],
+            'Order Status', readonly=True),
+        'product_id': fields.many2one(
+            'product.product', 'Product', readonly=True),
+        'warehouse_id': fields.many2one(
+            'stock.warehouse', 'Warehouse', readonly=True),
+        'location_id': fields.many2one(
+            'stock.location', 'Destination', readonly=True),
+        'partner_id': fields.many2one(
+            'res.partner', 'Supplier', readonly=True),
+        'pricelist_id': fields.many2one(
+            'product.pricelist', 'Pricelist', readonly=True),
+        'date_approve': fields.date(
+            'Date Approved', readonly=True),
+        'expected_date': fields.date(
+            'Expected Date', readonly=True),
+        'validator': fields.many2one(
+            'res.users', 'Validated By', readonly=True),
+        'product_uom': fields.many2one(
+            'product.uom', 'Reference Unit of Measure', required=True),
+        'company_id': fields.many2one(
+            'res.company', 'Company', readonly=True),
+        'user_id': fields.many2one(
+            'res.users', 'Responsible', readonly=True),
+        'quantity': fields.float('Quantity', readonly=True),
+        'price_total': fields.float('Total Price', readonly=True),
+        'price_average': fields.float(
+            'Average Price', readonly=True,
+            group_operator="avg"),
+        'negociation': fields.float(
+            'Purchase-Standard Price', readonly=True,
+            group_operator="avg"),
+        'price_standard': fields.float(
+            'Products Value', readonly=True,
+            group_operator="sum"),
+        'nbr': fields.integer('# of Lines', readonly=True),
+        'month': fields.selection(
+            [
+                ('01', 'January'), ('02', 'February'), ('03', 'March'),
+                ('04', 'April'), ('05', 'May'), ('06', 'June'),
+                ('07', 'July'), ('08', 'August'), ('09', 'September'),
+                ('10', 'October'), ('11', 'November'), ('12', 'December')
+            ], 'Month', readonly=True),
+        'category_id': fields.many2one('product.category', 'Category',
+                                       readonly=True),
+        'landed_cost_total': fields.float(
+            'Landed cost total', readonly=True,
+            group_operator="sum"),
+        'landed_cost_unit': fields.float(
+            'Landed cost unit', readonly=True,
+            group_operator="sum"),
+        'purchase_order_id': fields.many2one(
+            'purchase.order', 'Purchase Order', readonly=True),
+    }
+    _order = 'name desc,price_total desc'
+
+    def init(self, cr):
+        tools.sql.drop_view_if_exists(cr, 'purchase_landed_cost_report')
+        cr.execute("""
+            CREATE OR REPLACE FUNCTION po_landed_cost_per_unit(int)
+            RETURNS numeric
+                AS '
+            SELECT sum(subtotal) FROM (SELECT
+
+                                         ((po_lcp.amount_company_currency
+                                          / (SELECT sum(product_qty) FROM
+                                            purchase_order_line
+                                            WHERE order_id = pol.order_id))
+                                          * pol.product_qty
+                                    ) as subtotal
+                                    FROM purchase_order_line POL
+                                    LEFT JOIN landed_cost_position po_lcp
+                                    ON po_lcp.purchase_order_id = pol.order_id
+                                    LEFT JOIN landed_cost_distribution_type
+                                    po_lcdt
+                                    ON po_lcdt.id = po_lcp.distribution_type_id
+                                    WHERE pol.id = $1
+                                    AND po_lcp.active = true
+                                    AND po_lcp.purchase_order_line_id is null
+                                    AND po_lcdt.landed_cost_type = ''per_unit''
+                                    GROUP BY pol.id, po_lcp.id, po_lcdt.id)
+                                    as result'
+                       LANGUAGE SQL;
+
+            CREATE OR REPLACE FUNCTION po_landed_cost_per_value(int)
+            RETURNS numeric
+                AS '
+                    SELECT sum(subtotal)
+                    FROM (
+                        SELECT (
+                            (po_lcp.amount_company_currency
+                                * (pol.price_unit
+                                * pol.product_qty)) / po.amount_untaxed
+                        ) as subtotal
+                        FROM purchase_order_line POL
+                        LEFT JOIN purchase_order po
+                        ON po.id = pol.order_id
+                        LEFT JOIN landed_cost_position po_lcp
+                        ON po_lcp.purchase_order_id = pol.order_id
+                        LEFT JOIN landed_cost_distribution_type po_lcdt
+                        ON po_lcdt.id = po_lcp.distribution_type_id
+                        WHERE pol.id = $1
+                            AND po_lcp.active = true
+                            AND po_lcp.purchase_order_line_id is null
+                            AND po_lcdt.landed_cost_type = ''value''
+                        GROUP BY pol.id, po.id, po_lcp.id, po_lcdt.id) as
+                        result'
+            LANGUAGE SQL;
+
+
+            CREATE OR REPLACE FUNCTION pol_landed_cost_per_unit(int) RETURNS
+            numeric
+                AS '
+                    SELECT sum(subtotal)
+                    FROM (
+                        SELECT
+                                    pol.id as polid,
+                                    (
+                                        pol_lcp.amount_company_currency
+                                        * pol.product_qty
+                                    ) as subtotal
+                                    FROM purchase_order_line POL
+                                    LEFT JOIN landed_cost_position pol_lcp
+                                    ON pol_lcp.purchase_order_line_id = pol.id
+                                    LEFT JOIN landed_cost_distribution_type
+                                    pol_lcdt
+                                    ON
+                                    pol_lcdt.id = pol_lcp.distribution_type_id
+                                    WHERE pol.id = $1
+                                    AND pol_lcp.active = true
+                                    AND
+                                    pol_lcdt.landed_cost_type = ''per_unit''
+                                    GROUP BY pol.id, pol_lcp.id, pol_lcdt.id)
+                                    as result'
+            LANGUAGE SQL;
+
+            CREATE OR REPLACE FUNCTION pol_landed_cost_per_value(int) RETURNS
+            numeric
+                AS 'SELECT sum(subtotal)
+                    FROM (
+                            SELECT
+                                    pol.id as polid,
+                                    pol_lcp.amount_company_currency as subtotal
+                                    FROM purchase_order_line POL
+                                    LEFT JOIN landed_cost_position pol_lcp
+                                    ON pol_lcp.purchase_order_line_id = pol.id
+                                    LEFT JOIN landed_cost_distribution_type
+                                    pol_lcdt
+                                    ON
+                                    pol_lcdt.id = pol_lcp.distribution_type_id
+                                    WHERE pol.id = $1
+                                    AND pol_lcp.active = true
+                                    AND pol_lcdt.landed_cost_type = ''value''
+                                    GROUP BY pol.id, pol_lcp.id, pol_lcdt.id)
+                                    as result'
+            LANGUAGE SQL;
+
+
+            CREATE OR REPLACE FUNCTION pol_landed_cost_total(int) RETURNS
+            numeric
+                AS 'SELECT sum(subtotal)
+                    FROM (select po_landed_cost_per_unit as subtotal
+                        from po_landed_cost_per_unit($1) UNION
+            select po_landed_cost_per_value as subtotal
+            from po_landed_cost_per_value($1) UNION
+            select pol_landed_cost_per_unit as subtotal
+            from pol_landed_cost_per_unit($1) UNION
+            select pol_landed_cost_per_value as subtotal
+            from pol_landed_cost_per_value($1)) as result'
+            LANGUAGE SQL;
+
+            CREATE OR REPLACE FUNCTION single_pol_po_landed_cost_per_unit(int)
+            RETURNS numeric
+                AS '
+            SELECT sum(subtotal) FROM (SELECT
+
+                                         ((po_lcp.amount_company_currency
+                                          / (SELECT sum(product_qty) FROM
+                                            purchase_order_line WHERE
+                                            order_id = pol.order_id))
+                                    ) as subtotal
+                                    FROM purchase_order_line POL
+                                    LEFT JOIN landed_cost_position po_lcp
+                                    ON po_lcp.purchase_order_id = pol.order_id
+                                    LEFT JOIN landed_cost_distribution_type
+                                    po_lcdt
+                                    ON po_lcdt.id = po_lcp.distribution_type_id
+                                    WHERE pol.id = $1
+                                    AND po_lcp.active = true
+                                    AND po_lcp.purchase_order_line_id is null
+                                    AND po_lcdt.landed_cost_type = ''per_unit''
+                                    GROUP BY pol.id, po_lcp.id, po_lcdt.id)
+                                    as result'
+                       LANGUAGE SQL;
+            CREATE OR REPLACE FUNCTION single_pol_po_landed_cost_per_value(int)
+            RETURNS numeric
+                AS '
+                    SELECT sum(subtotal)
+                    FROM (
+                        SELECT (
+                            (po_lcp.amount_company_currency * pol.price_unit) /
+                            po.amount_untaxed
+                        ) as subtotal
+                        FROM purchase_order_line POL
+                        LEFT JOIN purchase_order po
+                        ON po.id = pol.order_id
+                        LEFT JOIN landed_cost_position po_lcp
+                        ON po_lcp.purchase_order_id = pol.order_id
+                        LEFT JOIN landed_cost_distribution_type po_lcdt
+                        ON po_lcdt.id = po_lcp.distribution_type_id
+                        WHERE pol.id = $1
+                            AND po_lcp.active = true
+                            AND po_lcp.purchase_order_line_id is null
+                            AND po_lcdt.landed_cost_type = ''value''
+                        GROUP BY pol.id, po.id, po_lcp.id, po_lcdt.id)
+                        as result'
+            LANGUAGE SQL;
+
+
+            CREATE OR REPLACE FUNCTION single_pol_landed_cost_per_unit(int)
+            RETURNS numeric
+                AS '
+                    SELECT sum(subtotal)
+                    FROM (
+                        SELECT
+                                    pol.id as polid,
+                                    pol_lcp.amount_company_currency as subtotal
+                                    FROM purchase_order_line POL
+                                    LEFT JOIN landed_cost_position pol_lcp
+                                    ON pol_lcp.purchase_order_line_id = pol.id
+                                    LEFT JOIN landed_cost_distribution_type
+                                    pol_lcdt
+                                    ON
+                                    pol_lcdt.id = pol_lcp.distribution_type_id
+                                    WHERE pol.id = $1
+                                    AND pol_lcp.active = true
+                                    AND
+                                    pol_lcdt.landed_cost_type = ''per_unit''
+                                    GROUP BY pol.id, pol_lcp.id, pol_lcdt.id)
+                                    as result'
+            LANGUAGE SQL;
+
+           CREATE OR REPLACE FUNCTION single_pol_landed_cost_per_value(int) RETURNS
+            numeric
+                AS 'SELECT sum(subtotal)
+                    FROM (
+                            SELECT
+                                    pol.id as polid,
+                                    (
+                                        pol_lcp.amount_company_currency /
+                                        pol.product_qty
+                                    )as subtotal
+                                    FROM purchase_order_line POL
+                                    LEFT JOIN landed_cost_position pol_lcp
+                                    ON pol_lcp.purchase_order_line_id = pol.id
+                                    LEFT JOIN landed_cost_distribution_type
+                                    pol_lcdt
+                                    ON
+                                    pol_lcdt.id = pol_lcp.distribution_type_id
+                                    WHERE pol.id = $1
+                                    AND pol_lcp.active = true
+                                    AND pol_lcdt.landed_cost_type = ''value''
+                                    GROUP BY pol.id, pol_lcp.id, pol_lcdt.id)
+                                    as result'
+            LANGUAGE SQL;
+            CREATE OR REPLACE FUNCTION pol_landed_cost_unit(int)
+            RETURNS numeric
+                AS 'SELECT sum(subtotal)
+                    FROM (select single_pol_po_landed_cost_per_unit as subtotal
+                        from single_pol_po_landed_cost_per_unit($1) UNION
+            select single_pol_po_landed_cost_per_value as subtotal
+            from single_pol_po_landed_cost_per_value($1) UNION
+            select single_pol_landed_cost_per_unit as subtotal
+            from single_pol_landed_cost_per_unit($1) UNION
+            select single_pol_landed_cost_per_value as subtotal
+            from single_pol_landed_cost_per_value($1)) as result'
+            LANGUAGE SQL;
+            create or replace view purchase_landed_cost_report as (
+                 select
+                    min(l.id) as id,
+                    s.id as purchase_order_id,
+                    s.date_order as date,
+                    to_char(s.date_order, 'YYYY') as name,
+                    to_char(s.date_order, 'MM') as month,
+                    to_char(s.date_order, 'YYYY-MM-DD') as day,
+                    s.state,
+                    s.date_approve,
+                    s.minimum_planned_date as expected_date,
+                    s.dest_address_id,
+                    s.pricelist_id,
+                    s.validator,
+                    s.warehouse_id as warehouse_id,
+                    s.partner_id as partner_id,
+                    s.create_uid as user_id,
+                    s.company_id as company_id,
+                    l.product_id,
+                    t.categ_id as category_id,
+                    t.uom_id as product_uom,
+                    s.location_id as location_id,
+                    sum(l.product_qty/u.factor*u2.factor) as quantity,
+                    count(*) as nbr,
+                    sum(l.price_unit*l.product_qty)::decimal(16,2)
+                    as price_total,
+                    avg(100.0 * (l.price_unit*l.product_qty) / NULLIF(
+                        t.standard_price*l.product_qty/
+                        u.factor*u2.factor, 0.0))::decimal(16,2)
+                        as negociation,
+                    sum(t.standard_price*l.product_qty/u.factor*u2.factor
+                        )::decimal(16,2) as price_standard,
+                    (sum(l.product_qty*l.price_unit)/NULLIF(sum(
+                        l.product_qty/u.factor*u2.factor),0.0)
+                        )::decimal(16,2) as price_average,
+                    pol_landed_cost_total(l.id)::decimal(16,2) as
+                    landed_cost_total,
+                    pol_landed_cost_unit(l.id)::decimal(16,2) as
+                    landed_cost_unit
+                from purchase_order_line l
+                    join purchase_order s on (l.order_id=s.id)
+                        left join product_product p on (l.product_id=p.id)
+                            left join product_template t on (
+                                p.product_tmpl_id=t.id)
+                    left join product_uom u on (u.id=l.product_uom)
+                    left join product_uom u2 on (u2.id=t.uom_id)
+                group by
+                    s.company_id,
+                    s.create_uid,
+                    s.partner_id,
+                    u.factor,
+                    s.location_id,
+                    l.id,
+                    s.id,
+                    l.price_unit,
+                    s.date_approve,
+                    l.date_planned,
+                    l.product_uom,
+                    s.minimum_planned_date,
+                    s.pricelist_id,
+                    s.validator,
+                    s.dest_address_id,
+                    l.product_id,
+                    t.categ_id,
+                    s.date_order,
+                    to_char(s.date_order, 'YYYY'),
+                    to_char(s.date_order, 'MM'),
+                    to_char(s.date_order, 'YYYY-MM-DD'),
+                    s.state,
+                    s.warehouse_id,
+                    u.uom_type,
+                    u.category_id,
+                    t.uom_id,
+                    u.id,
+                    u2.factor
+            )
+        """)

--- a/purchase_landed_costs_extended/report/purchase_report_view.xml
+++ b/purchase_landed_costs_extended/report/purchase_report_view.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+            <record model="ir.ui.view" id="view_purchase_order_landed_cost_graph">
+                <field name="name">product.month.graph</field>
+                <field name="model">purchase.landed.cost.report</field>
+                <field name="arch" type="xml">
+                    <graph string="Purchase Orders Statistics" type="bar">
+                        <field name="product_id"/>
+                        <field name="price_total" operator="+"/>
+                    </graph>
+                </field>
+            </record>
+
+            <record id="view_purchase_order_landed_cost_tree" model="ir.ui.view">
+                <field name="name">purchase.order.landed.cost.tree</field>
+                <field name="model">purchase.landed.cost.report</field>
+                <field name="arch" type="xml">
+                    <tree string="Purchase Orders Statistics" create="false">
+                        <field name="date" invisible="1"/>
+                        <field name="date_approve" invisible="1"/>
+                        <field name="expected_date" invisible="1"/>
+                        <field name="user_id" invisible="1"/>
+                        <field name="partner_id" invisible="1"/>
+                        <field name="product_id" invisible="1"/>
+                        <field name="category_id" invisible="1"/>
+                        <field name="product_uom" invisible="1"/>
+                        <field name="day" invisible="1"/>
+                        <field name="name" invisible="1"/>
+                        <field name="month" invisible="1"/>
+                        <field name="warehouse_id" invisible="1"/>
+                        <field name="validator" invisible="1"/>
+                        <field name="company_id" invisible="1"/>
+                        <field name="state" invisible="1"/>
+                        <field name="location_id" invisible="1"/>
+                        <field name="nbr" sum="# of Lines"/>
+                        <field name="quantity" sum="Quantity"/>
+                        <field name="price_average" sum="Average Price"/>
+                        <field name="price_total" sum="Total Price"/>
+                        <field name="price_standard" sum="Products Value"/>
+                        <field name="negociation" widget="progressbar"/>
+                        <field name="landed_cost_unit" sum="Landed cost unit"/>
+                        <field name="landed_cost_total" sum="Landed cost unit"/>
+                    </tree>
+                </field>
+            </record>
+
+            <record id="view_purchase_order_landed_cost_search" model="ir.ui.view">
+            <field name="name">report.purchase.order.landed.cost.search</field>
+            <field name="model">purchase.landed.cost.report</field>
+            <field name="arch" type="xml">
+                <search string="Purchase Orders">
+                    <filter icon="terp-document-new" string="Quotations" name="quotes" domain="[('state','=','draft')]"/>
+                    <filter icon="terp-gtk-jump-to-rtl" string="Orders" name="orders" domain="[('state','&lt;&gt;','draft'),('state','&lt;&gt;','cancel')]"/>
+                    <field name="partner_id"/>
+                    <field name="product_id"/>
+                    <field name="purchase_order_id"/>
+                    <group expand="0" string="Extended Filters...">
+                        <field name="user_id"/>
+                        <field name="validator"/>
+                        <field name="location_id"/>
+                        <field name="warehouse_id"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
+                        <field name="date"/>
+                        <field name="date_approve"/>
+                        <field name="expected_date"/>
+                    </group>
+                    <newline/>
+                    <group expand="1" string="Group By...">
+                        <filter string="Supplier" name="group_partner_id" icon="terp-personal" context="{'group_by':'partner_id'}"/>
+                        <filter string="Responsible" name="Responsible" icon="terp-personal" context="{'group_by':'user_id'}"/>
+                        <filter string="Validated by" icon="terp-personal" context="{'group_by':'validator'}"/>
+                        <filter string="Product" name="group_product_id" icon="terp-accessories-archiver" context="{'group_by':'product_id'}"/>
+                        <filter string="Order" name="group_purchase_order_id" icon="terp-accessories-archiver" context="{'group_by':'purchase_order_id'}"/>
+                        <filter string="Category" name="group_category_id" icon="terp-stock_symbol-selection" context="{'group_by':'category_id'}"/>
+                        <filter string="Warehouse" icon="terp-go-home" context="{'group_by':'warehouse_id'}"/>
+                        <filter string="Reference UOM" name="group_product_uom" icon="terp-mrp" context="{'group_by':'product_uom'}"/>
+                        <filter string="Destination" icon="terp-gtk-jump-to-ltr" context="{'group_by':'location_id'}"/>
+                        <filter string="Status" icon="terp-stock_effects-object-colorize" context="{'group_by':'state'}"/>
+                        <filter string="Company" icon="terp-go-home" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
+                        <filter string="Day" icon="terp-go-today" context="{'group_by':'day'}" help="Order of Day"/>
+                        <filter string="Month" icon="terp-go-month" context="{'group_by':'month'}" help="Order of Month"/>
+                        <filter string="Year" icon="terp-go-year" context="{'group_by':'name'}" help="Order of Year"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="view_purchase_order_landed_cost_qty_amount_graph">
+                <field name="name">purchase.order.landed.cost.qty.amount.graph</field>
+                <field name="model">purchase.landed.cost.report</field>
+                <field name="arch" type="xml">
+                    <graph string="Total Qty and Amount by month" type="bar">
+                        <field name="month"/>
+                        <field name="quantity" operator="+"/>
+                        <field name="price_total" operator="+"/>
+                    </graph>
+                </field>
+            </record>
+
+        <record model="ir.ui.view" id="view_purchase_order_landed_cost_by_user_graph">
+                <field name="name">purchase.order.landed.cost.by.user.graph</field>
+                <field name="model">purchase.landed.cost.report</field>
+                <field name="arch" type="xml">
+                    <graph string="Total Orders Lines by User per month" orientation="vertical" type="bar">
+                        <field name="month" />
+                        <field name="nbr" operator="+"/>
+                        <field name="user_id" group="True" />
+                    </graph>
+                </field>
+            </record>
+
+
+        <record id="action_purchase_order_landed_cost_landed_cost_report_all" model="ir.actions.act_window">
+            <field name="name">Landed Cost Extended</field>
+            <field name="res_model">purchase.landed.cost.report</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,graph</field>
+            <field name="view_id" ref="view_purchase_order_landed_cost_tree"></field>
+            <field name="context">{'search_default_year':1,'search_default_month':1,'search_default_group_partner_id':1,'search_default_group_product_id': 1, 'search_default_group_purchase_order_id': 1, 'search_default_orders': 1, 'group_by_no_leaf':1,'group_by':[]}</field>
+            <field name="help">Purchase Analysis allows you to easily check and analyse your company purchase history and performance. From this menu you can track your negotiation performance, the delivery performance of your suppliers, etc.</field>
+        </record>
+
+        <record id="action_purchase_order_landed_cost_landed_cost_report_graph" model="ir.actions.act_window">
+            <field name="name">Total Qty and Amount by month</field>
+            <field name="res_model">purchase.landed.cost.report</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">graph,tree</field>
+            <field name="view_id" ref="view_purchase_order_landed_cost_qty_amount_graph"></field>
+        </record>
+
+        <record id="action_purchase_order_landed_cost_by_user_all" model="ir.actions.act_window">
+            <field name="name">Total Orders by User per month</field>
+            <field name="res_model">purchase.landed.cost.report</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">graph,tree</field>
+            <field name="view_id" ref="view_purchase_order_landed_cost_by_user_graph"></field>
+        </record>
+
+
+        <menuitem action="action_purchase_order_landed_cost_landed_cost_report_all" id="menu_action_purchase_order_landed_cost_landed_cost_report_all" parent="base.next_id_73" sequence="3"/>
+
+    </data>
+</openerp>

--- a/purchase_landed_costs_extended/security/ir.model.access.csv
+++ b/purchase_landed_costs_extended/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_report_purchase_order_landed_cost,purchase_landed_costs_extended.purchase_landed_cost_report,model_purchase_landed_cost_report,purchase.group_purchase_manager,1,0,0,0
+access_report_purchase_order_landed_cost_user,purchase_landed_costs_extended.purchase_landed_cost_report user,model_purchase_landed_cost_report,purchase.group_purchase_user,1,0,0,0

--- a/purchase_landed_costs_extended/wizard/__init__.py
+++ b/purchase_landed_costs_extended/wizard/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2010-2014 Elico Corp. All Rights Reserved.
+#    Augustin Cisterne-Kaas <augustin.cisterne-kaas@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+import landed_cost_position_invoice

--- a/purchase_landed_costs_extended/wizard/landed_cost_position_invoice.py
+++ b/purchase_landed_costs_extended/wizard/landed_cost_position_invoice.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2010-2014 Elico Corp. All Rights Reserved.
+#    Augustin Cisterne-Kaas <augustin.cisterne-kaas@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import osv
+from openerp.tools.translate import _
+
+
+class landed_cost_position_invoice(osv.osv_memory):
+
+    """ To create invoice for purchase order line"""
+
+    _name = 'landed.cost.position.invoice'
+    _description = 'Landed Cost Position Make Invoice'
+
+    def make_invoices(self, cr, uid, ids, context=None):
+
+        context = context or None
+        record_ids = context.get('active_ids', [])
+        invoice_ids = []
+        if record_ids:
+            lcp_pool = self.pool.get('landed.cost.position')
+            po_pool = self.pool.get('purchase.order')
+
+            for order_cost in lcp_pool.browse(cr, uid, record_ids,
+                                              context=context):
+                if order_cost.generate_invoice and not order_cost.invoice_id:
+                    inv_id = po_pool._generate_invoice_from_landed_cost(
+                        cr, uid, order_cost, context=context)
+                    invoice_ids.append(inv_id)
+        domain = "[('id','in', [" + ','.join(map(str, invoice_ids)) + "])]"
+        return {
+            'domain': domain,
+            'name': _('Landed Cost Invoices'),
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'account.invoice',
+            'context': "{'type':'in_invoice', 'journal_type': 'purchase'}",
+            'type': 'ir.actions.act_window'
+        }

--- a/purchase_landed_costs_extended/wizard/landed_cost_position_invoice_view.xml
+++ b/purchase_landed_costs_extended/wizard/landed_cost_position_invoice_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!--  Make the invoice-->
+
+        <record id="view_landed_cost_position_invoice" model="ir.ui.view">
+            <field name="name">Create invoices</field>
+            <field name="model">landed.cost.position.invoice</field>
+            <field name="arch" type="xml">
+                <form string="Select an Open Landed Cost" version="7.0">
+                    <group>
+                        <label string="Do you want to generate the Landed Cost invoices?"/>
+                    </group>
+                    <footer>
+                        <button name="make_invoices" string="Confirm" type="object" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+    <act_window name="Create invoices"
+            res_model="landed.cost.position.invoice"
+            src_model="landed.cost.position"
+            view_mode="form"
+            target="new"
+            key2="client_action_multi"
+            id="action_view_landed_cost_position_invoice"/>
+    </data>
+</openerp>


### PR DESCRIPTION
Added purchase landed cost extended module.
- Allows landed cost in multi currency
- Allows to add landed cost on confirmed PO
- SQL report is not finished since it does not support the multi currency
- Added a wizard to generate landed cost invoices.
