### PR TITLE
new addon purchase_requisition_auto_rfq

### DIFF
--- a/purchase_requisition_auto_rfq/__init__.py
+++ b/purchase_requisition_auto_rfq/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import model

--- a/purchase_requisition_auto_rfq/__openerp__.py
+++ b/purchase_requisition_auto_rfq/__openerp__.py
@@ -33,6 +33,9 @@ Purchase Requisition Auto RFQ
 This module adds a button on the purchase requisition form to create a RFQ
 using the suppliers from the products listed in the requisition.
 
+Note: nose is required to run the tests. It is not listed as en external
+dependency because it is not needed in production.
+
 """,
  "depends": ["purchase_requisition",
              ],

--- a/purchase_requisition_auto_rfq/__openerp__.py
+++ b/purchase_requisition_auto_rfq/__openerp__.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{"name": "Purchase Requisition Auto RFQ",
+ "summary": "Automatically create RFQ from a purchase requisition",
+ "version": "0.2",
+ "author": "Camptocamp",
+ "category": "Purchase Management",
+ "license": "AGPL-3",
+ 'complexity': "normal",
+ "images": [],
+ "description": """
+Purchase Requisition Auto RFQ
+=============================
+
+This module adds a button on the purchase requisition form to create a RFQ
+using the suppliers from the products listed in the requisition.
+
+""",
+ "depends": ["purchase_requisition",
+             ],
+    "demo": ['demo/product_and_supplier.yml',
+             ],
+    "data": ["view/purchase_requisition.xml",
+             ],
+    "auto_install": False,
+    "test": ["test/purchase_requisition.yml",
+             "test/purchase_requisition_no_supplier.yml",
+             ],
+    "installable": True,
+    "certificate": "",
+ }

--- a/purchase_requisition_auto_rfq/demo/product_and_supplier.yml
+++ b/purchase_requisition_auto_rfq/demo/product_and_supplier.yml
@@ -1,0 +1,28 @@
+-
+ Kitchen set is sold by Agrolait and China Export
+-
+ !record {model: product.product, id: kitchenset}:
+   name: Kitchen Set
+   type: product
+   seller_ids:
+     - name: base.res_partner_2
+       sequence: 1
+     - name: base.res_partner_3
+       sequence: 2
+-
+ Blanket is sold by China Export and Mediapole
+-
+ !record {model: product.product, id: blankets}:
+   name: Blankets
+   type: product
+   seller_ids:
+     - name: base.res_partner_3
+       sequence: 1
+     - name: base.res_partner_4
+       sequence: 2
+-
+ Tarpaulins have no suppliers
+-
+ !record {model: product.product, id: tarpaulin}:
+   name: Tarpaulin
+   type: product

--- a/purchase_requisition_auto_rfq/model/__init__.py
+++ b/purchase_requisition_auto_rfq/model/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import purchase_requisition

--- a/purchase_requisition_auto_rfq/model/purchase_requisition.py
+++ b/purchase_requisition_auto_rfq/model/purchase_requisition.py
@@ -36,7 +36,6 @@ class PurchaseRequisition(models.Model):
         """
         po_obj = self.env['purchase.order']
         po_line_obj = self.env['purchase.order.line']
-        rfq_ids = []
         seller_products = defaultdict(set)
         for requisition in self:
             products_without_supplier = []
@@ -66,6 +65,5 @@ class PurchaseRequisition(models.Model):
                 for line in purchase.order_line:
                     if line.product_id.id not in sold_products:
                         lines_to_remove |= line
-            rfq_ids += po_ids
         lines_to_remove.unlink()
-        return rfq_ids
+        return True

