### PR TITLE
[7.0] Add module 'account_creditor_price difference'

### DIFF
--- a/account_creditor_price_difference/__init__.py
+++ b/account_creditor_price_difference/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import product
+import stock
+import purchase
+import invoice

--- a/account_creditor_price_difference/__openerp__.py
+++ b/account_creditor_price_difference/__openerp__.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>).
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Account Creditor Price Difference',
+    'version': '1.0',
+    'author': 'Eficent',
+    'website': 'http://www.eficent.com',
+    'description': """
+
+Account Creditor Price Difference
+==================================
+
+When the supplier invoice is created from a purchase order, if the
+destination of the product is a company location the application
+will propose as debiting account the stock input account from the
+product or product category, instead of the product, in order
+to balance the credit that occurred when the product was received.
+
+The stock input account is frequently called the Goods Received Not Invoiced
+account (GRIN).
+
+Furthermore, when the invoice is accepted, the application will identify
+any differences between the invoice price and the product cost, and will
+post the differences to a new Price Differences account defined in the
+product or product category.
+
+""",
+    'images': [],
+    'depends': ['product', 'purchase'],
+    'category': 'Accounting & Finance',
+    'demo': [],
+    'data': ['product_view.xml',],
+    'auto_install': False,
+    'installable': True,
+}

--- a/account_creditor_price_difference/invoice.py
+++ b/account_creditor_price_difference/invoice.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import osv
+
+class account_invoice_line(osv.osv):
+    _inherit = "account.invoice.line"
+
+    def move_line_get(self, cr, uid, invoice_id, context=None):
+        res = super(account_invoice_line,self).move_line_get(
+            cr, uid, invoice_id, context=context)
+        inv = self.pool.get('account.invoice').browse(
+            cr, uid, invoice_id, context=context)
+        company_currency = inv.company_id.currency_id.id
+
+        if inv.type in ('in_invoice', 'in_refund'):
+            for i_line in inv.invoice_line:
+                if i_line.product_id \
+                        and i_line.product_id.valuation == 'real_time':
+                    if i_line.product_id.type != 'service':
+                        # get the price difference account at the product
+                        acc = i_line.product_id.property_account_creditor_price_difference \
+                            and i_line.product_id.property_account_creditor_price_difference.id
+                        if not acc:
+                            # if not found on the product get the price difference account at the category
+                            acc = i_line.product_id.categ_id.property_account_creditor_price_difference_categ \
+                                and i_line.product_id.categ_id.property_account_creditor_price_difference_categ.id
+                        a = None
+
+                        # oa will be the stock input account
+                        # first check the product, if empty check the category
+                        oa = i_line.product_id.property_stock_account_input \
+                            and i_line.product_id.property_stock_account_input.id
+                        if not oa:
+                            oa = i_line.product_id.categ_id.property_stock_account_input_categ \
+                                and i_line.product_id.categ_id.property_stock_account_input_categ.id
+
+                        if oa:
+                            # get the fiscal position
+                            fpos = i_line.invoice_id.fiscal_position or False
+                            a = self.pool.get('account.fiscal.position').map_account(cr, uid, fpos, oa)
+                        diff_res = []
+                        # calculate and write down the possible price difference between invoice price and product price
+                        for line in res:
+                            if a == line['account_id'] \
+                                    and i_line.product_id.id == line['product_id']:
+                                uom = i_line.product_id.uos_id \
+                                    or i_line.product_id.uom_id
+                                standard_price = self.pool.get('product.uom')._compute_price(
+                                    cr, uid, uom.id, i_line.product_id.standard_price, i_line.uos_id.id)
+                                if inv.currency_id.id != company_currency:
+                                    standard_price = self.pool.get('res.currency').compute(
+                                        cr, uid, company_currency, inv.currency_id.id, standard_price, context={'date': inv.date_invoice})
+                                if standard_price != i_line.price_unit \
+                                        and line['price_unit'] == i_line.price_unit and acc:
+                                    price_diff = i_line.price_unit - standard_price
+                                    line.update({'price': standard_price * line['quantity']})
+                                    diff_res.append({
+                                        'type': 'src',
+                                        'name': i_line.name[:64],
+                                        'price_unit': price_diff,
+                                        'quantity': line['quantity'],
+                                        'price': price_diff * line['quantity'],
+                                        'account_id': acc,
+                                        'product_id': line['product_id'],
+                                        'uos_id': line['uos_id'],
+                                        'account_analytic_id': line['account_analytic_id'],
+                                        'taxes': line.get('taxes',[]),
+                                        })
+                        res += diff_res
+        return res

--- a/account_creditor_price_difference/product.py
+++ b/account_creditor_price_difference/product.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, osv
+
+class product_category(osv.osv):
+    _inherit = "product.category"
+    _columns = {
+        'property_account_creditor_price_difference_categ': fields.property(
+            'account.account',
+            type='many2one',
+            relation='account.account',
+            string="Price Difference Account",
+            view_load=True,
+            help="This account will be used to value price difference between purchase price and cost price."),
+
+    }
+product_category()
+
+class product_template(osv.osv):
+    _inherit = "product.template"
+    _columns = {
+        'property_account_creditor_price_difference': fields.property(
+            'account.account',
+            type='many2one',
+            relation='account.account',
+            string="Price Difference Account",
+            view_load=True,
+            help="This account will be used to value price difference between purchase price and cost price."),
+    }
+product_template()

