### PR TITLE
add new module purchase_transport_document

### DIFF
--- a/purchase_transport_document/README.rst
+++ b/purchase_transport_document/README.rst
@@ -1,0 +1,9 @@
+Purchase Transport Document
+===========================
+This module adds a new object "Transport Document" and allows to select
+Documents in Purchase Orders. Other modules can depend on this simple one to
+use the same documents.
+
+This way it is possible to specify which documents have to be supplied with the
+purchase. Possible examples (CMR, Bill of Lading and others) are provided as
+demo data.

--- a/purchase_transport_document/__init__.py
+++ b/purchase_transport_document/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import model

--- a/purchase_transport_document/__openerp__.py
+++ b/purchase_transport_document/__openerp__.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#    Author: Leonardo Pistone
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{"name": "Purchase Transport Document",
+ "summary": "Add a new Transport Document object in the Purchase Order",
+ "version": "0.1",
+ "author": "Camptocamp",
+ "category": "Purchase Management",
+ "license": "AGPL-3",
+ 'complexity': "easy",
+ "description": """
+Purchase Transport Document
+===========================
+""",
+ "depends": ["purchase",
+             ],
+ "data": ["view/purchase_order.xml",
+          "view/transport_document.xml",
+          ],
+ "installable": True,
+ }

--- a/purchase_transport_document/__openerp__.py
+++ b/purchase_transport_document/__openerp__.py
@@ -29,11 +29,20 @@
  "description": """
 Purchase Transport Document
 ===========================
+This module adds a new object "Transport Document" and allows to select
+Documents in Purchase Orders. Other modules can depend on this simple one to
+use the same documents.
+
+This way it is possible to specify which documents have to be supplied with the
+purchase. Possible examples (CMR, Bill of Langand and others) are provided as
+demo data.
 """,
  "depends": ["purchase",
              ],
  "data": ["view/purchase_order.xml",
           "view/transport_document.xml",
+          "security/ir.model.access.csv",
           ],
+ "demo": ["demo.xml"],
  "installable": True,
  }

--- a/purchase_transport_document/__openerp__.py
+++ b/purchase_transport_document/__openerp__.py
@@ -34,7 +34,7 @@ Documents in Purchase Orders. Other modules can depend on this simple one to
 use the same documents.
 
 This way it is possible to specify which documents have to be supplied with the