--- a/purchase_requisition_auto_rfq/model/purchase_requisition.py
+++ b/purchase_requisition_auto_rfq/model/purchase_requisition.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from collections import defaultdict
+
+from openerp import models, api
+from openerp.tools.translate import _
+
+
+class PurchaseRequisition(models.Model):
+    _inherit = 'purchase.requisition'
+
+    @api.multi
+    def auto_rfq_from_suppliers(self):
+        """create purchase orders from registered suppliers for products in the
+        requisition.
+
+        The created PO for each supplier will only concern the products for
+        which an existing product.supplierinfo record exist for that product.
+        """
+        po_obj = self.env['purchase.order']
+        po_line_obj = self.env['purchase.order.line']
+        rfq_ids = []
+        seller_products = defaultdict(set)
+        for requisition in self:
+            products_without_supplier = []
+            for line in requisition.line_ids:
+                sellers = line.product_id.product_tmpl_id.seller_ids
+                if not sellers:
+                    products_without_supplier.append(line.product_id)
+                for seller in sellers:
+                    seller_products[seller.name.id].add(line.product_id.id)
+            if products_without_supplier:
+                body = _(u'<p><b>RFQ generation</b></p>'
+                         '<p>The following products have no '
+                         'registered suppliers and are not included in the '
+                         'generated RFQs:<ul>%s</ul></p>')
+                body %= ''.join(u'<li>%s</li>' % product.name
+                                for product in products_without_supplier)
+                self.message_post(body=body,
+                                  subject=_(u'RFQ Generation'))
+        lines_to_remove = po_line_obj.browse()
+        for seller_id, sold_products in seller_products.iteritems():
+            po_info = self.make_purchase_order(seller_id)
+            # make_purchase_order creates po lines for all the products in the
+            # requisition. We need to unlink all the created lines for which
+            # the supplier is not an official supplier for the product.
+            po_ids = po_info.values()
+            for purchase in po_obj.browse(po_ids):
+                for line in purchase.order_line:
+                    if line.product_id.id not in sold_products:
+                        lines_to_remove |= line
+            rfq_ids += po_ids
+        lines_to_remove.unlink()
+        return rfq_ids

--- a/purchase_requisition_auto_rfq/test/purchase_requisition.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition.yml
@@ -1,0 +1,40 @@
+-
+ I make a tender for 100 blanket and 10 kitchen set.
+
+    Kitchen set are ordered from Supplie A and Supplier B (in supplier info)
+    Blanket are ordered from Supplier B and Supplier C
+
+ I then click a button that will create RFQ based on supplier info, I expect to have 3 RFQ
+
+ 1) Supplier A for 10 kitchen sets
+ 2) Supplier B for 10 kitchen sets and 1000 blanket
+ 3) Supplier C for 100 blanket
+-
+ Create a purchase requisition for blankets and kitchen sets
+-
+ !record {model: purchase.requisition, id: requisition1}:
+   name: PR01
+   line_ids:
+    - product_id: kitchenset
+      product_qty: 10
+    - product_id: blankets
+      product_qty: 100
+-
+ I generate the RFQ
+-
+ !python {model: purchase.requisition}: |
+    from collections import defaultdict
+    ids = self.auto_rfq_from_suppliers(cr, uid, [ref('requisition1')], context=context)
+    assert len(set(ids)) == 3, "expected 3 distinct rfq, got %r" % ids
+    rfq_obj = self.pool['purchase.order']
+    supplier_products = defaultdict(list)
+    for rfq in rfq_obj.browse(cr, uid, ids, context=context):
+      for line in rfq.order_line:
+        supplier_products[rfq.partner_id.id].append(line.product_id.id)
+    expected = {ref('base.res_partner_3'): [ref('kitchenset'), ref('blankets')],
+                ref('base.res_partner_2'): [ref('kitchenset')],
+                ref('base.res_partner_4'): [ref('blankets')],
+                }
+    assert expected == supplier_products
+    requisition = self.browse(cr, uid, ref('requisition1'), context=context)
+    assert len(requisition.message_ids) == 2, "nb messages: %d" % len(requisition.message_ids)

