### PR TITLE
[ADD] module 'purchase_delivery'

### DIFF
--- a/purchase_delivery/__init__.py
+++ b/purchase_delivery/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#               <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import model

--- a/purchase_delivery/__openerp__.py
+++ b/purchase_delivery/__openerp__.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#               <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    'name': 'Purchase Delivery Costs',
+    'version': '1.0',
+    'category': 'Purchase Management',
+    'description': """
+Allows you to add delivery methods in purchase orders and picking.
+==============================================================
+
+This module makes it possible to add delivery method to purchase orders and
+can compute a shipping line in the purchase order or in the invoice when
+created from an incoming shipment.
+
+The application makes use of the same concepts of carrier and delivery grid
+extending them as follows:
+    * Introduces origin countries, states and ZIP in the delivery grid.
+    * Uses the cost defined in the grid, instead of the sale price.
+    * Uses the vendor address to match with the existing grid based on the
+    origin information defined in the grid.
+    * Uses the destination address (customer address for direct shipments
+    and warehouse otherwise) to determine the grid, based on the destination
+    parameters defined in the grid.
+
+In case that the incoming shipment contains moves that have multiple
+destination addresses, computes the average freight cost.
+""",
+    'author': 'Eficent',
+    'depends': ['delivery', 'purchase'],
+    'data': [
+        'view/delivery_view.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'auto_install': False,
+    'images': [],
+}

--- a/purchase_delivery/model/__init__.py
+++ b/purchase_delivery/model/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#               <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import delivery
+from . import purchase
+from . import stock
+

--- a/purchase_delivery/model/delivery.py
+++ b/purchase_delivery/model/delivery.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#               <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, orm
+from openerp.tools.translate import _
+
+
+class delivery_carrier(orm.Model):
+    _inherit = "delivery.carrier"
+
+    def name_get(self, cr, uid, ids, context=None):
+        if not len(ids):
+            return []
+        if context is None:
+            context = {}
+        return [(r['id'], r['name']) for r in self.read(
+            cr, uid, ids, ['name'], context)]
+
+    def grid_src_dest_get(self, cr, uid, ids, src_id, dest_id, context=None):
+        dest = self.pool.get('res.partner').browse(cr, uid, dest_id,
+                                                   context=context)
+        src = self.pool.get('res.partner').browse(cr, uid, src_id,
+                                                  context=context)
+        for carrier in self.browse(cr, uid, ids, context=context):
+            for grid in carrier.grids_id:
+                get_id = lambda x: x.id
+                country_ids = map(get_id, grid.country_ids)
+                state_ids = map(get_id, grid.state_ids)
+                src_country_ids = map(get_id, grid.src_country_ids)
+                src_state_ids = map(get_id, grid.src_state_ids)
+
+                if country_ids and dest.country_id.id not in country_ids:
+                    continue
+                if state_ids and dest.state_id.id not in state_ids:
+                    continue
+                if grid.zip_from and (dest.zip or '') < grid.zip_from:
+                    continue
+                if grid.zip_to and (dest.zip or '') > grid.zip_to:
+                    continue
+                if src_country_ids and src.country_id.id not in \
+                        src_country_ids:
+                    continue
+                if src_state_ids and src.state_id.id not in src_state_ids:
+                    continue
+                if grid.src_zip_from and (src.zip or '') < grid.src_zip_from:
+                    continue
+                if grid.src_zip_to and (src.zip or '') > grid.src_zip_to:
+                    continue
+                return grid.id
+        return False
+
+
+class delivery_grid(orm.Model):
+    _inherit = "delivery.grid"
+
+    _columns = {
+            'src_country_ids': fields.many2many(
+                'res.country', 'delivery_grid_src_country_rel',
+                'grid_id', 'country_id', 'Source Countries'),
+            'src_state_ids': fields.many2many('res.country.state',
+                                              'delivery_grid_src_state_rel',
+                                              'grid_id', 'state_id',
+                                              'Source States'),
+            'src_zip_from': fields.char('Start Source Zip', size=12),
+            'src_zip_to': fields.char('To Source Zip', size=12),
+    }
+
+    def get_cost(self, cr, uid, id, order, dt, context=None):
+        total = 0
+        weight = 0
+        volume = 0
+        product_uom_obj = self.pool.get('product.uom')
+        for line in order.order_line:
+            if not line.product_id:
+                continue
+            q = product_uom_obj._compute_qty(cr, uid, line.product_uom.id,
+                                             line.product_qty,
+                                             line.product_id.uom_id.id)
+            total += line.price_subtotal or 0.0
+            weight += (line.product_id.weight or 0.0) * q
+            volume += (line.product_id.volume or 0.0) * q
+
+        return self.get_cost_from_picking(cr, uid, id, total, weight,
+                                          volume, context=context)
+
+    def get_cost_from_picking(self, cr, uid, id, total, weight, volume,
+                              context=None):
+        grid = self.browse(cr, uid, id, context=context)
+        price = 0.0
+        ok = False
+
+        for line in grid.line_ids:
+            price_dict = {'price': total, 'volume': volume, 'weight': weight,
+                          'wv': volume*weight}
+            test = eval(line.type+line.operator+str(line.max_value),
+                        price_dict)
+            if test:
+                if line.price_type == 'variable':
+                    price = line.standard_price * price_dict[
+                        line.variable_factor]
+                else:
+                    price = line.standard_price
+                ok = True
+                break
+        if not ok:
+            raise orm.except_orm(_('No cost available!'),
+                                 _('No line matched this product or order '
+                                   'in the chosen delivery grid.'))
+
+        return price

