### PR TITLE
add missing remark and delivery_remark fields on views

### DIFF
--- a/purchase_requisition_bid_selection/view/purchase_order.xml
+++ b/purchase_requisition_bid_selection/view/purchase_order.xml
@@ -16,6 +16,11 @@
           <attribute name="attrs">{'invisible': ['|', ('requisition_id','!=',False)]}</attribute>
         </xpath>
 
+        <xpath expr="//page[@string='Deliveries &amp; Invoices']" position="inside">
+          <separator string="Delivery Remarks"/>
+          <field name="delivery_remark"/>
+        </xpath>
+
       </field>
     </record>
 
@@ -32,6 +37,18 @@
         <xpath expr="//field[@name='requisition_id']" position="after">
           <field name="tender_bid_receipt_mode"/>
         </xpath>
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_purchase_order_line_form">
+      <field name="name">purchase.order.line.form.inherit</field>
+      <field name="model">purchase.order.line</field>
+      <field name="inherit_id" ref="purchase.purchase_order_line_form"/>
+      <field name="arch" type="xml">
+        <field name="name" position="after">
+          <separator string="Remarks"/>
+          <field name="remark"/>
+        </field>
       </field>
     </record>
 

--- a/purchase_requisition_bid_selection/view/purchase_requisition.xml
+++ b/purchase_requisition_bid_selection/view/purchase_requisition.xml
@@ -102,6 +102,17 @@
           <attribute name="on_change">onchange_picking_type_id(picking_type_id)</attribute>
         </field>
 
+        <notebook position="inside">
+          <page string="Deliveries">
+            <separator string="Delivery Remarks"/>
+            <field name="delivery_remark"/>
+          </page>
+        </notebook>
+
+        <xpath expr="//field[@name='line_ids']/form//field[@name='company_id']" position="after">
+          <field name="remark"/>
+        </xpath>
+
       </field>
     </record>
   </data>


### PR DESCRIPTION
Those fields were missing in https://github.com/OCA/purchase-workflow/pull/37
