### PR TITLE
fix: chosen bids become selected, not canceled

### DIFF
--- a/purchase_requisition_bid_selection/__openerp__.py
+++ b/purchase_requisition_bid_selection/__openerp__.py
@@ -19,7 +19,7 @@
 #
 
 {"name": "Purchase Requisition Bid Selection",
- "version": "0.5",
+ "version": "0.6",
  "author": "Camptocamp",
  "license": "AGPL-3",
  "category": "Purchase Management",

--- a/purchase_requisition_bid_selection/model/purchase_requisition.py
+++ b/purchase_requisition_bid_selection/model/purchase_requisition.py
@@ -209,7 +209,7 @@ class PurchaseRequisition(models.Model):
         return quotation.bid_partial
 
     @api.model
-    def cancel_quotation(self, tender):
+    def cancel_unconfirmed_quotations(self, tender):
         """
         Called from generate_po. Cancel only draft and sent rfq
         """

--- a/purchase_requisition_bid_selection/test/process/restricted.yml
+++ b/purchase_requisition_bid_selection/test/process/restricted.yml
@@ -195,14 +195,14 @@
   !python {model: purchase.requisition}: |
     self.generate_po(cr, uid, [ref("req1")])
 -
-  Then I should see 2 cancelled bids
+  Then I should see 2 selected bids
 -
   !python {model: purchase.requisition, id: req1}: |
     from nose.tools import *
 
     assert_equal(2, len(self.purchase_ids))
     for bid in self.purchase_ids:
-        assert_equal('cancel', bid.state)
+        assert_equal('bid_selected', bid.state)
         assert_equal('bid', bid.type)
 -
   And I should see 2 generated purchase orders in draft that can be validated


### PR DESCRIPTION
This is because the method changed name upstream.
