### PR TITLE
8.0 Fixes for Comparative bid analysis (bid selection)

### DIFF
--- a/purchase_requisition_bid_selection/i18n/purchase_requisition_bid_selection.pot
+++ b/purchase_requisition_bid_selection/i18n/purchase_requisition_bid_selection.pot
@@ -1,0 +1,527 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_requisition_bid_selection
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-03-24 12:17+0000\n"
+"PO-Revision-Date: 2015-03-24 12:17+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.requisition,bid_receipt_mode:0
+msgid "- Open : The bids can be opened when received and encoded. \n"
+"- Closed : The bids can be marked as received but they have to be opened \n"
+"all at the same time after an opening ceremony (probably specific to public sector)."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.requisition,bid_tendering_mode:0
+msgid "- Restricted : you select yourself the bidders and generate a RFQ for each of those. \n"
+"- Open : anybody can bid (you have to advertise the call for bids) and you directly encode the bids you received. You are still able to generate RFQ if you want to contact usual bidders."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Accept selection"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.action_modal:purchase_requisition_bid_selection.modal_confirm_close_selection
+msgid "Are you sure you want to accept the current selection?\n"
+"            You cannot cancel this action."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,tender_bid_receipt_mode:0
+#: field:purchase.requisition,bid_receipt_mode:0
+msgid "Bid Receipt Mode"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,bid_eligible:0
+#: field:purchase.order.line,bid_eligible:0
+msgid "Bid eligible"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,bid_partial:0
+msgid "Bid partially selected"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:update.bid.selection.remark,bid_selection_remark:0
+msgid "Bid selection remark"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition.line,purchase_line_ids:0
+msgid "Bids Lines"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order.line:purchase_requisition_bid_selection.view_purchase_order_line_search
+msgid "Bids encoded"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition,budget:0
+msgid "Budget"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order.line,requisition_line_id:0
+msgid "Call for Bid Line"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition,bid_tendering_mode:0
+msgid "Call for Bids Mode"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order.line:purchase_requisition_bid_selection.view_purchase_order_line_search
+msgid "Call for Bids line"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: model:purchase.cancel_reason,name:purchase_requisition_bid_selection.purchase_cancelreason_callforbids_canceled
+msgid "Call for bids canceled"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.action_modal:purchase_requisition_bid_selection.action_modal_confirm_different_quantity
+#: view:purchase.action_modal:purchase_requisition_bid_selection.modal_confirm_close_selection
+#: view:purchase.action_modal.ask_selection_reasons:purchase_requisition_bid_selection.ask_selection_reasons
+#: view:purchase.requisition.partner:purchase_requisition_bid_selection.view_purchase_requisition_partner_draftbid
+#: view:update.bid.selection.remark:purchase_requisition_bid_selection.view_update_bid_selection_remark
+msgid "Cancel"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: code:addons/purchase_requisition_bid_selection/model/purchase_requisition.py:220
+#, python-format
+msgid "Canceled by the call for bids associated to this request for quotation."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: model:ir.actions.act_window,name:purchase_requisition_bid_selection.action_purchase_requisition_partner_draftbid
+#: view:purchase.requisition.partner:purchase_requisition_bid_selection.view_purchase_requisition_partner_draftbid
+msgid "Choose Supplier"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.action_modal:purchase_requisition_bid_selection.action_modal_confirm_different_quantity
+#: view:purchase.action_modal:purchase_requisition_bid_selection.modal_confirm_close_selection
+#: view:purchase.action_modal.ask_selection_reasons:purchase_requisition_bid_selection.ask_selection_reasons
+msgid "Confirm"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.action_modal:purchase_requisition_bid_selection.modal_confirm_close_selection
+msgid "Confirmation"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,country_of_origin:0
+msgid "Country of origin"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition.partner:purchase_requisition_bid_selection.view_purchase_requisition_partner_draftbid
+msgid "Create Bid"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.action_modal.ask_selection_reasons,create_uid:0
+#: field:update.bid.selection.remark,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.action_modal.ask_selection_reasons,create_date:0
+#: field:update.bid.selection.remark,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.requisition,req_payment_term_id:0
+msgid "Default value requested to the supplier."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.requisition,req_incoterm_id:0
+msgid "Default value requested to the supplier. International Commercial Terms are a series of predefined commercial terms used in international transactions."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Deliveries"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order:purchase_requisition_bid_selection.view_purchase_order_form
+#: field:purchase.order,delivery_remark:0
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+#: field:purchase.requisition,delivery_remark:0
+msgid "Delivery Remarks"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order.line:purchase_requisition_bid_selection.view_purchase_order_line_search
+msgid "Eligible"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Encode a Bid"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: code:addons/purchase_requisition_bid_selection/model/purchase_requisition.py:246
+#: code:addons/purchase_requisition_bid_selection/model/purchase_requisition.py:269
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: code:addons/purchase_requisition_bid_selection/model/purchase_requisition.py:130
+#, python-format
+msgid "Error!"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.action_modal:purchase_requisition_bid_selection.action_modal_confirm_different_quantity
+msgid "For some lines, the selected quantity does not match the requested quantity.\n"
+"            Please confirm the operation."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Generate PO"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition,generated_order_ids:0
+msgid "Generated Purchase Orders"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.action_modal.ask_selection_reasons,id:0
+#: field:update.bid.selection.remark,id:0
+msgid "ID"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order.line:purchase_requisition_bid_selection.view_purchase_order_line_search
+#: field:purchase.order.line,incoterm_id:0
+msgid "Incoterm"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.requisition,req_incoterm_address:0
+msgid "Incoterm Place of Delivery. International Commercial Terms are a series of predefined commercial terms used in international transactions."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.order.line,incoterm_id:0
+msgid "International Commercial Terms are a series of predefined commercial terms used in international transactions."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.action_modal.ask_selection_reasons,write_uid:0
+#: field:update.bid.selection.remark,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.action_modal.ask_selection_reasons,write_date:0
+#: field:update.bid.selection.remark,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order.line:purchase_requisition_bid_selection.view_purchase_order_line_search
+msgid "Meets Specifications"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,meets_specifications:0
+#: field:purchase.order.line,meets_specifications:0
+msgid "Meets specifications"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: selection:purchase.order,tender_bid_receipt_mode:0
+#: selection:purchase.requisition,bid_receipt_mode:0
+#: selection:purchase.requisition,bid_tendering_mode:0
+msgid "Open"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Options"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.action_modal.ask_selection_reasons:purchase_requisition_bid_selection.ask_selection_reasons
+msgid "Please enter a reason for the suggested selection."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,keep_in_draft:0
+msgid "Prevent validation of purchase order."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition,pricelist_id:0
+msgid "Pricelist"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.requisition,pricelist_id:0
+msgid "Pricelist that represent the currency for current logistic request."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: model:ir.model,name:purchase_requisition_bid_selection.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: model:ir.model,name:purchase_requisition_bid_selection.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: model:ir.model,name:purchase_requisition_bid_selection.model_purchase_requisition
+msgid "Purchase Requisition"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: model:ir.model,name:purchase_requisition_bid_selection.model_purchase_requisition_line
+msgid "Purchase Requisition Line"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: model:ir.model,name:purchase_requisition_bid_selection.model_purchase_requisition_partner
+msgid "Purchase Requisition Partner"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Re-Open Bids Selection"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:update.bid.selection.remark:purchase_requisition_bid_selection.view_update_bid_selection_remark
+msgid "Remark"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order.line:purchase_requisition_bid_selection.view_purchase_order_line_form
+#: field:purchase.order.line,remark:0
+#: field:purchase.requisition.line,remark:0
+msgid "Remarks / Conditions"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition,req_validity:0
+msgid "Requested Bid's End of Validity"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition,req_incoterm_id:0
+msgid "Requested Incoterms"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition,req_incoterm_address:0
+msgid "Requested Incoterms Place"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition,req_payment_term_id:0
+msgid "Requested Payment Term"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.requisition,req_terms_of_payment:0
+msgid "Requested Terms of Payment"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.requisition,req_validity:0
+msgid "Requested validity period requested to the bidder, i.e. please send bids that stay valid until that date.\n"
+" The bidder is allowed to send a bid with another validity end date that gets encoded in the bid."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Requests for Quotation"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Requests for Quotation / Bids"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: selection:purchase.requisition,bid_tendering_mode:0
+msgid "Restricted"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: selection:purchase.order,tender_bid_receipt_mode:0
+#: selection:purchase.requisition,bid_receipt_mode:0
+msgid "Sealed"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.action_modal.ask_selection_reasons:purchase_requisition_bid_selection.ask_selection_reasons
+#: field:purchase.action_modal.ask_selection_reasons,selection_reasons:0
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+#: field:purchase.requisition,selection_reasons:0
+msgid "Selection reasons"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,bid_selection_remark:0
+msgid "Selection remarks"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.order,keep_in_draft:0
+msgid "Technical field used to prevent the PO that is automatically generated from a Tender to be validated. It is checked on the workflow transition."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order:purchase_requisition_bid_selection.view_purchase_order_form
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Terms and Conditions"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Terms and Conditions..."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order:purchase_requisition_bid_selection.view_purchase_order_form
+msgid "Terms and conditions..."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,terms_of_payment:0
+msgid "Terms of payment"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: help:purchase.order,bid_partial:0
+msgid "True if the bid has been partially selected"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: model:ir.actions.act_window,name:purchase_requisition_bid_selection.action_update_bid_selection_remark
+msgid "Update bid selection remark"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:update.bid.selection.remark:purchase_requisition_bid_selection.view_update_bid_selection_remark
+msgid "Update remark"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "Update selection remark"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "View Generated PO"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,volume_estimated:0
+msgid "Volume estimated (m3)"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.action_modal:purchase_requisition_bid_selection.action_modal_confirm_different_quantity
+msgid "Warning"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: field:purchase.order,weight_estimated:0
+msgid "Weight estimated (kg)"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: code:addons/purchase_requisition_bid_selection/model/purchase_requisition.py:270
+#, python-format
+msgid "You cannot cancel a call for bids which has already received bids."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: code:addons/purchase_requisition_bid_selection/model/purchase_requisition.py:246
+#, python-format
+msgid "You do not have valid sent RFQs."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: code:addons/purchase_requisition_bid_selection/model/purchase_requisition.py:131
+#, python-format
+msgid "You have to define some products before confirming the call for bids."
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "closed"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "draft,in_progress,open,selected,closed,done"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "gtk-apply"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.action_modal:purchase_requisition_bid_selection.action_modal_confirm_different_quantity
+#: view:purchase.action_modal:purchase_requisition_bid_selection.modal_confirm_close_selection
+#: view:purchase.action_modal.ask_selection_reasons:purchase_requisition_bid_selection.ask_selection_reasons
+#: view:purchase.requisition.partner:purchase_requisition_bid_selection.view_purchase_requisition_partner_draftbid
+#: view:update.bid.selection.remark:purchase_requisition_bid_selection.view_update_bid_selection_remark
+msgid "or"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.order:purchase_requisition_bid_selection.view_purchase_order_form
+msgid "{'invisible': ['|', ('requisition_id','!=',False)]}"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "{'invisible': ['|', ('state', 'not in', ('open','selected','closed','done')), ('exclusive', '=', 'exclusive')]}"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "{'invisible': ['|','|',('bid_tendering_mode','=','open'),('line_ids','=',[]),('state','!=','in_progress')]}"
+msgstr ""
+
+#. module: purchase_requisition_bid_selection
+#: view:purchase.requisition:purchase_requisition_bid_selection.view_purchase_requisition_form
+msgid "{'invisible': ['|',('purchase_ids','=',[]),('state', 'in', ('draft'))]}"
+msgstr ""
+

