### PR TITLE
remove onchange picking type on purchase order

### DIFF
--- a/purchase_rfq_bid_workflow/model/purchase_order.py
+++ b/purchase_rfq_bid_workflow/model/purchase_order.py
@@ -263,24 +263,6 @@ class PurchaseOrder(models.Model):
                           subtype="mail.mt_comment")
         return super(PurchaseOrder, self).print_quotation()
 
-    def onchange_picking_type_id(self, cr, uid, ids, picking_type_id,
-                                 context=None):
-        PickType = self.pool['stock.picking.type']
-
-        result = super(PurchaseOrder, self).onchange_picking_type_id(
-            cr, uid, ids, picking_type_id, context)
-
-        if picking_type_id:
-            pick_type = PickType.browse(cr, uid, picking_type_id,
-                                        context=context)
-
-            if pick_type.warehouse_id and pick_type.warehouse_id.partner_id:
-                dest_address_id = pick_type.warehouse_id.partner_id.id
-
-                result['value']['dest_address_id'] = dest_address_id
-
-        return result
-
     @api.multi
     def po_tender_requisition_selected(self):
         """Workflow function that write state 'bid selected'"""

--- a/purchase_rfq_bid_workflow/view/purchase_order.xml
+++ b/purchase_rfq_bid_workflow/view/purchase_order.xml
@@ -56,10 +56,6 @@
           <field name="incoterm_address"/>
         </xpath>
 
-        <field name="picking_type_id" position="attributes">
-          <attribute name="on_change">onchange_picking_type_id(picking_type_id)</attribute>
-        </field>
-
         <button name="action_cancel" position="attributes">
           <!-- approved,except_picking,except_invoice removed -->
           <!-- draftbid,draftpo added -->


### PR DESCRIPTION
The removed code changed the destination address of the PO with the
address of the warehouse related to the picking type. That is bad for
two reasons:
- The dest_address_id is used for the customer address in dropshipping
  scenarios. That has nothing to do with the warehouse address.
- The dest_address_id has itself an onchange that sets the destination
  address to customers, because we are in a dropshipping scenario. Thus,
  this commit fixes #56.

I didn't manage to write a test for that because of odoo/odoo#3503.
