### PR TITLE
[FIX] ensure active_model and active_ids are setted when opening cancel ...

### DIFF
--- a/purchase_rfq_bid_workflow/model/purchase_order.py
+++ b/purchase_rfq_bid_workflow/model/purchase_order.py
@@ -186,6 +186,8 @@ class PurchaseOrder(models.Model):
                                          'action_modal_cancel_reason'))[1]
         ctx = self._context.copy()
         ctx['action'] = 'action_cancel_ok'
+        ctx['active_model'] = 'purchase.order'
+        ctx['active_ids'] = self.ids
         # TODO: filter based on po type
         return {
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
...wizard for Bids

This ensure that in Bid list view "View RFQs/Bids" context values are
correctly set as it defines active_model

Otherwise model is 'purchase.requisition' and it will raise:

```
File ".../purchase-workflow/purchase_rfq_bid_workflow/wizard/modal.py
", line 36, in action
    self._context['action'])()
AttributeError: 'purchase.requisition' object has no attribute 'action_cancel_ok'
```