--- a/purchase_requisition_bid_selection/model/purchase_order.py
+++ b/purchase_requisition_bid_selection/model/purchase_order.py
@@ -17,7 +17,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-
 from openerp import models, fields, api, osv
 
 
@@ -117,7 +116,8 @@ class PurchaseOrderLine(models.Model):
                                         related='order_id.country_of_origin')
     incoterm_id = fields.Many2one('stock.incoterms',
                                   string='Incoterm',
-                                  related='order_id.incoterm_id')
+                                  related='order_id.incoterm_id',
+                                  store=True)
     incoterm_address = fields.Char('Incoterms place',
                                    related='order_id.incoterm_address')
     terms_of_payment = fields.Char(related='order_id.terms_of_payment')

--- a/purchase_requisition_bid_selection/view/purchase_order.xml
+++ b/purchase_requisition_bid_selection/view/purchase_order.xml
@@ -76,9 +76,13 @@
       <field name="arch" type="xml">
 
         <xpath expr="//filter[@name='hide_cancelled']" position="before">
+          <separator/>
           <filter name="showbids" string="Bids encoded" domain="[('order_id.state', '=', 'bid')]"/>
+          <separator/>
           <filter name="meets_specifications" string="Meets Specifications" domain="[('meets_specifications', '=', True)]"/>
