### PR TITLE
[8.0] add module purchase_origin_address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ python:
   - "2.7"
 
 env:
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="framework_agreement"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="framework_agreement"
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" EXCLUDE="framework_agreement"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB" EXCLUDE="framework_agreement"
+    - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="framework_agreement"
+    - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="framework_agreement"
+    - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
+    - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
+    - VERSION="8.0" ODOO_REPO="odoo/odoo" EXCLUDE="framework_agreement,purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
+    - VERSION="8.0" ODOO_REPO="OCA/OCB" EXCLUDE="framework_agreement,purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
 
 virtualenv:
   system_site_packages: true

--- a/purchase_origin_address/README.rst
+++ b/purchase_origin_address/README.rst
@@ -9,3 +9,4 @@ Contributors
 ------------
 
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
+* Leonardo Pistone <leonardo.pistone@camptocamp.com>

--- a/purchase_origin_address/README.rst
+++ b/purchase_origin_address/README.rst
@@ -1,0 +1,11 @@
+Purchase Origin Address
+=======================
+
+This modules adds an origin address on the purchase order that will be
+transferred on picking in.
+
+
+Contributors
+------------
+
+* Yannick Vaucher <yannick.vaucher@camptocamp.com>

--- a/purchase_origin_address/__init__.py
+++ b/purchase_origin_address/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import model

--- a/purchase_origin_address/__openerp__.py
+++ b/purchase_origin_address/__openerp__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Author: Yannick Vaucher
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+{'name': 'Purchase Origin Address',
+ 'summary': 'Allows to manage origin address on purchase',
+ 'version': '1.0',
+ 'author': 'Camptocamp',
+ 'category': 'Purchase Management',
+ 'license': 'AGPL-3',
+ 'complexity': 'normal',
+ 'images': [],
+ 'depends': ['purchase',
+             ],
+ 'demo': [],
+ 'data': ['view/purchase_order.xml',
+          'view/stock_picking.xml',
+          ],
+ 'auto_install': False,
+ 'test': [],
+ 'installable': True,
+ }

--- a/purchase_origin_address/i18n/purchase_origin_address.pot
+++ b/purchase_origin_address/i18n/purchase_origin_address.pot
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_origin_address
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-28 14:12+0000\n"
+"PO-Revision-Date: 2014-10-28 14:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_origin_address
+#: field:purchase.order,origin_address_id:0
+#: field:stock.picking,origin_address_id:0
+msgid "Origin Address"
+msgstr ""
+
+#. module: purchase_origin_address
+#: model:ir.model,name:purchase_origin_address.model_stock_picking
+msgid "Picking List"
+msgstr ""
+
+#. module: purchase_origin_address
+#: model:ir.model,name:purchase_origin_address.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+

--- a/purchase_origin_address/model/__init__.py
+++ b/purchase_origin_address/model/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import purchase_order
+from . import stock_picking

--- a/purchase_origin_address/model/purchase_order.py
+++ b/purchase_origin_address/model/purchase_order.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Author: Yannick Vaucher
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+from openerp import models, fields, api
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    origin_address_id = fields.Many2one(
+        'res.partner',
+        'Origin Address')
+
+    @api.multi
+    def onchange_partner_id(self, partner_id):
+        res = super(PurchaseOrder, self).onchange_partner_id(partner_id)
+        res['value']['origin_address_id'] = partner_id
+        return res
+
+    def action_picking_create(self):
+        res = super(PurchaseOrder, self).action_picking_create()
+        for order in self:
+            order.picking_ids.write(
+                {'origin_address_id': order.origin_address_id.id})
+        return res

--- a/purchase_origin_address/model/stock_picking.py
+++ b/purchase_origin_address/model/stock_picking.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Author: Yannick Vaucher
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+from openerp import models, fields
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    origin_address_id = fields.Many2one(
+        'res.partner',
+        'Origin Address')

--- a/purchase_origin_address/tests/__init__.py
+++ b/purchase_origin_address/tests/__init__.py
@@ -20,7 +20,3 @@
 #
 
 from . import test_origin_address
-
-checks = [
-    test_origin_address,
-]

--- a/purchase_origin_address/tests/__init__.py
+++ b/purchase_origin_address/tests/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Author: Yannick Vaucher
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from . import test_origin_address
+
+checks = [
+    test_origin_address,
+]