--- a/purchase_delivery/model/purchase.py
+++ b/purchase_delivery/model/purchase.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#               <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import time
+from openerp.osv import fields, orm
+from openerp.tools.translate import _
+
+
+class purchase_order(orm.Model):
+    _inherit = 'purchase.order'
+    _columns = {
+        'carrier_id': fields.many2one("delivery.carrier", "Delivery Method",
+                                      help="Complete this field if you plan "
+                                           "to invoice the shipping based on "
+                                           "picking."),
+    }
+
+    def onchange_partner_id(self, cr, uid, ids, part):
+        result = super(purchase_order, self).onchange_partner_id(
+            cr, uid, ids, part)
+        if part:
+            dtype = self.pool.get('res.partner').browse(
+                cr, uid, part).property_delivery_carrier.id
+            result['value']['carrier_id'] = dtype
+        return result
+
+    def _prepare_order_picking(self, cr, uid, order, context=None):
+        result = super(purchase_order, self)._prepare_order_picking(
+            cr, uid, order, context=context)
+        result.update(carrier_id=order.carrier_id.id)
+        return result
+
+    def delivery_set(self, cr, uid, ids, context=None):
+        line_obj = self.pool.get('purchase.order.line')
+        grid_obj = self.pool.get('delivery.grid')
+        carrier_obj = self.pool.get('delivery.carrier')
+        acc_fp_obj = self.pool.get('account.fiscal.position')
+        for order in self.browse(cr, uid, ids, context=context):
+            src_address_id = order.partner_id
+            dest_address_id = order.dest_address_id or False
+            if (
+                not dest_address_id
+                and order.warehouse_id
+                and order.warehouse_id.partner_id
+            ):
+                dest_address_id = order.warehouse_id.partner_id
+            if not dest_address_id:
+                raise orm.except_orm(_('No destination address available!'),
+                                     _('An address must be added to the'
+                                       'purchase order or the warehouse.'))
+            grid_id = carrier_obj.grid_src_dest_get(cr, uid,
+                                                    [order.carrier_id.id],
+                                                    src_address_id.id,
+                                                    dest_address_id.id)
+            if not grid_id:
+                raise orm.except_orm(_('No Grid Available!'),
+                                     _('No grid matching for this carrier!'))
+
+            if order.state not in ('draft', 'sent'):
+                raise orm.except_orm(_('Order not in Draft State!'),
+                                     _('The order state have to be draft '
+                                       'to add delivery lines.'))
+
+            grid = grid_obj.browse(cr, uid, grid_id, context=context)
+
+            taxes = grid.carrier_id.product_id.taxes_id
+            fpos = order.fiscal_position or False
+            taxes_ids = acc_fp_obj.map_tax(cr, uid, fpos, taxes)
+            # create the purchase order line
+            line_obj.create(cr, uid, {
+                'order_id': order.id,
+                'name': grid.carrier_id.name,
+                'product_qty': 1,
+                'product_uom': grid.carrier_id.product_id.uom_id.id,
+                'product_id': grid.carrier_id.product_id.id,
+                'price_unit': grid_obj.get_cost(
+                    cr, uid, grid.id, order, time.strftime('%Y-%m-%d'),
+                    context),
+                'taxes_id': [(6, 0, taxes_ids)],
+                'date_planned': order.date_order,
+            })
+        return True
+
+    def _prepare_order_line_move(self, cr, uid, order, order_line, picking_id,
+                                 context=None):
+        res = super(purchase_order, self)._prepare_order_line_move(
+            cr, uid, order, order_line, picking_id, context=context)
+        if order.warehouse_id and not order.dest_address_id:
+            res['partner_id'] = order.warehouse_id.partner_id.id,
+        return res