--- a/purchase_requisition_auto_rfq/test/purchase_requisition.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition.yml
@@ -43,5 +43,5 @@
                 ref('base.res_partner_4'): [ref('blankets')],
                 }
 
-    assert_equal(expected, supplier_products)
+    assert_equal(expected, dict(supplier_products))
     assert_equal(len(self.message_ids), 2)

--- a/purchase_requisition_auto_rfq/test/purchase_requisition.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition.yml
@@ -35,13 +35,24 @@
 
     supplier_products = defaultdict(list)
     for rfq in rfqs:
-      for line in rfq.order_line:
-        supplier_products[rfq.partner_id.id].append(line.product_id.id)
+        for line in rfq.order_line:
+            supplier_products[rfq.partner_id.id].append((
+                line.product_id.id,
+                line.product_qty,
+            ))
 
-    expected = {ref('base.res_partner_3'): [ref('kitchenset'), ref('blankets')],
-                ref('base.res_partner_2'): [ref('kitchenset')],
-                ref('base.res_partner_4'): [ref('blankets')],
-                }
+    expected = {
+        ref('base.res_partner_3'): [
+            (ref('kitchenset'), 10.0),
+            (ref('blankets'), 100.0)
+        ],
+        ref('base.res_partner_2'): [
+            (ref('kitchenset'), 10.0)
+        ],
+        ref('base.res_partner_4'): [
+            (ref('blankets'), 100.0)
+        ],
+    }
 
     assert_equal(expected, dict(supplier_products))
     assert_equal(len(self.message_ids), 2)

--- a/purchase_requisition_auto_rfq/test/purchase_requisition.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition.yml
@@ -25,19 +25,24 @@
  I generate the RFQ and check that I get three rfq with the correct partners
  and products. I also check that the requisition has two messages.
 -
- !python {model: purchase.requisition}: |
+ !python { model: purchase.requisition, id: requisition1 }: |
+    from nose.tools import *
     from collections import defaultdict
-    ids = self.auto_rfq_from_suppliers(cr, uid, [ref('requisition1')], context=context)
-    assert len(set(ids)) == 3, "expected 3 distinct rfq, got %r" % ids
-    rfq_obj = self.pool['purchase.order']
+    RFQ = self.env['purchase.order']
+
+    rfq_ids = self.auto_rfq_from_suppliers()
+    rfqs = RFQ.browse(rfq_ids)
+    assert_equal(len(rfqs), 3)
+
     supplier_products = defaultdict(list)
-    for rfq in rfq_obj.browse(cr, uid, ids, context=context):
+    for rfq in rfqs:
       for line in rfq.order_line:
         supplier_products[rfq.partner_id.id].append(line.product_id.id)
+
     expected = {ref('base.res_partner_3'): [ref('kitchenset'), ref('blankets')],
                 ref('base.res_partner_2'): [ref('kitchenset')],
                 ref('base.res_partner_4'): [ref('blankets')],
                 }
-    assert expected == supplier_products
-    requisition = self.browse(cr, uid, ref('requisition1'), context=context)
-    assert len(requisition.message_ids) == 2, "nb messages: %d" % len(requisition.message_ids)
+
+    assert_equal(expected, supplier_products)
+    assert_equal(len(self.message_ids), 2)

--- a/purchase_requisition_auto_rfq/test/purchase_requisition.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition.yml
@@ -1,14 +1,16 @@
 -
  I make a tender for 100 blanket and 10 kitchen set.
 
-    Kitchen set are ordered from Supplie A and Supplier B (in supplier info)
-    Blanket are ordered from Supplier B and Supplier C
+    Kitchen set are ordered from Supplier A and Supplier B (in supplier info)
+    Blankets are ordered from Supplier B and Supplier C
 
- I then click a button that will create RFQ based on supplier info, I expect to have 3 RFQ
+ I then click a button that will create RFQ based on supplier info.
+
+ I expect to have 3 RFQ
 
  1) Supplier A for 10 kitchen sets
