### PR TITLE
[FIX] supplier invoice: avoid discount doubloon

### DIFF
--- a/purchase_discount/views/account_invoice_view.xml
+++ b/purchase_discount/views/account_invoice_view.xml
@@ -6,6 +6,9 @@
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_supplier_form"/>
             <field name="arch" type="xml">
+                <field name="discount" position="attributes">
+                    <attribute name="invisible">True</attribute>
+                </field>            
                 <field name="price_unit" position="after">
                     <field name="discount"/>
                 </field>


### PR DESCRIPTION
Standard discount is only visible when you active "Allow setting a discount on the sales order lines" in Sales Configuration.
If you active this option + install this addon : the discount is visible two times on invoice lines (only for supplier invoices).
This commit allows to display only one field in all cases.