+          <separator/>
           <filter name="bid_eligible" string="Eligible" domain="[('bid_eligible', '=', True)]"/>
+          <separator/>
         </xpath>
 
         <xpath expr="//filter[@name='groupby_product']" position="after">

--- a/purchase_requisition_bid_selection/wizard/modal.xml
+++ b/purchase_requisition_bid_selection/wizard/modal.xml
@@ -44,6 +44,10 @@
       <field name="arch" type="xml">
         <form string="Selection reasons">
 
+          <p>
+            Please enter a reason for the suggested selection.
+          </p>
+
           <group name="Selection reasons">
             <field name="selection_reasons" nolabel="1"/>
           </group>

--- a/purchase_requisition_bid_selection/wizard/update_bid_selection_remark.xml
+++ b/purchase_requisition_bid_selection/wizard/update_bid_selection_remark.xml
@@ -7,7 +7,7 @@
       <field name="arch" type="xml">
         <form string="Remark">
           <group>
-            <field name="bid_selection_remark" />
+            <field name="bid_selection_remark"/>
           </group>
           <footer>
             <button name="update_remark" string="Update remark" type="object" class="oe_highlight"/>

--- a/purchase_requisition_multicurrency/model/purchase_order.py
+++ b/purchase_requisition_multicurrency/model/purchase_order.py
@@ -45,11 +45,13 @@ class PurchaseOrderLine(models.Model):
     price_unit_co = fields.Float(
         compute='_compute_prices_in_company_currency',
         string="Unit Price",
+        store=True,
         help="Unit Price in company currency."
         )
     price_subtotal_co = fields.Float(
         compute='_compute_prices_in_company_currency',
         string="Subtotal",
+        store=True,
         help="Subtotal in company currency."
         )
 


### PR DESCRIPTION
- store computed values in company currency to make them orderable
- store related incoterm to make it groupable
- add separators between filters to add them as AND conditions
- add a help text on wizard which had no label and no instructions
- add missing POT file