--- a/account_creditor_price_difference/product_view.xml
+++ b/account_creditor_price_difference/product_view.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record id="product_normal_form_view" model="ir.ui.view">
+            <field name="name">product.normal.form.inherit.stock</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="account.product_normal_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='property_account_expense']" position="after">
+                    <label string="" colspan="2"/>
+                    <field name="property_account_creditor_price_difference" domain="[('type','&lt;&gt;','view'),('type','&lt;&gt;','consolidation')]" attrs="{'readonly':[('purchase_ok','=',0)]}" />
+                    <newline/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="product_template_form_view" model="ir.ui.view">
+            <field name="name">product.template.product.form.inherit</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="account.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="/form/notebook/page/field[@name='property_account_expense']" position="after">
+                    <field name="property_account_creditor_price_difference" domain="[('type','&lt;&gt;','view'),('type','&lt;&gt;','consolidation')]" attrs="{'readonly':[('purchase_ok','=',0)]}" />
+                    <newline/>
+                </xpath>
+             </field>
+        </record>
+
+        <record id="view_category_property_form" model="ir.ui.view">
+            <field name="name">product.category.property.form.inherit.stock</field>
+            <field name="model">product.category</field>
+            <field name="inherit_id" ref="account.view_category_property_form"/>
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//field[@name='property_account_income_categ']" position="before">
+                        <field name="property_account_creditor_price_difference_categ" domain="[('type','&lt;&gt;','view'),('type','&lt;&gt;','consolidation')]"/>
+                    </xpath>
+                </data>
+            </field>
+        </record>
+
+    </data>
+</openerp>
+

--- a/account_creditor_price_difference/purchase.py
+++ b/account_creditor_price_difference/purchase.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, osv
+
+class purchase_order(osv.osv):
+    _name = "purchase.order"
+    _inherit = "purchase.order"
+    _description = "Purchase Order"
+
+    def _choose_account_from_po_line(self, cr, uid, order_line, context=None):
+        account_id = super(purchase_order, self)._choose_account_from_po_line(cr, uid, order_line, context=context)
+        if order_line.product_id and not order_line.product_id.type == 'service':
+            #Only consider if it's going to be moved to a company location
+            if order_line.order_id.location_id and order_line.order_id.location_id.company_id:
+                acc_id = order_line.product_id.property_stock_account_input and order_line.product_id.property_stock_account_input.id
+                if not acc_id:
+                    acc_id = order_line.product_id.categ_id.property_stock_account_input_categ and order_line.product_id.categ_id.property_stock_account_input_categ.id
+                if acc_id:
+                    fpos = order_line.order_id.fiscal_position or False
+                    account_id = self.pool.get('account.fiscal.position').map_account(cr, uid, fpos, acc_id)
+        return account_id
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_creditor_price_difference/stock.py
+++ b/account_creditor_price_difference/stock.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              Jordi Ballester Alomar <jordi.ballester@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import osv
+
+
+class stock_picking(osv.osv):
+    _inherit = "stock.picking"
+    _description = "Picking List"
+
+    def action_invoice_create(self, cr, uid, ids, journal_id=False,
+                              group=False, type='out_invoice', context=None):
+        '''Return ids of created invoices for the pickings'''
+        res = super(stock_picking, self).action_invoice_create(
+            cr, uid, ids, journal_id, group, type, context=context)
+
+        if type == 'in_refund':
+            for inv in self.pool.get('account.invoice').browse(
+                    cr, uid, res.values(), context=context):
+                for ol in inv.invoice_line:
+                    if ol.product_id:
+                        oa = ol.product_id.property_stock_account_input \
+                            and ol.product_id.property_stock_account_input.id
+                        if not oa:
+                            oa = ol.product_id.categ_id.property_stock_account_input_categ \
+                                and ol.product_id.categ_id.property_stock_account_input_categ.id
+                        if oa:
+                            fpos = ol.invoice_id.fiscal_position or False
+                            a = self.pool.get('account.fiscal.position').map_account(
+                                cr, uid, fpos, oa)
+                            self.pool.get('account.invoice.line').write(
+                                cr, uid, [ol.id], {'account_id': a})
+
+        elif type == 'in_invoice':
+            for inv in self.pool.get('account.invoice').browse(
+                    cr, uid, res.values(), context=context):
+                for ol in inv.invoice_line:
+                    if ol.product_id:
+                        oa = ol.product_id.property_stock_account_input \
+                            and ol.product_id.property_stock_account_input.id
+                        if not oa:
+                            oa = ol.product_id.categ_id.property_stock_account_input_categ \
+                                and ol.product_id.categ_id.property_stock_account_input_categ.id
+                        if oa:
+                            fpos = ol.invoice_id.fiscal_position or False
+                            a = self.pool.get('account.fiscal.position').map_account(
+                                cr, uid, fpos, oa)
+                            self.pool.get('account.invoice.line').write(
+                                cr, uid, [ol.id], {'account_id': a})
+        return res
+
+stock_picking()


### PR DESCRIPTION
When the supplier invoice is created from a purchase order, if the
destination of the product is a company location the application
will propose as debiting account the stock input account from the
product or product category, instead of the product, in order
to balance the credit that occurred when the product was received.

The stock input account is frequently called the Goods Received Not Invoiced
account (GRIN).

Furthermore, when the invoice is accepted, the application will identify
any differences between the invoice price and the product cost, and will
post the differences to a new Price Differences account defined in the
product or product category.

See the following blog post:

http://www.eficent.com/openerp_en/product-receptions-and-returns-with-real-time-inventory-valuation-in-odoo/
