### PR TITLE
purchase_requisition_bid_workflow: generated PO should be in state draft_po

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ env:
     - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="purchase_delivery_address"
     - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="framework_agreement"
     - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="framework_agreement"
-    - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
-    - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
+    - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="purchase_rfq_bid_workflow"
+    - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="purchase_rfq_bid_workflow"
+    - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
+    - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
     - VERSION="8.0" ODOO_REPO="odoo/odoo" EXCLUDE="purchase_delivery_address,framework_agreement,purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
     - VERSION="8.0" ODOO_REPO="OCA/OCB" EXCLUDE="purchase_delivery_address,framework_agreement,purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection"
 

--- a/purchase_requisition_bid_selection/__openerp__.py
+++ b/purchase_requisition_bid_selection/__openerp__.py
@@ -27,7 +27,7 @@
  "images": [],
  "depends": ["purchase_requisition",
              "stock",  # For incoterms
-             "purchase_rfq_bid_workflow",  # for field incoterms place
+             "purchase_rfq_bid_workflow",
              ],
  "demo": [],
  "data": ["wizard/modal.xml",

--- a/purchase_requisition_bid_selection/__openerp__.py
+++ b/purchase_requisition_bid_selection/__openerp__.py
@@ -19,7 +19,7 @@
 #
 
 {"name": "Purchase Requisition Bid Selection",
- "version": "0.4",
+ "version": "0.5",
  "author": "Camptocamp",
  "license": "AGPL-3",
  "category": "Purchase Management",

--- a/purchase_requisition_bid_selection/__openerp__.py
+++ b/purchase_requisition_bid_selection/__openerp__.py
@@ -34,6 +34,7 @@
           "wizard/purchase_requisition_partner_view.xml",
           "view/purchase_requisition.xml",
           "view/purchase_order.xml",
+          "workflow/purchase_order.xml",
           "workflow/purchase_requisition.xml",
           "data/purchase.cancelreason.yml",
           ],

--- a/purchase_requisition_bid_selection/model/purchase_order.py
+++ b/purchase_requisition_bid_selection/model/purchase_order.py
@@ -41,6 +41,11 @@ class PurchaseOrder(models.Model):
         'Bid partially selected',
         readonly=True,
         help="True if the bid has been partially selected")
+    keep_in_draft = fields.Boolean(
+        'Prevent validation of purchase order.',
+        help="Technical field used to prevent the PO that is automatically "
+        "generated from a Tender to be validated. It is checked on the "
+        "workflow transition.")
     delivery_remark = fields.Text('Delivery Remarks')
 
     @api.model

--- a/purchase_requisition_bid_selection/model/purchase_requisition.py
+++ b/purchase_requisition_bid_selection/model/purchase_requisition.py
@@ -251,7 +251,7 @@ class PurchaseRequisition(models.Model):
 
     @api.one
     def _get_po_to_cancel(self):
-        """Get the list of PO/RFQ that can be canceled on RFQ
+        """Get the list of PO/RFQ that can be cancelled on RFQ
 
         :param callforbids: `purchase.requisition` record
 
@@ -307,7 +307,7 @@ class PurchaseRequisition(models.Model):
     @api.multi
     def tender_cancel(self):
         """
-        Cancel call for bids and try to cancelrelated  RFQs/PO
+        Cancel call for bids and try to cancel related RFQs/PO
 
         """
         reason_id = self._get_default_reason()

--- a/purchase_requisition_bid_selection/model/purchase_requisition.py
+++ b/purchase_requisition_bid_selection/model/purchase_requisition.py
@@ -178,6 +178,7 @@ class PurchaseRequisition(models.Model):
         result.update({
             'type': 'purchase',
             'state': 'draftpo',
+            'keep_in_draft': True,
         })
         return result
 
@@ -192,7 +193,9 @@ class PurchaseRequisition(models.Model):
                     not po_line.order_id.bid_partial):
                 po_line.order_id.bid_partial = True
 
-        return super(PurchaseRequisition, self).generate_po()
+        result = super(PurchaseRequisition, self).generate_po()
+        self.generated_order_ids.write({'keep_in_draft': False})
+        return result
 
     @api.model
     def quotation_selected(self, quotation):

--- a/purchase_requisition_bid_selection/model/purchase_requisition.py
+++ b/purchase_requisition_bid_selection/model/purchase_requisition.py
@@ -50,9 +50,15 @@ class PurchaseRequisitionClassic(osv.orm.Model):
         'purchase_ids': osv.fields.one2many(
             'purchase.order',
             'requisition_id',
-            'Purchase Orders',
+            'RFQs and Bids',
             states={'done': [('readonly', True)]},
             domain=[('type', 'in', ('rfq', 'bid'))]),
+        'generated_order_ids': osv.fields.one2many(
+            'purchase.order',
+            'requisition_id',
+            'Generated Purchase Orders',
+            states={'done': [('readonly', True)]},
+            domain=[('type', '=', 'purchase')]),
     }
 
 

--- a/purchase_requisition_bid_selection/test/process/restricted.yml
+++ b/purchase_requisition_bid_selection/test/process/restricted.yml
@@ -195,8 +195,22 @@
   !python {model: purchase.requisition}: |
     self.generate_po(cr, uid, [ref("req1")])
 -
-  I check the POs
+  Then I should see 2 cancelled bids
 -
   !python {model: purchase.requisition, id: req1}: |
     from nose.tools import *
-    assert_equal(len(self.purchase_ids), 2)
+
+    assert_equal(2, len(self.purchase_ids))
+    for bid in self.purchase_ids:
+        assert_equal('cancel', bid.state)
+        assert_equal('bid', bid.type)
+-
+  And I should see 2 generated purchase orders in draft
+-
+  !python {model: purchase.requisition, id: req1}: |
+    from nose.tools import *
+
+    assert_equal(2, len(self.generated_order_ids))
+    for po in self.generated_order_ids:
+        assert_equal('draftpo', po.state)
+        assert_equal('purchase', po.type)

--- a/purchase_requisition_bid_selection/test/process/restricted.yml
+++ b/purchase_requisition_bid_selection/test/process/restricted.yml
@@ -205,7 +205,8 @@
         assert_equal('cancel', bid.state)
         assert_equal('bid', bid.type)
 -
-  And I should see 2 generated purchase orders in draft
+  And I should see 2 generated purchase orders in draft that can be validated
+  manually.
 -
   !python {model: purchase.requisition, id: req1}: |
     from nose.tools import *
@@ -214,3 +215,4 @@
     for po in self.generated_order_ids:
         assert_equal('draftpo', po.state)
         assert_equal('purchase', po.type)
+        assert_is(False, po.keep_in_draft)

--- a/purchase_requisition_bid_selection/workflow/purchase_order.xml
+++ b/purchase_requisition_bid_selection/workflow/purchase_order.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record id="purchase.trans_draft_confirmed" model="workflow.transition">
+      <field name="condition">not keep_in_draft</field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
In the core purchase_requisition module, the generated PO from a call
for bids is validated. That is done in a big method generate_po that I
don't want to override.

On the other hand, we added a new state draftpo that is useful exactly
for that situation: an order (i.e. not a bit nor a rfq) that is not
validated yet.

The workaround used here is to add a technical boolean field
keep_in_draft which is checked on the workflow transition. The field is
set in the generated PO so that it is not confirmed, and disabled
immediately after, so that the order can be validated manually
afterwards.

A context cannot be used here because it is not passed via the workflow.

I updated the YAML test to check that the generated order is really in draft.