--- a/purchase_origin_address/tests/test_origin_address.py
+++ b/purchase_origin_address/tests/test_origin_address.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Author: Yannick Vaucher
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+from openerp.tests import common
+from openerp import fields
+
+
+class TestOriginAddress(common.TransactionCase):
+    """ Test origin address is correctly set on picking
+    """
+
+    def setUp(self):
+        super(TestOriginAddress, self).setUp()
+
+        model_data = self.env['ir.model.data']
+        self.ref = model_data.xmlid_to_res_id
+        self.part1_id = self.ref('base.res_partner_1')
+        self.part12_id = self.ref('base.res_partner_12')
+        self.order1_vals = {
+            'partner_id': self.part1_id,
+            'location_id': self.ref('stock.stock_location_stock')
+            }
+
+        self.order_line1_vals = {
+            'product_id': self.ref('product.product_product_33'),
+            'name': "[HEAD-USB] Headset USB",
+            'product_qty': 24,
+            'product_uom': self.ref('product.product_uom_unit'),
+            'date_planned': fields.Datetime.now(),
+            'price_unit': 65,
+            }
+
+        self.PurchaseOrder = self.env['purchase.order']
+
+    def test_create_picking_with_default_origin(self):
+        """Create a picking in from purchase order and check
+        origin address is copied
+
+        """
+
+        po_vals = self.order1_vals.copy()
+        res = self.PurchaseOrder.onchange_partner_id(self.part1_id)
+        po_vals.update(res['value'])
+
+        po1 = self.PurchaseOrder.create(po_vals)
+
+        pol_vals = self.order_line1_vals.copy()
+        pol_vals['order_id'] = po1.id
+        self.env['purchase.order.line'].create(pol_vals)
+
+        po1.signal_workflow('purchase_confirm')
+
+        self.assertEquals(po1.picking_ids.origin_address_id,
+                          po1.origin_address_id)
+
+    def test_create_picking_without_origin(self):
+        """Create a picking in from purchase order
+        remove origin address and check
+        origin address is false on picking
+
+        """
+
+        po_vals = self.order1_vals.copy()
+        res = self.PurchaseOrder.onchange_partner_id(self.part1_id)
+        po_vals.update(res['value'])
+
+        po2 = self.PurchaseOrder.create(po_vals)
+
+        po2.origin_address_id = False
+
+        pol_vals = self.order_line1_vals.copy()
+        pol_vals['order_id'] = po2.id
+        self.env['purchase.order.line'].create(pol_vals)
+
+        po2.signal_workflow('purchase_confirm')
+
+        self.assertFalse(po2.picking_ids.origin_address_id.id)
+
+    def test_create_picking_with_other_origin(self):
+        """Create a picking in from purchase order and check
+        origin address is copied and is the same as on the purchase
+        order
+
+        """
+
+        po_vals = self.order1_vals.copy()
+        res = self.PurchaseOrder.onchange_partner_id(self.part1_id)
+        po_vals.update(res['value'])
+
+        po3 = self.PurchaseOrder.create(po_vals)
+
+        po3.origin_address_id = self.part12_id
+
+        pol_vals = self.order_line1_vals.copy()
+        pol_vals['order_id'] = po3.id
+        self.env['purchase.order.line'].create(pol_vals)
+
+        po3.signal_workflow('purchase_confirm')
+
+        self.assertEquals(po3.picking_ids.origin_address_id,
+                          po3.origin_address_id)

--- a/purchase_origin_address/tests/test_origin_address.py
+++ b/purchase_origin_address/tests/test_origin_address.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 #
-#    Author: Yannick Vaucher
+#    Author: Yannick Vaucher, Leonardo Pistone
 #    Copyright 2014 Camptocamp SA
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -27,27 +27,36 @@ class TestOriginAddress(common.TransactionCase):
     """
 
     def setUp(self):
+        """This setup is repeated on a new transaction for every test.
+        No need to duplicate test data then.
+        """
         super(TestOriginAddress, self).setUp()
 
         model_data = self.env['ir.model.data']
-        self.ref = model_data.xmlid_to_res_id
-        self.part1_id = self.ref('base.res_partner_1')
-        self.part12_id = self.ref('base.res_partner_12')
-        self.order1_vals = {
-            'partner_id': self.part1_id,
-            'location_id': self.ref('stock.stock_location_stock')
-            }
+        ref = model_data.xmlid_to_res_id
+        self.part1_id = ref('base.res_partner_1')
+        self.part12_id = ref('base.res_partner_12')
+        PO = self.env['purchase.order']
+        POL = self.env['purchase.order.line']
 
-        self.order_line1_vals = {
-            'product_id': self.ref('product.product_product_33'),
+        po_vals = {
+            'partner_id': self.part1_id,
+            'location_id': ref('stock.stock_location_stock')
+        }
+
+        res = PO.onchange_partner_id(self.part1_id)
+        po_vals.update(res['value'])
+        self.po = PO.create(po_vals)
+
+        POL.create({
+            'order_id': self.po.id,
+            'product_id': ref('product.product_product_33'),
             'name': "[HEAD-USB] Headset USB",
             'product_qty': 24,
-            'product_uom': self.ref('product.product_uom_unit'),
+            'product_uom': ref('product.product_uom_unit'),
             'date_planned': fields.Datetime.now(),
             'price_unit': 65,
-            }
-
-        self.PurchaseOrder = self.env['purchase.order']
+        })
 
     def test_create_picking_with_default_origin(self):
         """Create a picking in from purchase order and check
