### PR TITLE
fix inverted creation of rfq and bids

### DIFF
--- a/purchase_requisition_auto_rfq_bid_selection/model/purchase_requisition.py
+++ b/purchase_requisition_auto_rfq_bid_selection/model/purchase_requisition.py
@@ -36,9 +36,9 @@ class PurchaseRequisition(models.Model):
         requisitions_draft_rfq = self.with_context(draft_bid=0).browse()
         for requisition in self:
             if requisition.bid_tendering_mode == 'restricted':
-                requisitions_draft_bid |= requisition
-            else:
                 requisitions_draft_rfq |= requisition
+            else:
+                requisitions_draft_bid |= requisition
         for requisitions in (requisitions_draft_bid, requisitions_draft_rfq):
             po_info = requisitions.make_purchase_order(seller_id)
             res.update(po_info)

--- a/purchase_requisition_auto_rfq_bid_selection/test/purchase_requisition.yml
+++ b/purchase_requisition_auto_rfq_bid_selection/test/purchase_requisition.yml
@@ -14,7 +14,7 @@
 -
  !record {model: purchase.requisition, id: requisition1}:
    name: PR01
-   bid_tendering_mode: restricted
+   bid_tendering_mode: open
    line_ids:
     - product_id: purchase_requisition_auto_rfq.kitchenset
       product_qty: 10


### PR DESCRIPTION
The module purchase_requisition_auto_rfq_bid_selection is just a bridge:
it should not change the functionality of bids and rfqs:
- an open call for bids should have bids
- a restricted call for bids should have rfqs

Installing the bridge module the two get inverted. This fixes it.

The yaml test was inverted as well: it is flipped, too.