-purchase. Possible examples (CMR, Bill of Langand and others) are provided as
+purchase. Possible examples (CMR, Bill of Landing and others) are provided as
 demo data.
 """,
  "depends": ["purchase",

--- a/purchase_transport_document/__openerp__.py
+++ b/purchase_transport_document/__openerp__.py
@@ -42,7 +42,7 @@ demo data.
  "data": ["view/purchase_order.xml",
           "view/transport_document.xml",
           "security/ir.model.access.csv",
+          "data/transport_document.xml",
           ],
- "demo": ["demo.xml"],
  "installable": True,
  }

--- a/purchase_transport_document/__openerp__.py
+++ b/purchase_transport_document/__openerp__.py
@@ -34,7 +34,7 @@ Documents in Purchase Orders. Other modules can depend on this simple one to
 use the same documents.
 
 This way it is possible to specify which documents have to be supplied with the
-purchase. Possible examples (CMR, Bill of Landing and others) are provided as
+purchase. Possible examples (CMR, Bill of Lading and others) are provided as
 demo data.
 """,
  "depends": ["purchase",

--- a/purchase_transport_document/__openerp__.py
+++ b/purchase_transport_document/__openerp__.py
@@ -26,17 +26,6 @@
  "category": "Purchase Management",
  "license": "AGPL-3",
  'complexity': "easy",
- "description": """
-Purchase Transport Document
-===========================
-This module adds a new object "Transport Document" and allows to select
-Documents in Purchase Orders. Other modules can depend on this simple one to
-use the same documents.
-
-This way it is possible to specify which documents have to be supplied with the
-purchase. Possible examples (CMR, Bill of Lading and others) are provided as
-demo data.
-""",
  "depends": ["purchase",
              ],
  "data": ["view/purchase_order.xml",

--- a/purchase_transport_document/data/transport_document.xml
+++ b/purchase_transport_document/data/transport_document.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-  <data>
+  <data noupdate="1">
 
     <record model="transport.document" id="CMR">
       <field name="name">CMR</field>

--- a/purchase_transport_document/data/transport_document.xml
+++ b/purchase_transport_document/data/transport_document.xml
@@ -6,16 +6,16 @@
       <field name="name">CMR</field>
     </record>
 
-    <record model="transport.document" id="bill_of_landing">
-      <field name="name">Bill of Landing</field>
+    <record model="transport.document" id="bill_of_lading">
+      <field name="name">Bill of Lading</field>
     </record>
 
     <record model="transport.document" id="air_waybill">
       <field name="name">Air Waybill</field>
     </record>
 
-    <record model="transport.document" id="multimodal_bill_of_landing">
-      <field name="name">Multimodal Bill of Landing</field>
+    <record model="transport.document" id="multimodal_bill_of_lading">
+      <field name="name">Multimodal Bill of Lading</field>
     </record>
 
     <record model="transport.document" id="cargo_insurance_certificate">

--- a/purchase_transport_document/demo.xml
+++ b/purchase_transport_document/demo.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record model="transport.document" id="CMR">
+      <field name="name">CMR</field>
+    </record>
+
+    <record model="transport.document" id="bill_of_landing">
+      <field name="name">Bill of Landing</field>
+    </record>
+
+    <record model="transport.document" id="air_waybill">
+      <field name="name">Air Waybill</field>
+    </record>
+
+    <record model="transport.document" id="multimodal_bill_of_landing">
+      <field name="name">Multimodal Bill of Landing</field>
+    </record>
+
+    <record model="transport.document" id="cargo_insurance_certificate">
+      <field name="name">Cargo Insurance Certificate</field>
+    </record>
+
+    <record model="transport.document" id="packing_list">
+      <field name="name">Packing list</field>
+    </record>
+
+    <record model="transport.document" id="delivery_note">
+      <field name="name">Delivery Note</field>
+    </record>
+
+  </data>
+</openerp>

--- a/purchase_transport_document/i18n/purchase_transport_document.pot
+++ b/purchase_transport_document/i18n/purchase_transport_document.pot
@@ -21,8 +21,8 @@ msgid "Air Waybill"
 msgstr ""
 
 #. module: purchase_transport_document
-#: model:transport.document,name:purchase_transport_document.bill_of_landing
-msgid "Bill of Landing"
+#: model:transport.document,name:purchase_transport_document.bill_of_lading
+msgid "Bill of Lading"
 msgstr ""
 
 #. module: purchase_transport_document
@@ -66,8 +66,8 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: purchase_transport_document
-#: model:transport.document,name:purchase_transport_document.multimodal_bill_of_landing
-msgid "Multimodal Bill of Landing"
+#: model:transport.document,name:purchase_transport_document.multimodal_bill_of_lading
+msgid "Multimodal Bill of Lading"
 msgstr ""
 
 #. module: purchase_transport_document

--- a/purchase_transport_document/i18n/purchase_transport_document.pot
+++ b/purchase_transport_document/i18n/purchase_transport_document.pot
@@ -1,0 +1,101 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_transport_document
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-24 09:12+0000\n"
+"PO-Revision-Date: 2014-10-24 09:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_transport_document
+#: model:transport.document,name:purchase_transport_document.air_waybill
+msgid "Air Waybill"
+msgstr ""
+
+#. module: purchase_transport_document
+#: model:transport.document,name:purchase_transport_document.bill_of_landing
+msgid "Bill of Landing"
+msgstr ""
+
+#. module: purchase_transport_document
+#: model:transport.document,name:purchase_transport_document.CMR
+msgid "CMR"
+msgstr ""
+
+#. module: purchase_transport_document
+#: model:transport.document,name:purchase_transport_document.cargo_insurance_certificate
+msgid "Cargo Insurance Certificate"
+msgstr ""
+
+#. module: purchase_transport_document
+#: field:transport.document,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: purchase_transport_document
+#: field:transport.document,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: purchase_transport_document
+#: model:transport.document,name:purchase_transport_document.delivery_note
+msgid "Delivery Note"
+msgstr ""
+
+#. module: purchase_transport_document
+#: field:transport.document,id:0
+msgid "ID"
+msgstr ""
+
+#. module: purchase_transport_document
+#: field:transport.document,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: purchase_transport_document
+#: field:transport.document,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: purchase_transport_document
+#: model:transport.document,name:purchase_transport_document.multimodal_bill_of_landing
+msgid "Multimodal Bill of Landing"
+msgstr ""
+
+#. module: purchase_transport_document
+#: field:transport.document,name:0
+msgid "Name"
+msgstr ""
+
+#. module: purchase_transport_document
+#: model:transport.document,name:purchase_transport_document.packing_list
+msgid "Packing list"
+msgstr ""
+
+#. module: purchase_transport_document
+#: model:ir.model,name:purchase_transport_document.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: purchase_transport_document
+#: view:transport.document:purchase_transport_document.view_transport_document_form
+msgid "Transport Document"
+msgstr ""
+
+#. module: purchase_transport_document
+#: model:ir.actions.act_window,name:purchase_transport_document.action_transport_document
+#: model:ir.ui.menu,name:purchase_transport_document.menu_transport_document
+#: view:purchase.order:purchase_transport_document.purchase_order_form
+#: field:purchase.order,transport_document_ids:0
+#: view:transport.document:purchase_transport_document.view_transport_document_tree
+msgid "Transport Documents"
+msgstr ""
+

--- a/purchase_transport_document/model/__init__.py
+++ b/purchase_transport_document/model/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+import transport_document
+import purchase_order

--- a/purchase_transport_document/model/purchase_order.py
+++ b/purchase_transport_document/model/purchase_order.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#    Author: Leonardo Pistone
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, fields
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    transport_document_ids = fields.Many2many(
+        'transport.document',
+        string="Transport Documents"
+    )

--- a/purchase_transport_document/model/transport_document.py
+++ b/purchase_transport_document/model/transport_document.py
@@ -24,4 +24,4 @@ from openerp import models, fields
 class TransportDocument(models.Model):
     _name = "transport.document"
 
-    name = fields.Char('Name')
+    name = fields.Char('Name', translate=True)

--- a/purchase_transport_document/model/transport_document.py
+++ b/purchase_transport_document/model/transport_document.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2014 Camptocamp SA
+#    Author: Leonardo Pistone
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, fields
+
+
+class TransportDocument(models.Model):
+    _name = "transport.document"
+
+    name = fields.Char('Name')

--- a/purchase_transport_document/security/ir.model.access.csv
+++ b/purchase_transport_document/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_transport_document,access_transport_document,model_transport_document,,1,1,1,1

--- a/purchase_transport_document/view/purchase_order.xml
+++ b/purchase_transport_document/view/purchase_order.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="purchase_order_form">
+      <field name="name">purchase_order_form</field>
+      <field name="model">purchase.order</field>
+      <field name="inherit_id" ref="purchase.purchase_order_form"/>
+      <field name="arch" type="xml">
+
+        <notebook position="inside">
+          <page string="Transport Documents">
+            <field name="transport_document_ids"/>
+          </page>
+        </notebook>
+
+      </field>
+    </record>
+  </data>
+</openerp>

--- a/purchase_transport_document/view/transport_document.xml
+++ b/purchase_transport_document/view/transport_document.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="view_transport_document_form">
+      <field name="name">view_transport_document_form</field>
+      <field name="model">transport.document</field>
+      <field name="arch" type="xml">
+        <form>
+          <group string="Transport Document">
+            <field name="name"/>
+          </group>
+        </form>
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_transport_document_tree">
+      <field name="name">view_transport_document_tree</field>
+      <field name="model">transport.document</field>
+      <field name="arch" type="xml">
+        <tree string="Transport Documents">
+          <field name="name"/>
+        </tree>
+      </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="action_transport_document">
+      <field name="name">Transport Documents</field>
+      <field name="res_model">transport.document</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem
+      name="Transport Documents"
+      parent="purchase.menu_purchase_config_purchase"
+      action="action_transport_document"
+      id="menu_transport_document"/>
+
+  </data>
+</openerp>


### PR DESCRIPTION
This module adds a new object transport.document and allows to choose
those in the purchase order.
- [x] improve doc
- [x] add demo data
- [x] add security rule
- [x] demo -> data noupdate="1"
- [x] make name translatable
- [x] add POT