- 2) Supplier B for 10 kitchen sets and 1000 blanket
- 3) Supplier C for 100 blanket
+ 2) Supplier B for 10 kitchen sets and 100 blankets
+ 3) Supplier C for 100 blankets
 -
  Create a purchase requisition for blankets and kitchen sets
 -
@@ -20,7 +22,8 @@
     - product_id: blankets
       product_qty: 100
 -
- I generate the RFQ
+ I generate the RFQ and check that I get three rfq with the correct partners
+ and products. I also check that the requisition has two messages.
 -
  !python {model: purchase.requisition}: |
     from collections import defaultdict

--- a/purchase_requisition_auto_rfq/test/purchase_requisition.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition.yml
@@ -28,10 +28,9 @@
  !python { model: purchase.requisition, id: requisition1 }: |
     from nose.tools import *
     from collections import defaultdict
-    RFQ = self.env['purchase.order']
 
-    rfq_ids = self.auto_rfq_from_suppliers()
-    rfqs = RFQ.browse(rfq_ids)
+    self.auto_rfq_from_suppliers()
+    rfqs = self.purchase_ids
     assert_equal(len(rfqs), 3)
 
     supplier_products = defaultdict(list)

--- a/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
@@ -29,7 +29,7 @@
                 ref('base.res_partner_4'): [ref('blankets')],
                 }
 
-    assert_equal(expected, supplier_products)
+    assert_equal(expected, dict(supplier_products))
     assert_equal(len(self.message_ids), 3)
 
     found = False

--- a/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
@@ -15,10 +15,9 @@
  !python { model: purchase.requisition, id: requisition2 }: |
     from nose.tools import *
     from collections import defaultdict
-    RFQ = self.env['purchase.order']
 
-    rfq_ids = self.auto_rfq_from_suppliers()
-    rfqs = RFQ.browse(rfq_ids)
+    self.auto_rfq_from_suppliers()
+    rfqs = self.purchase_ids
     assert_equal(len(rfqs), 2)
 
     supplier_products = defaultdict(list)

--- a/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
@@ -9,7 +9,8 @@
     - product_id: blankets
       product_qty: 100
 -
- I generate the RFQ
+ I generate the RFQ and check that I have two RFQ for the blankets. I also
+ check that I got an error message for the tarpaulins.
 -
  !python {model: purchase.requisition}: |
     from collections import defaultdict

--- a/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
@@ -12,24 +12,30 @@
  I generate the RFQ and check that I have two RFQ for the blankets. I also
  check that I got an error message for the tarpaulins.
 -
- !python {model: purchase.requisition}: |
+ !python { model: purchase.requisition, id: requisition2 }: |
+    from nose.tools import *
     from collections import defaultdict
-    ids = self.auto_rfq_from_suppliers(cr, uid, [ref('requisition2')], context=context)
-    assert len(set(ids)) == 2, "expected 2 distinct rfq, got %r" % ids
-    rfq_obj = self.pool['purchase.order']
+    RFQ = self.env['purchase.order']
+
+    rfq_ids = self.auto_rfq_from_suppliers()
+    rfqs = RFQ.browse(rfq_ids)
+    assert_equal(len(rfqs), 2)
+
     supplier_products = defaultdict(list)
-    for rfq in rfq_obj.browse(cr, uid, ids, context=context):
+    for rfq in rfqs:
       for line in rfq.order_line:
         supplier_products[rfq.partner_id.id].append(line.product_id.id)
+
     expected = {ref('base.res_partner_3'): [ref('blankets')],
                 ref('base.res_partner_4'): [ref('blankets')],
                 }
-    assert expected == supplier_products
-    requisition = self.browse(cr, uid, ref('requisition2'), context=context)
-    assert len(requisition.message_ids) == 3
+
+    assert_equal(expected, supplier_products)
+    assert_equal(len(self.message_ids), 3)
+
     found = False
