### PR TITLE
[FIX] Decimal precision parameter for products

### DIFF
--- a/purchase_delivery_term/purchase.py
+++ b/purchase_delivery_term/purchase.py
@@ -124,7 +124,7 @@ class purchase_order_line_master(orm.Model):
             digits_compute=dp.get_precision('Product Price')),
         'product_qty': fields.float(
             'Quantity',
-            digits_compute=dp.get_precision('Product UoM'),
+            digits_compute=dp.get_precision('Product Unit of Measure'),
             required=True),
         'product_uom': fields.many2one(
             'product.uom', 'Product UOM', required=True),

--- a/purchase_landed_costs/purchase.py
+++ b/purchase_landed_costs/purchase.py
@@ -502,7 +502,7 @@ class purchase_order(orm.Model):
             string='Landed Costs Total Untaxed'),
         'quantity_total': fields.function(
             _quantity_total,
-            digits_compute=dp.get_precision('Product UoM'),
+            digits_compute=dp.get_precision('Product Unit of Measure'),
             string='Total Quantity'),
     }
 


### PR DESCRIPTION
Supersedes https://code.launchpad.net/~numerigraphe-team/purchase-wkfl/7.0-fix-decimal-precision/+merge/223883
"In version 7 the name of the digital precision parameter for UoMs has changed : this branch updates the modules where the change is missing."
Rebased on 7.0 today