--- a/purchase_delivery/model/stock.py
+++ b/purchase_delivery/model/stock.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#               <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, orm
+from openerp.tools.translate import _
+
+
+class stock_picking(orm.Model):
+    _inherit = 'stock.picking'
+
+    def _prepare_shipping_invoice_line(self, cr, uid, picking, invoice, context=None):
+        """Prepare the invoice line to add to the shipping costs to the shipping's
+           invoice.
+
+            :param browse_record picking: the stock picking being invoiced
+            :param browse_record invoice: the stock picking's invoice
+            :return: dict containing the values to create the invoice line,
+                     or None to create nothing
+        """
+        if invoice.type in ['out_invoice', 'out_refund']:
+            return super(stock_picking, self)._prepare_shipping_invoice_line(
+                cr, uid, picking, invoice, context=context)
+        else:
+            carrier_obj = self.pool.get('delivery.carrier')
+            grid_obj = self.pool.get('delivery.grid')
+            if not picking.carrier_id or \
+                any(inv_line.product_id.id == picking.carrier_id.product_id.id
+                    for inv_line in invoice.invoice_line):
+                return None
+            total_price = 0.0
+            total_qty = 0.0
+            for move in picking.move_lines:
+                grid_id = carrier_obj.grid_src_dest_get(
+                    cr, uid, [picking.carrier_id.id], picking.partner_id.id,
+                    move.partner_id.id, context=context)
+                if not grid_id:
+                    raise orm.except_orm(_('Warning!'),
+                                         _('The carrier %s (id: %d) has no '
+                                           'delivery grid!')
+                                         % (picking.carrier_id.name,
+                                            picking.carrier_id.id))
+                price = grid_obj.get_cost_from_picking(cr, uid, grid_id,
+                                                       invoice.amount_untaxed,
+                                                       move.product_id.weight,
+                                                       move.product_id.volume,
+                                                       context=context)
+                total_price += price
+                total_qty += move.product_qty
+            price = total_price / total_qty
+            account_id = picking.carrier_id.product_id.\
+                property_account_expense.id
+            if not account_id:
+                account_id = picking.carrier_id.product_id.categ_id.\
+                    property_account_expense_categ.id
+
+            taxes = picking.carrier_id.product_id.taxes_id
+            partner = picking.partner_id
+            fpos_obj = self.pool.get('account.fiscal.position')
+            if partner:
+                account_id = fpos_obj.map_account(
+                    cr, uid, partner.property_account_position, account_id)
+                taxes_ids = fpos_obj.map_tax(
+                    cr, uid, partner.property_account_position, taxes)
+            else:
+                taxes_ids = [x.id for x in taxes]
+
+            return {
+                'name': picking.carrier_id.name,
+                'invoice_id': invoice.id,
+                'uom_id': picking.carrier_id.product_id.uos_id.id,
+                'product_id': picking.carrier_id.product_id.id,
+                'account_id': account_id,
+                'price_unit': price,
+                'quantity': 1,
+                'invoice_line_tax_id': [(6, 0, taxes_ids)],
+            }

