### PR TITLE
[ADD] purchase_delivery_split_date

### DIFF
--- a/purchase_delivery_split_date/__init__.py
+++ b/purchase_delivery_split_date/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import purchase

--- a/purchase_delivery_split_date/__openerp__.py
+++ b/purchase_delivery_split_date/__openerp__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': "Purchase Deliveries split by date",
+    'version': '1.0',
+    'author': u'Numérigraphe',
+    'category': 'Purchase Management',
+    'description': """
+Split Purchase Deliveries in one reception per expected date
+------------------------------------------------------------
+
+When this module is installed, each Purchase Order you confirm will generate
+one Reception Order per delivery date indicated in the Purchase Order Lines.
+
+Contributors
+------------
+
+ * Philippe Rossi <pr@numerigraphe.com> (initial patch against v6.0)
+ * Lionel Sausin <ls@numerigraphe.com> (modularization for v7.0)
+""",
+    'license': 'AGPL-3',
+    "depends": ['purchase'],
+}

--- a/purchase_delivery_split_date/purchase.py
+++ b/purchase_delivery_split_date/purchase.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class PurchaseOrder(orm.Model):
+    _inherit = "purchase.order"
+
+    def _create_pickings(self, cr, uid, order, order_lines, picking_id=False,
+                         context=None):
+        """Group the Purchase Order's receptions by expected date"""
+        picking_ids = []
+        delivery_dates = {}
+        # Triage the order lines by delivery date
+        for line in order_lines:
+            if line.date_planned in delivery_dates:
+                delivery_dates[line.date_planned].append(line)
+            else:
+                delivery_dates[line.date_planned] = [line]
+        # Process each group of lines
+        for lines in delivery_dates.itervalues():
+            picking_ids.extend(
+                super(PurchaseOrder, self)._create_pickings(
+                    cr, uid, order, lines, picking_id=picking_id,
+                    context=context))
+        return picking_ids


### PR DESCRIPTION
Module to split purchase receptions by dates.
Supersedes this Launchpad proposal: https://code.launchpad.net/~numerigraphe-team/purchase-wkfl/7.0-add-purchase_delivery_split_date/+merge/211374

"This branch adds a new module which, when installed, creates one reception picking for each expected date on the purchase order.
This way stock workers have a clear view of which goods should be received when.

This modules uses the modular design of purchase orders to create several pickings rather that a single one: to the best of my knowledge, this should be compatible with the other modules in this branch."