-    for msg in requisition.message_ids:
-      if msg.body and u'RFQ generation' in msg.body:
-        assert 'Tarpaulin' in msg.body
-        found = True
-    assert found, "no message about missing supplier found"
+    for msg in self.message_ids:
+        if msg.body and u'RFQ generation' in msg.body:
+            assert_in('Tarpaulin', msg.body)
+            found = True
+    assert_true(found, "no message about missing supplier found")

--- a/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
@@ -1,0 +1,34 @@
+-
+ Create a purchase requisition for blankets and tarpaulins
+-
+ !record {model: purchase.requisition, id: requisition2}:
+   name: PR02
+   line_ids:
+    - product_id: tarpaulin
+      product_qty: 10
+    - product_id: blankets
+      product_qty: 100
+-
+ I generate the RFQ
+-
+ !python {model: purchase.requisition}: |
+    from collections import defaultdict
+    ids = self.auto_rfq_from_suppliers(cr, uid, [ref('requisition2')], context=context)
+    assert len(set(ids)) == 2, "expected 2 distinct rfq, got %r" % ids
+    rfq_obj = self.pool['purchase.order']
+    supplier_products = defaultdict(list)
+    for rfq in rfq_obj.browse(cr, uid, ids, context=context):
+      for line in rfq.order_line:
+        supplier_products[rfq.partner_id.id].append(line.product_id.id)
+    expected = {ref('base.res_partner_3'): [ref('blankets')],
+                ref('base.res_partner_4'): [ref('blankets')],
+                }
+    assert expected == supplier_products
+    requisition = self.browse(cr, uid, ref('requisition2'), context=context)
+    assert len(requisition.message_ids) == 3
+    found = False
+    for msg in requisition.message_ids:
+      if msg.body and u'RFQ generation' in msg.body:
+        assert 'Tarpaulin' in msg.body
+        found = True
+    assert found, "no message about missing supplier found"

--- a/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
+++ b/purchase_requisition_auto_rfq/test/purchase_requisition_no_supplier.yml
@@ -22,12 +22,20 @@
 
     supplier_products = defaultdict(list)
     for rfq in rfqs:
-      for line in rfq.order_line:
-        supplier_products[rfq.partner_id.id].append(line.product_id.id)
+        for line in rfq.order_line:
+            supplier_products[rfq.partner_id.id].append((
+                line.product_id.id,
+                line.product_qty,
+            ))
 
-    expected = {ref('base.res_partner_3'): [ref('blankets')],
-                ref('base.res_partner_4'): [ref('blankets')],
-                }
+    expected = {
+        ref('base.res_partner_3'): [
+            (ref('blankets'), 100.0)
+        ],
+        ref('base.res_partner_4'): [
+            (ref('blankets'), 100.0)
+        ],
+    }
 
     assert_equal(expected, dict(supplier_products))
     assert_equal(len(self.message_ids), 3)

--- a/purchase_requisition_auto_rfq/view/purchase_requisition.xml
+++ b/purchase_requisition_auto_rfq/view/purchase_requisition.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+    <record model="ir.ui.view" id="purchase_requisition_form_inherit">
+      <field name="name">purchase.requisition.form</field>
+      <field name="model">purchase.requisition</field>
+      <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_form"/>
+      <field name="arch" type="xml">
+        <xpath expr="//button[@string='Request a Quotation']" position="before">
+          <button name="auto_rfq_from_suppliers" type="object" string="Generate RFQs from suppliers"
+                  attrs="{'invisible': ['|',('line_ids','=',[]),('state','!=','in_progress')]}"
+                  />
+        </xpath>
+      </field>
+    </record>
+  </data>
+</openerp>


### PR DESCRIPTION
This addon adds a button to generate RFQ for the purchase requisition
using the product.supplierinfo in order to only have the lines corresponding to
the products sold by each supplier.
