### PR TITLE
fix: avoid confirmed rfq at installation

### DIFF
--- a/purchase_rfq_bid_workflow/__init__.py
+++ b/purchase_rfq_bid_workflow/__init__.py
@@ -1,3 +1,11 @@
 # -*- coding: utf-8 -*-
 from . import model
 from . import wizard
+
+
+def fix_inconsistent_initial_types(cr, registry):
+    PO = registry['purchase.order']
+    approved_ids = registry['purchase.order'].search(cr, 1, [
+        ('state', '=', 'approved')
+    ])
+    PO.write(cr, 1, approved_ids, {'type': 'purchase'})

--- a/purchase_rfq_bid_workflow/__init__.py
+++ b/purchase_rfq_bid_workflow/__init__.py
@@ -2,11 +2,13 @@
 from . import model
 from . import wizard
 
+from openerp import SUPERUSER_ID
+
 
 def fix_inconsistent_initial_types(cr, registry):
     """A post init hook executed when the module is installed."""
     PO = registry['purchase.order']
-    approved_ids = registry['purchase.order'].search(cr, 1, [
+    approved_ids = PO.search(cr, 1, [
         ('state', '=', 'approved')
     ])
-    PO.write(cr, 1, approved_ids, {'type': 'purchase'})
+    PO.write(cr, SUPERUSER_ID, approved_ids, {'type': 'purchase'})

--- a/purchase_rfq_bid_workflow/__init__.py
+++ b/purchase_rfq_bid_workflow/__init__.py
@@ -4,6 +4,7 @@ from . import wizard
 
 
 def fix_inconsistent_initial_types(cr, registry):
+    """A post init hook executed when the module is installed."""
     PO = registry['purchase.order']
     approved_ids = registry['purchase.order'].search(cr, 1, [
         ('state', '=', 'approved')

--- a/purchase_rfq_bid_workflow/__openerp__.py
+++ b/purchase_rfq_bid_workflow/__openerp__.py
@@ -20,7 +20,8 @@
 
 {"name": "Purchase RFQ Bid workflow",
  "summary": "Improve the purchase workflow to manage RFQ, Bids, and Orders",
- "version": "0.2",
+ "post_init_hook": 'fix_inconsistent_initial_types',
+ "version": "0.3",
  "author": "Camptocamp",
  "category": "Purchase Management",
  "license": "AGPL-3",

--- a/purchase_rfq_bid_workflow/tests/__init__.py
+++ b/purchase_rfq_bid_workflow/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_consistent_type_and_state

--- a/purchase_rfq_bid_workflow/tests/test_consistent_type_and_state.py
+++ b/purchase_rfq_bid_workflow/tests/test_consistent_type_and_state.py
@@ -1,0 +1,10 @@
+from openerp.tests import common
+
+
+class TestConsistentTypeAndState(common.TransactionCase):
+    def test_all_approved_are_purchases(self):
+        PO = self.env['purchase.order']
+        self.assertFalse(PO.search([
+            ('state', '=', 'approved'),
+            ('type', '!=', 'purchase'),
+        ]))


### PR DESCRIPTION
This module adds a type selection field (rfq, bid, or purchase). It
correctly takes care to change the type as the workflow progresses, but
existing data (including demo data created by core modules) is left in
inconsistent states. Specifically, there are o few RFQs in state
Confirmed.

This fixes the situation when the module is installed. Migration scripts
cannot be used at installation anymore, so I use the new v8 hooks.
