### PR TITLE
Improve framework agreement

### DIFF
--- a/framework_agreement/__openerp__.py
+++ b/framework_agreement/__openerp__.py
@@ -59,6 +59,7 @@ provides a library to integrate it with any other model easily
           'view/purchase_view.xml',
           'view/company_view.xml',
           'security/multicompany.xml',
+          'security/groups.xml',
           'security/ir.model.access.csv'],
  'demo': [],
  'test': [],

--- a/framework_agreement/__openerp__.py
+++ b/framework_agreement/__openerp__.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 {'name': 'Framework Agreement',
- 'version': '1.0',
+ 'version': '1.1',
  'author': 'Camptocamp',
  'maintainer': 'Camptocamp',
  'category': 'Purchase Management',

--- a/framework_agreement/model/framework_agreement.py
+++ b/framework_agreement/model/framework_agreement.py
@@ -99,6 +99,8 @@ class framework_agreement(models.Model):
         inverse_name='framework_agreement_id'
     )
 
+    payment_term_id = fields.Many2one('account.payment.term', 'Payment Term')
+
     @api.model
     def _check_running_date(self, agreement):
         """ Returns agreement state based on date.

--- a/framework_agreement/model/framework_agreement.py
+++ b/framework_agreement/model/framework_agreement.py
@@ -101,6 +101,16 @@ class framework_agreement(models.Model):
 
     payment_term_id = fields.Many2one('account.payment.term', 'Payment Term')
 
+    incoterm_id = fields.Many2one(
+        'stock.incoterms',
+        'Incoterm',
+        help="International Commercial Terms are a series of predefined "
+        "commercial terms used in international transactions.")
+
+    incoterm_address = fields.Char('Incoterm Address')
+
+    delivery_remarks = fields.Text('Delivery Remarks')
+
     @api.model
     def _check_running_date(self, agreement):
         """ Returns agreement state based on date.

--- a/framework_agreement/model/framework_agreement.py
+++ b/framework_agreement/model/framework_agreement.py
@@ -111,6 +111,10 @@ class framework_agreement(models.Model):
 
     delivery_remarks = fields.Text('Delivery Remarks')
 
