### PR TITLE
sync readonly between pricelist and currency

### DIFF
--- a/purchase_rfq_bid_workflow/model/purchase_order.py
+++ b/purchase_rfq_bid_workflow/model/purchase_order.py
@@ -93,6 +93,14 @@ class PurchaseOrder(models.Model):
         ('purchase', 'Purchase Order')
     ]
 
+    STATES = {
+        'draft': [('readonly', False)],
+        'sent': [('readonly', False)],
+        'draftbid': [('readonly', False)],
+        'bid': [('readonly', False)],
+        'draftpo': [('readonly', False)],
+    }
+
     type = fields.Selection(
         TYPE_SELECTION,
         'Type',
@@ -107,6 +115,23 @@ class PurchaseOrder(models.Model):
              "international transactions.")
     cancel_reason_id = fields.Many2one(
         'purchase.cancel_reason', 'Reason for Cancellation', readonly=True)
+
+    # in pricelist_id and currency_id we change readonly and states
+    pricelist_id = fields.Many2one(
+        'product.pricelist',
+        'Pricelist',
+        readonly=True,
+        required=True,
+        states=STATES,
+        help="The pricelist sets the currency used for this purchase order. "
+             "It also computes the supplier price for the selected "
+             "products/quantities.")
+    currency_id = fields.Many2one(
+        'res.currency',
+        'Currency',
+        readonly=True,
+        required=True,
+        states=STATES)
 
     @api.model
     def create(self, values):

--- a/purchase_rfq_bid_workflow/model/purchase_order.py
+++ b/purchase_rfq_bid_workflow/model/purchase_order.py
@@ -116,7 +116,11 @@ class PurchaseOrder(models.Model):
     cancel_reason_id = fields.Many2one(
         'purchase.cancel_reason', 'Reason for Cancellation', readonly=True)
 
-    # in pricelist_id and currency_id we change readonly and states
+    # in pricelist_id and currency_id we change readonly and states to make
+    # them identical and avoid problems where the onchange from pricelist to
+    # currency is reverted in save. However, the user can still set a currency
+    # different from the currency of the pricelist, which is undesirable. See:
+    # https://github.com/odoo/odoo/issues/4598
     pricelist_id = fields.Many2one(
         'product.pricelist',
         'Pricelist',


### PR DESCRIPTION
Addresses #80, see also odoo/odoo#4598.

If we have some states in which the pricelist can be changed but the
currency is readonly, the currency seems to be changed, but while saving
it goes back.

The core purchase module probably needs a similar fix.
