### PR TITLE
Revert "make state selection global"

### DIFF
--- a/purchase_rfq_bid_workflow/model/purchase_order.py
+++ b/purchase_rfq_bid_workflow/model/purchase_order.py
@@ -20,29 +20,24 @@
 from openerp import models, fields, api, exceptions, osv
 from openerp.tools.translate import _
 
-STATE_SELECTION = [
-    ('draft', 'Draft RFQ'),
-    ('sent', 'RFQ Sent'),
-    ('draftbid', 'Draft Bid'),  # added
-    ('bid', 'Bid Encoded'),  # Bid Received renamed into Bid Encoded
-    ('bid_selected', 'Bid selected'),  # added
-    ('draftpo', 'Draft PO'),  # added
-    ('confirmed', 'Waiting Approval'),
-    ('approved', 'Purchase Confirmed'),
-    ('except_picking', 'Shipping Exception'),
-    ('except_invoice', 'Invoice Exception'),
-    ('done', 'Done'),
-    ('cancel', 'Canceled')
-]
-TYPE_SELECTION = [
-    ('rfq', 'Request for Quotation'),
-    ('bid', 'Bid'),
-    ('purchase', 'Purchase Order')
-]
-
 
 class PurchaseOrderClassic(osv.orm.Model):
     _inherit = "purchase.order"
+
+    STATE_SELECTION = [
+        ('draft', 'Draft RFQ'),
+        ('sent', 'RFQ Sent'),
+        ('draftbid', 'Draft Bid'),  # added
+        ('bid', 'Bid Encoded'),  # Bid Received renamed into Bid Encoded
+        ('bid_selected', 'Bid selected'),  # added
+        ('draftpo', 'Draft PO'),  # added
+        ('confirmed', 'Waiting Approval'),
+        ('approved', 'Purchase Confirmed'),
+        ('except_picking', 'Shipping Exception'),
+        ('except_invoice', 'Invoice Exception'),
+        ('done', 'Done'),
+        ('cancel', 'Canceled')
+    ]
 
     _columns = {
         'state': osv.fields.selection(
@@ -86,6 +81,12 @@ class PurchaseOrder(models.Model):
             return 'bid'
         else:
             return 'rfq'
+
+    TYPE_SELECTION = [
+        ('rfq', 'Request for Quotation'),
+        ('bid', 'Bid'),
+        ('purchase', 'Purchase Order')
+    ]
 
     type = fields.Selection(
         TYPE_SELECTION,


### PR DESCRIPTION
This reverts commit 5714c9f6377d950e69cf91dbc211be7ba567892e.

STATE_SELECTION and TYPE_SELECTION were intentionally made class
attributes because they are later modified in other modules like
framework_agreement_requisition. That was a good idea, so I am reverting
that.

Specifically, this is blocking https://github.com/OCA/vertical-ngo/pull/10

Conflicts:
    purchase_rfq_bid_workflow/model/purchase_order.py
