### PR TITLE
8.0 add module purchase_partner_invoice_method

### DIFF
--- a/purchase_partner_invoice_method/__init__.py
+++ b/purchase_partner_invoice_method/__init__.py
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Purchase Partner Invoice Method for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import partner
+from . import purchase

--- a/purchase_partner_invoice_method/__openerp__.py
+++ b/purchase_partner_invoice_method/__openerp__.py
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Purchase Partner Invoice Method module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com).
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Purchase Partner Invoice Method',
+    'version': '1.0',
+    'category': 'Purchase Management',
+    'license': 'AGPL-3',
+    'summary': "Adds supplier invoicing control on partner form",
+    'description': """
+This module adds a new field on the partner form in the *Accouting* tab:
+*Supplier Invoicing Control*. The value of this field will be used when you
+create a new Purchase Order with this partner as supplier.
+
+This module has been written by Alexis de Lattre
+<alexis.delattre@akretion.com>
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com',
+    'depends': ['purchase'],
+    'data': ['partner_view.xml'],
+    'demo': ['partner_demo.xml'],
+    'installable': True,
+}

--- a/purchase_partner_invoice_method/i18n/fr.po
+++ b/purchase_partner_invoice_method/i18n/fr.po
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_partner_invoice_method
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-16 23:17+0000\n"
+"PO-Revision-Date: 2014-11-16 23:17+0000\n"
+"Last-Translator: Alexis de Lattre <alexis.delattre@akretion.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_partner_invoice_method
+#: selection:res.partner,supplier_invoice_method:0
+msgid "Based on Purchase Order lines"
+msgstr "Basé sur les lignes de commande"
+
+#. module: purchase_partner_invoice_method
+#: selection:res.partner,supplier_invoice_method:0
+msgid "Based on generated draft invoice"
+msgstr "Basé sur une facture brouillon générée"
+
+#. module: purchase_partner_invoice_method
+#: selection:res.partner,supplier_invoice_method:0
+msgid "Based on incoming shipments"
+msgstr "Basé sur les réceptions"
+
+#. module: purchase_partner_invoice_method
+#: model:ir.model,name:purchase_partner_invoice_method.model_res_partner
+msgid "Partner"
+msgstr "Partenaire"
+
+#. module: purchase_partner_invoice_method
+#: model:ir.model,name:purchase_partner_invoice_method.model_purchase_order
+msgid "Purchase Order"
+msgstr "Bon de commande"
+
+#. module: purchase_partner_invoice_method
+#: help:res.partner,supplier_invoice_method:0
+msgid "Select the default invoicing control for the purchase orders of this supplier"
+msgstr "Sélectionnez la méthode de contrôle facturation par défaut des bons de commande de ce fournisseur"
+
+#. module: purchase_partner_invoice_method
+#: field:res.partner,supplier_invoice_method:0
+msgid "Supplier Invoicing Control"
+msgstr "Contrôle facturation fournisseur"
+

--- a/purchase_partner_invoice_method/i18n/purchase_partner_invoice_method.pot
+++ b/purchase_partner_invoice_method/i18n/purchase_partner_invoice_method.pot
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_partner_invoice_method
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-16 23:16+0000\n"
+"PO-Revision-Date: 2014-11-16 23:16+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_partner_invoice_method
+#: selection:res.partner,supplier_invoice_method:0
+msgid "Based on Purchase Order lines"
+msgstr ""
+
+#. module: purchase_partner_invoice_method
+#: selection:res.partner,supplier_invoice_method:0
+msgid "Based on generated draft invoice"
+msgstr ""
+
+#. module: purchase_partner_invoice_method
+#: selection:res.partner,supplier_invoice_method:0
+msgid "Based on incoming shipments"
+msgstr ""
+
+#. module: purchase_partner_invoice_method
+#: model:ir.model,name:purchase_partner_invoice_method.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: purchase_partner_invoice_method
+#: model:ir.model,name:purchase_partner_invoice_method.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: purchase_partner_invoice_method
+#: help:res.partner,supplier_invoice_method:0
+msgid "Select the default invoicing control for the purchase orders of this supplier"
+msgstr ""
+
+#. module: purchase_partner_invoice_method
+#: field:res.partner,supplier_invoice_method:0
+msgid "Supplier Invoicing Control"
+msgstr ""
+

--- a/purchase_partner_invoice_method/partner.py
+++ b/purchase_partner_invoice_method/partner.py
@@ -1,0 +1,42 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Purchase Partner Invoice Method for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    supplier_invoice_method = fields.Selection([
+        ('manual', 'Based on Purchase Order lines'),
+        ('order', 'Based on generated draft invoice'),
+        ('picking', 'Based on incoming shipments')
+        ],
+        string='Supplier Invoicing Control', company_dependent=True,
+        help='Select the default invoicing control for the purchase orders '
+        'of this supplier')
+
+    @api.model
+    def _commercial_fields(self):
+        res = super(ResPartner, self)._commercial_fields()
+        res += ['supplier_invoice_method']
+        return res

--- a/purchase_partner_invoice_method/partner_demo.xml
+++ b/purchase_partner_invoice_method/partner_demo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2014 Akretion (http://www.akretion.com/)
+    @author Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data noupdate="1">
+
+
+<record id="base.res_partner_1" model="res.partner"> <!-- Asustek -->
+    <field name="supplier_invoice_method">picking</field>
+</record>
+
+<record id="base.res_partner_3" model="res.partner"> <!-- China Export -->
+    <field name="supplier_invoice_method">manual</field>
+</record>
+
+<record id="base.res_partner_4" model="res.partner"> <!-- Delta PC -->
+    <field name="supplier_invoice_method">picking</field>
+</record>
+
+<record id="base.res_partner_12" model="res.partner"> <!-- C2C -->
+    <field name="supplier_invoice_method">manual</field>
+</record>
+
+<record id="base.res_partner_23" model="res.partner"> <!-- Vauxoo -->
+    <field name="supplier_invoice_method">order</field>
+</record>
+
+
+</data>
+</openerp>

--- a/purchase_partner_invoice_method/partner_view.xml
+++ b/purchase_partner_invoice_method/partner_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2014 Akretion (http://www.akretion.com/)
+    @author Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data>
+
+
+<record id="view_partner_property_form" model="ir.ui.view">
+    <field name="name">purchase_partner_invoice_method.partner_form</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="account.view_partner_property_form"/>
+    <field name="arch" type="xml">
+        <field name="property_supplier_payment_term" position="after">
+            <field name="supplier_invoice_method"/>
+        </field>
+    </field>
+</record>
+
+
+</data>
+</openerp>

--- a/purchase_partner_invoice_method/purchase.py
+++ b/purchase_partner_invoice_method/purchase.py
@@ -20,18 +20,17 @@
 #
 ##############################################################################
 
-from openerp.osv import orm
+from openerp import models, api
 
 
-class PurchaseOrder(orm.Model):
+class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
-    def onchange_partner_id(self, cr, uid, ids, partner_id, context=None):
-        res = super(PurchaseOrder, self).onchange_partner_id(
-            cr, uid, ids, partner_id, context=context)
+    @api.multi
+    def onchange_partner_id(self, partner_id):
+        res = super(PurchaseOrder, self).onchange_partner_id(partner_id)
         if partner_id:
-            partner = self.pool['res.partner'].browse(
-                cr, uid, partner_id, context=context)
+            partner = self.env['res.partner'].browse(partner_id)
             if partner.supplier_invoice_method:
                 res['value']['invoice_method'] = \
                     partner.supplier_invoice_method

--- a/purchase_partner_invoice_method/purchase.py
+++ b/purchase_partner_invoice_method/purchase.py
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Purchase Partner Invoice Method for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class PurchaseOrder(orm.Model):
+    _inherit = 'purchase.order'
+
+    def onchange_partner_id(self, cr, uid, ids, partner_id, context=None):
+        res = super(PurchaseOrder, self).onchange_partner_id(
+            cr, uid, ids, partner_id, context=context)
+        if partner_id:
+            partner = self.pool['res.partner'].browse(
+                cr, uid, partner_id, context=context)
+            if partner.supplier_invoice_method:
+                res['value']['invoice_method'] = \
+                    partner.supplier_invoice_method
+        return res


### PR DESCRIPTION
This is a small module that handles a simple need: the need to have a default invoice method per supplier. If this module is approved in the purchase-workflow project, I'll propose a similar module "sale_partner_order_policy" to the sale-workflow project.

I use the new API in this module.
