### PR TITLE
fix purchase cancelation

### DIFF
--- a/purchase_rfq_bid_workflow/model/purchase_order.py
+++ b/purchase_rfq_bid_workflow/model/purchase_order.py
@@ -204,8 +204,8 @@ class PurchaseOrder(models.Model):
         assert self._context.get('active_id')
         action_modal = act_modal_cancel_obj.browse(self._context['active_id'])
         self.cancel_reason_id = action_modal.reason_id
-
-        self.signal_workflow('purchase_cancel')
+        # resume the normal course of events for purchase cancel
+        return super(PurchaseOrder, self).action_cancel()
 
     @api.multi
     def wkf_action_cancel(self):


### PR DESCRIPTION
we need to call super().action_cancel  which will cancel the pickings and invoices if needed
and then trigger the workflow.