--- a/purchase_delivery/view/delivery_view.xml
+++ b/purchase_delivery/view/delivery_view.xml
@@ -1,0 +1,95 @@
+<openerp>
+    <data>
+
+        <record id="view_delivery_carrier_form" model="ir.ui.view">
+            <field name="name">delivery.carrier.form</field>
+            <field name="model">delivery.carrier</field>
+            <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='pricelist_ids']/form/notebook"
+                       position="inside">
+                    <page string="Origin">
+                        <group>
+                            <group>
+                                <field name="src_country_ids"
+                                       widget="many2many_tags"/>
+                                <field name="src_state_ids"
+                                       widget="many2many_tags"/>
+                            </group>
+                            <group>
+                                <label for="src_zip_from" string="Zip"/>
+                                <div>
+                                    <field name="src_zip_from"
+                                           class="oe_inline"/>
+                                    -
+                                    <field name="src_zip_to"
+                                           class="oe_inline"/>
+                                </div>
+                            </group>
+                        </group>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+
+
+        <record id="view_delivery_grid_form" model="ir.ui.view">
+            <field name="name">delivery.grid.form</field>
+            <field name="model">delivery.grid</field>
+            <field name="inherit_id" ref="delivery.view_delivery_grid_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="/form/notebook" position="inside">
+                    <page string="Origin">
+                        <group string="Countries">
+                            <field name="src_country_ids"/>
+                        </group>
+                        <group string="States">
+                            <field colspan="2" name="src_state_ids"
+                                   nolabel="1"/>
+                            <field name="src_zip_from"/>
+                            <field name="src_zip_to"/>
+                        </group>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_order_withcarrier_form" model="ir.ui.view">
+            <field name="name">delivery.purchase.order_withcarrier.form
+                .view</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@string='Incoming Shipments &amp; Invoices']" position="inside">
+                    <group style="width: 65%%">
+                        <label for="carrier_id"/>
+                        <div>
+                            <field name="carrier_id" context="{'order_id':active_id or False}" class="oe_inline"/>
+                            <button name="delivery_set" string="Add in Quote" type="object"
+                                class="oe_edit_only"
+                                attrs="{'invisible':['|',('carrier_id','=',False),('state','not in',('draft','sent'))]}"/>
+                            <br/>
+                            <label string="If you don't 'Add in Quote', the exact price will be computed when invoicing based on delivery order(s)."
+                                class="oe_edit_only"
+                                attrs="{'invisible':['|',('carrier_id','=',False),('state','not in',('draft','sent'))]}"/>
+                        </div>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_picking_withcarrier_in_form" model="ir.ui.view">
+            <field name="name">delivery.stock.picking_withcarrier.in.form.view</field>
+            <field name="model">stock.picking.in</field>
+            <field name="inherit_id"
+                   ref="delivery.view_picking_withcarrier_in_form"/>
+            <field name="arch" type="xml">
+                <field name="min_date" position="after">
+                    <field name="carrier_id"/>
+                    <field name="carrier_tracking_ref"/>
+                    <field name="number_of_packages"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/purchase_delivery/view/delivery_view.xml
+++ b/purchase_delivery/view/delivery_view.xml
@@ -69,7 +69,8 @@
                                 class="oe_edit_only"
                                 attrs="{'invisible':['|',('carrier_id','=',False),('state','not in',('draft','sent'))]}"/>
                             <br/>
-                            <label string="If you don't 'Add in Quote', the exact price will be computed when invoicing based on delivery order(s)."
+                            <label
+                                    string="If you don't 'Add in Quote', the exact price will be computed when invoicing based on incoming shipment(s)."
                                 class="oe_edit_only"
                                 attrs="{'invisible':['|',('carrier_id','=',False),('state','not in',('draft','sent'))]}"/>
                         </div>


### PR DESCRIPTION
This module makes it possible to add delivery method to purchase orders and
can compute a shipping line in the purchase order or in the invoice when
created from an incoming shipment.

The application makes use of the same concepts of carrier and delivery grid
extending them as follows:
    \* Introduces origin countries, states and ZIP in the delivery grid.
    \* Uses the cost defined in the grid, instead of the sale price.
    \* Uses the vendor address to match with the existing grid based on the
    origin information defined in the grid.
    \* Uses the destination address (customer address for direct shipments
    and warehouse otherwise) to determine the grid, based on the destination
    parameters defined in the grid.

In case that the incoming shipment contains moves that have multiple
destination addresses, computes the average freight cost.