+    clauses = fields.Html('Clauses')
+
+    shipment_origin_id = fields.Many2one('res.partner', 'Shipment Origin')
+
     @api.model
     def _check_running_date(self, agreement):
         """ Returns agreement state based on date.

--- a/framework_agreement/model/framework_agreement.py
+++ b/framework_agreement/model/framework_agreement.py
@@ -109,7 +109,7 @@ class framework_agreement(models.Model):
 
     incoterm_address = fields.Char('Incoterm Address')
 
-    delivery_remarks = fields.Text('Delivery Remarks')
+    delivery_remark = fields.Text('Delivery Remarks')
 
     clauses = fields.Html('Clauses')
 

--- a/framework_agreement/model/purchase.py
+++ b/framework_agreement/model/purchase.py
@@ -178,15 +178,23 @@ class purchase_order(models.Model):
             pricelist_id).currency_id
 
     @api.multi
-    def _propagate_payment_term(self):
-        if self.framework_agreement_id.payment_term_id:
-            self.payment_term_id = self.framework_agreement_id.payment_term_id
+    def _propagate_fields(self):
+        agreement = self.framework_agreement_id
+
+        if agreement.payment_term_id:
+            self.payment_term_id = agreement.payment_term_id
+
+        if agreement.incoterm_id:
+            self.incoterm_id = agreement.incoterm_id
+
+        if agreement.incoterm_address:
+            self.incoterm_address = agreement.incoterm_address
 
     @api.onchange('framework_agreement_id')
     def onchange_agreement(self):
         res = {}
 
-        self._propagate_payment_term()
+        self._propagate_fields()
 
         if isinstance(self.id, models.NewId):
             return res

--- a/framework_agreement/model/purchase.py
+++ b/framework_agreement/model/purchase.py
@@ -177,9 +177,17 @@ class purchase_order(models.Model):
         return self.env['product.pricelist'].browse(
             pricelist_id).currency_id
 
+    @api.multi
+    def _propagate_payment_term(self):
+        if self.framework_agreement_id.payment_term_id:
+            self.payment_term_id = self.framework_agreement_id.payment_term_id
+
     @api.onchange('framework_agreement_id')
     def onchange_agreement(self):
         res = {}
+
+        self._propagate_payment_term()
+
         if isinstance(self.id, models.NewId):
             return res
         if self.framework_agreement_id:

--- a/framework_agreement/security/groups.xml
+++ b/framework_agreement/security/groups.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record id="base.group_user" model="res.groups">
+      <field name="implied_ids" eval="[(4, ref('product.group_purchase_pricelist'))]"/>
+    </record>
+
+  </data>
+</openerp>

--- a/framework_agreement/view/framework_agreement_view.xml
+++ b/framework_agreement/view/framework_agreement_view.xml
@@ -93,7 +93,7 @@
                   </form>
                 </field>
                 <div class="oe_clear"/>
-                <field name="delivery_remarks" class="oe_inline" placeholder="Delivery Remarks"/>
+                <field name="delivery_remark" class="oe_inline" placeholder="Delivery Remarks"/>
               </page>
               <page string="Clauses">
                 <field name="clauses" nolabel="1" placeholder="Clauses"/>

--- a/framework_agreement/view/framework_agreement_view.xml
+++ b/framework_agreement/view/framework_agreement_view.xml
@@ -46,6 +46,7 @@
               <group>
                 <field name="company_id" groups="base.group_multi_company" widget="selection"/>
                 <field name="supplier_id" context="{'search_default_supplier': True, 'default_supplier': True, 'default_customer': False}" domain="[('supplier','=',True)]"/>
+                <field name="payment_term_id" options="{'no_open': True, 'no_create': True}"/>
                 <field name="product_id"/>
               </group>
               <group>

--- a/framework_agreement/view/framework_agreement_view.xml
+++ b/framework_agreement/view/framework_agreement_view.xml
@@ -47,6 +47,8 @@
                 <field name="company_id" groups="base.group_multi_company" widget="selection"/>
                 <field name="supplier_id" context="{'search_default_supplier': True, 'default_supplier': True, 'default_customer': False}" domain="[('supplier','=',True)]"/>
                 <field name="payment_term_id" options="{'no_open': True, 'no_create': True}"/>
+                <field name="incoterm_id" widget="selection" groups="base.group_user"/>
+                <field name="incoterm_address"/>
                 <field name="product_id"/>
               </group>
               <group>
@@ -89,6 +91,8 @@
                     </notebook>
                   </form>
                 </field>
+                <div class="oe_clear"/>
+                <field name="delivery_remarks" class="oe_inline" placeholder="Delivery Remarks"/>
               </page>
             </notebook>
           </sheet>

--- a/framework_agreement/view/framework_agreement_view.xml
+++ b/framework_agreement/view/framework_agreement_view.xml
@@ -55,6 +55,7 @@
                 <field name="delay"/>
                 <field name="quantity"/>
                 <field name="available_quantity"/>
+                <field name="shipment_origin_id"/>
               </group>
             </group>
 
@@ -93,6 +94,9 @@
                 </field>
                 <div class="oe_clear"/>
                 <field name="delivery_remarks" class="oe_inline" placeholder="Delivery Remarks"/>
+              </page>
+              <page string="Clauses">
+                <field name="clauses" nolabel="1" placeholder="Clauses"/>
               </page>
             </notebook>
           </sheet>


### PR DESCRIPTION
This includes some improvements over the framework_agreement_module.
- When installed, enable the option for purchase pricelists. The module is not usable without.
- Add fields that are often used in Long Term Agreement: incoterm, incoterm address, clauses, shipment origin
- The new fields that exist on the Purchase Order are propagated automatically when the Agreement is selected.

Thanks!