@@ -55,20 +64,9 @@ class TestOriginAddress(common.TransactionCase):
 
         """
 
-        po_vals = self.order1_vals.copy()
-        res = self.PurchaseOrder.onchange_partner_id(self.part1_id)
-        po_vals.update(res['value'])
-
-        po1 = self.PurchaseOrder.create(po_vals)
-
-        pol_vals = self.order_line1_vals.copy()
-        pol_vals['order_id'] = po1.id
-        self.env['purchase.order.line'].create(pol_vals)
-
-        po1.signal_workflow('purchase_confirm')
-
-        self.assertEquals(po1.picking_ids.origin_address_id,
-                          po1.origin_address_id)
+        self.po.signal_workflow('purchase_confirm')
+        self.assertEquals(self.po.picking_ids.origin_address_id,
+                          self.po.origin_address_id)
 
     def test_create_picking_without_origin(self):
         """Create a picking in from purchase order
@@ -77,21 +75,9 @@ class TestOriginAddress(common.TransactionCase):
 
         """
 
-        po_vals = self.order1_vals.copy()
-        res = self.PurchaseOrder.onchange_partner_id(self.part1_id)
-        po_vals.update(res['value'])
-
-        po2 = self.PurchaseOrder.create(po_vals)
-
-        po2.origin_address_id = False
-
-        pol_vals = self.order_line1_vals.copy()
-        pol_vals['order_id'] = po2.id
-        self.env['purchase.order.line'].create(pol_vals)
-
-        po2.signal_workflow('purchase_confirm')
-
-        self.assertFalse(po2.picking_ids.origin_address_id.id)
+        self.po.origin_address_id = False
+        self.po.signal_workflow('purchase_confirm')
+        self.assertFalse(self.po.picking_ids.origin_address_id.id)
 
     def test_create_picking_with_other_origin(self):
         """Create a picking in from purchase order and check
@@ -100,19 +86,7 @@ class TestOriginAddress(common.TransactionCase):
 
         """
 
-        po_vals = self.order1_vals.copy()
-        res = self.PurchaseOrder.onchange_partner_id(self.part1_id)
-        po_vals.update(res['value'])
-
-        po3 = self.PurchaseOrder.create(po_vals)
-
-        po3.origin_address_id = self.part12_id
-
-        pol_vals = self.order_line1_vals.copy()
-        pol_vals['order_id'] = po3.id
-        self.env['purchase.order.line'].create(pol_vals)
-
-        po3.signal_workflow('purchase_confirm')
-
-        self.assertEquals(po3.picking_ids.origin_address_id,
-                          po3.origin_address_id)
+        self.po.origin_address_id = self.part12_id
+        self.po.signal_workflow('purchase_confirm')
+        self.assertEquals(self.po.picking_ids.origin_address_id,
+                          self.po.origin_address_id)

--- a/purchase_origin_address/view/purchase_order.xml
+++ b/purchase_origin_address/view/purchase_order.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="purchase_order_form">
+      <field name="name">purchase.order.inherit</field>
+      <field name="model">purchase.order</field>
+      <field name="inherit_id" ref="purchase.purchase_order_form"/>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="origin_address_id"/>
+        </field>
+
+      </field>
+    </record>
+
+  </data>
+</openerp>

--- a/purchase_origin_address/view/stock_picking.xml
+++ b/purchase_origin_address/view/stock_picking.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<openerp>
+  <data>
+
+    <record id="view_picking_form" model="ir.ui.view">
+      <field name="name">stock.picking.form</field>
+      <field name="model">stock.picking</field>
+      <field name="inherit_id" ref="stock.view_picking_form"/>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="origin_address_id"/>
+        </field>
+
+      </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
In this module, we add a settable origin address on the purchase order that we copy on created picking in.
