### PR TITLE
tender: do not raise if delivery address is empty

### DIFF
--- a/purchase_requisition_delivery_address/model/purchase_requisition.py
+++ b/purchase_requisition_delivery_address/model/purchase_requisition.py
@@ -37,6 +37,9 @@ class PurchaseRequisition(models.Model):
 
     @api.onchange('dest_address_id')
     def onchange_dest_address_id(self):
+        if not self.dest_address_id:
+            return
+
         PickType = self.env['stock.picking.type']
         types = PickType.search([
             ('warehouse_id.partner_id', '=', self.dest_address_id.id)])


### PR DESCRIPTION
The onchange method is called immediately after pressing the button
"create". At this point the delivery address is empty, and we don't want
to be shown a strange warning about a missing field.
