### PR TITLE
[8.0] [FIX] purchase_requisition_bid_selection - cancel draftbid on generate po

### DIFF
--- a/purchase_requisition_bid_selection/model/purchase_requisition.py
+++ b/purchase_requisition_bid_selection/model/purchase_requisition.py
@@ -23,7 +23,6 @@ from openerp.exceptions import except_orm
 import openerp.osv.expression as expression
 from openerp.tools.safe_eval import safe_eval
 from openerp.tools.translate import _
-from openerp import netsvc
 from openerp.tools.float_utils import float_compare
 
 
@@ -158,13 +157,6 @@ class PurchaseRequisition(models.Model):
             remark=requisition_line.remark,
         )
         return vals
-
-    def trigger_validate_po(self, cr, uid, po_id, context=None):
-        wf_service = netsvc.LocalService("workflow")
-        wf_service.trg_validate(uid, 'purchase.order', po_id, 'draft_po', cr)
-        po_obj = self.pool.get('purchase.order')
-        po_obj.write(cr, uid, po_id, {'bid_partial': False}, context=context)
-        return True
 
     @api.model
     def check_valid_quotation(self, quotation):

--- a/purchase_requisition_bid_selection/model/purchase_requisition.py
+++ b/purchase_requisition_bid_selection/model/purchase_requisition.py
@@ -240,9 +240,9 @@ class PurchaseRequisition(models.Model):
                 elif purchase.state != 'cancel':
                     rfq_valid = True
         if pos_to_cancel:
-            reason_id = self.env['ir.model.data'].xmlid_to_res_id(
+            reason = self.env.ref(
                 'purchase_extended.purchase_cancelreason_rfq_canceled')
-            pos_to_cancel.write({'cancel_reason': reason_id})
+            pos_to_cancel.write({'cancel_reason': reason.id})
             pos_to_cancel.action_cancel()
         if not rfq_valid:
             raise except_orm(
@@ -290,11 +290,9 @@ class PurchaseRequisition(models.Model):
     @api.model
     def _get_default_reason(self):
         """Return default cancel reason"""
-        IrModelData = self.env['ir.model.data']
-        ref = ('purchase_requisition_bid_selection'
-               '.purchase_cancelreason_callforbids_canceled')
-        reason_id = IrModelData.xmlid_to_res_id(ref)
-        return reason_id
+        reason = self.env.ref('purchase_requisition_bid_selection'
+                              '.purchase_cancelreason_callforbids_canceled')
+        return reason.id
 
     @api.multi
     def tender_cancel(self):
@@ -366,19 +364,15 @@ class PurchaseRequisition(models.Model):
         ctx.update({'action': 'close_callforbids_ok',
                     'active_model': self._name,
                     })
-        IrModelData = self.env['ir.model.data']
-        ref = (
-            'purchase_requisition_bid_selection.action_modal_close_callforbids'
-        )
-        view_id = IrModelData.xmlid_to_res_id(ref)
-
+        view = self.env.ref('purchase_requisition_bid_selection'
+                            '.action_modal_close_callforbids')
         return {
             'type': 'ir.actions.act_window',
             'view_type': 'form',
             'view_mode': 'form',
             'res_model': 'purchase.action_modal',
-            'view_id': view_id,
-            'views': [(view_id, 'form')],
+            'view_id': view.id,
+            'views': [(view.id, 'form')],
             'target': 'new',
             'context': ctx,
         }

--- a/purchase_requisition_bid_selection/model/purchase_requisition.py
+++ b/purchase_requisition_bid_selection/model/purchase_requisition.py
@@ -207,7 +207,7 @@ class PurchaseRequisition(models.Model):
         """
         tender.refresh()
         for quotation in tender.purchase_ids:
-            if quotation.state in ['draft', 'sent', 'bid']:
+            if quotation.state in ['draft', 'sent', 'draftbid', 'bid']:
                 if self.quotation_selected(quotation):
                     quotation.signal_workflow('select_requisition')
                 else:

--- a/purchase_requisition_bid_selection/tests/__init__.py
+++ b/purchase_requisition_bid_selection/tests/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import test_cancel_purchase_requisition
+from . import test_generate_po

--- a/purchase_requisition_bid_selection/tests/test_generate_po.py
+++ b/purchase_requisition_bid_selection/tests/test_generate_po.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Author: Yannick Vaucher
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+import openerp.tests.common as common
+from openerp import fields
+
+
+class test_generate_po(common.TransactionCase):
+    """ Test generation of a purchase order from selected Bid and ensure
+    unselected Bids are cancelled
+    """
+
+    def setUp(self):
+        super(test_generate_po, self).setUp()
+        PReq = self.env['purchase.requisition']
+        PO = self.env['purchase.order']
+        POL = self.env['purchase.order.line']
+
+        # Put purchase.requisition directly to 'closed'
+        dummy_wkf_trans = self.env['workflow.transition'].create({
+            'act_from': self.env.ref('purchase_requisition.act_draft').id,
+            'act_to': self.env.ref(
+                'purchase_requisition_bid_selection.act_closed').id,
+            'condition': True,
+        })
+        self.preq = PReq.create({'state': 'closed'})
+        dummy_wkf_trans.unlink()
+
+        partner_12 = self.env.ref('base.res_partner_12')
+        partner_13 = self.env.ref('base.res_partner_13')
+        partner_14 = self.env.ref('base.res_partner_14')
+
+        # Put purchase.oders directly to 'bid'
+        dummy_wkf_trans = self.env['workflow.transition'].create({
+            'act_from': self.env.ref('purchase.act_draft').id,
+            'act_to': self.env.ref('purchase.act_bid').id,
+            'condition': True,
+        })
+        self.bid_selected = PO.create(
+            {'state': 'bid',
+             'bid_partial': True,
+             'partner_id': partner_12.id,
+             'location_id': self.env.ref('stock.stock_location_stock').id,
+             'pricelist_id': partner_12.property_product_pricelist_purchase.id,
+             })
+        POL.create({
+            'state': 'confirmed',
+            'order_id': self.bid_selected.id,
+            'name': '/',
+            'price_unit': 100,
+            'date_planned': fields.Datetime.now(),
+            })
+        self.bid = PO.create(
+            {'state': 'bid',
+             'partner_id': partner_13.id,
+             'location_id': self.env.ref('stock.stock_location_stock').id,
+             'pricelist_id': partner_13.property_product_pricelist_purchase.id,
+             })
+        dummy_wkf_trans.unlink()
+
+        # draftbid is at same workflow state as draft
+        self.draftbid = PO.create(
+            {'state': 'draftbid',
+             'partner_id': partner_14.id,
+             'location_id': self.env.ref('stock.stock_location_stock').id,
+             'pricelist_id': partner_14.property_product_pricelist_purchase.id,
+             })
+
+        purchases = self.bid_selected | self.bid | self.draftbid
+        self.preq.purchase_ids = purchases
+        self.preq.po_line_ids = purchases.mapped('order_line')
+
+    def test_generate_po(self):
+        """ We generate the PO of a Purchase Requisition having 3 Bids in
+        different states
+
+        """
+        self.preq.generate_po()
+        self.assertEqual(self.preq.state, 'done')
+        self.assertEqual(self.bid_selected.state, 'bid_selected')
+        self.assertEqual(self.bid.state, 'cancel')
+        self.assertEqual(self.draftbid.state, 'cancel')


### PR DESCRIPTION
Fix cancellation of draftpo remaing in state draftpo instead of being cancelled when generating PO.
Plus add test to reproduce

This PR depends on 
- [x] #92 
