### PR TITLE
[8.0]  Somes fixes on  purchase partial invoicing

### DIFF
--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -109,9 +109,11 @@ class purchase_order(orm.Model):
     }
 
     def _prepare_inv_line(self, cr, uid, account_id, order_line, context=None):
+        if context is None:
+            context = {}
         res = super(purchase_order, self).\
             _prepare_inv_line(cr, uid, account_id, order_line, context=context)
-        if context is not None and context.get('partial_quantity_lines'):
+        if context.get('partial_quantity_lines'):
             partial_quantity_lines = context.get('partial_quantity_lines')
             if partial_quantity_lines.get(order_line.id):
                 res.update({'quantity':

--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -111,10 +111,12 @@ class purchase_order(orm.Model):
     def _prepare_inv_line(self, cr, uid, account_id, order_line, context=None):
         res = super(purchase_order, self).\
             _prepare_inv_line(cr, uid, account_id, order_line, context=context)
-        if context is not None and context.get('partial_quantity', False):
-            partial_quantity = context.get('partial_quantity')
-            if partial_quantity.get(order_line.id, False):
-                res.update({'quantity': partial_quantity.get(order_line.id)})
+        if context is not None and context\
+                .get('partial_quantity_lines', False):
+            partial_quantity_lines = context.get('partial_quantity_lines')
+            if partial_quantity_lines.get(order_line.id, False):
+                res.update({'quantity':
+                            partial_quantity_lines.get(order_line.id)})
         return res
 
 

--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -52,12 +52,12 @@ class purchase_order_line(orm.Model):
         return res
 
     def _order_lines_from_invoice_line(self, cr, uid, ids, context=None):
-        result = {}
+        result = set()
         for invoice in self.pool['account.invoice'].browse(cr, uid, ids,
                                                            context=context):
             for line in invoice.invoice_line:
-                result[line.purchase_line_id.id] = True
-        return result.keys()
+                result.add(line.purchase_line_id.id)
+        return list(result)
 
     _inherit = 'purchase.order.line'
 

--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -96,7 +96,8 @@ class purchase_order(orm.Model):
     def _invoiced(self, cursor, user, ids, name, arg, context=None):
         res = {}
         for purchase in self.browse(cursor, user, ids, context=context):
-            res[purchase.id] = all(line.all_invoices_approved
+            res[purchase.id] = all(line.all_invoices_approved and
+                                   line.fully_invoiced
                                    for line in purchase.order_line)
         return res
 

--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -111,10 +111,9 @@ class purchase_order(orm.Model):
     def _prepare_inv_line(self, cr, uid, account_id, order_line, context=None):
         res = super(purchase_order, self).\
             _prepare_inv_line(cr, uid, account_id, order_line, context=context)
-        if context is not None and context\
-                .get('partial_quantity_lines', False):
+        if context is not None and context.get('partial_quantity_lines'):
             partial_quantity_lines = context.get('partial_quantity_lines')
-            if partial_quantity_lines.get(order_line.id, False):
+            if partial_quantity_lines.get(order_line.id):
                 res.update({'quantity':
                             partial_quantity_lines.get(order_line.id)})
         return res

--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -20,6 +20,7 @@
 ##############################################################################
 
 from openerp.osv import fields, orm
+import openerp.addons.decimal_precision as dp
 
 
 class purchase_order_line(orm.Model):
@@ -66,6 +67,7 @@ class purchase_order_line(orm.Model):
             _invoiced_qty,
             string='Invoiced quantity',
             type='float',
+            digits_compute=dp.get_precision('Product Unit of Measure'),
             copy=False,
             store={
                    'account.invoice': (_order_lines_from_invoice_line, [], 5),

--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -51,17 +51,37 @@ class purchase_order_line(orm.Model):
                 res[line.id] = False
         return res
 
+    def _order_lines_from_invoice_line(self, cr, uid, ids, context=None):
+        result = {}
+        for invoice in self.pool['account.invoice'].browse(cr, uid, ids,
+                                                           context=context):
+            for line in invoice.invoice_line:
+                result[line.purchase_line_id.id] = True
+        return result.keys()
+
     _inherit = 'purchase.order.line'
 
     _columns = {
         'invoiced_qty': fields.function(
             _invoiced_qty,
             string='Invoiced quantity',
-            type='float'),
+            type='float',
+            copy=False,
+            store={
+                   'account.invoice': (_order_lines_from_invoice_line, [], 5),
+                   'purchase.order.line': (lambda self, cr, uid, ids,
+                                           context=None: ids,
+                                           ['invoice_lines'], 5)}),
         'fully_invoiced': fields.function(
             _fully_invoiced,
             string='Fully invoiced',
-            type='boolean'),
+            type='boolean',
+            copy=False,
+            store={
+                   'account.invoice': (_order_lines_from_invoice_line, [], 10),
+                   'purchase.order.line': (lambda self, cr, uid, ids,
+                                           context=None: ids,
+                                           ['invoice_lines'], 10)}),
         'all_invoices_approved': fields.function(
             _all_invoices_approved,
             string='All invoices approved',

--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -87,6 +87,15 @@ class purchase_order(orm.Model):
                                          "been validated"),
     }
 
+    def _prepare_inv_line(self, cr, uid, account_id, order_line, context=None):
+        res = super(purchase_order, self).\
+            _prepare_inv_line(cr, uid, account_id, order_line, context=context)
+        if context is not None and context.get('partial_quantity', False):
+            partial_quantity = context.get('partial_quantity')
+            if partial_quantity.get(order_line.id, False):
+                res.update({'quantity': partial_quantity.get(order_line.id)})
+        return res
+
 
 class account_invoice(orm.Model):
     _inherit = 'account.invoice'

--- a/purchase_partial_invoicing/wizard/po_line_invoice.py
+++ b/purchase_partial_invoicing/wizard/po_line_invoice.py
@@ -82,7 +82,7 @@ class purchase_line_invoice(orm.TransientModel):
         if len(invoiced_ids) > 0:
             purchase_line_obj.write(cr, uid, not_invoiced_ids,
                                     {'invoiced': True})
-        ctx.update({'partial_quantity': changed_lines})
+        ctx.update({'partial_quantity_lines': changed_lines})
         res = super(purchase_line_invoice, self).makeInvoices(
             cr, uid, ids, context=ctx)
         for po_line_id in changed_lines:

--- a/purchase_partial_invoicing/wizard/po_line_invoice.py
+++ b/purchase_partial_invoicing/wizard/po_line_invoice.py
@@ -76,10 +76,10 @@ class purchase_line_invoice(orm.TransientModel):
                 invoiced_ids.append(line.po_line_id.id)
             else:
                 not_invoiced_ids.append(line.po_line_id.id)
-        if len(not_invoiced_ids) > 0:
+        if not_invoiced_ids:
             purchase_line_obj.write(cr, uid, not_invoiced_ids,
                                     {'invoiced': False})
-        if len(invoiced_ids) > 0:
+        if invoiced_ids:
             purchase_line_obj.write(cr, uid, not_invoiced_ids,
                                     {'invoiced': True})
         ctx.update({'partial_quantity_lines': changed_lines})


### PR DESCRIPTION
-  Use context instead of write on purchase order line to invoice partial quantity.
-  Domain with fully_invoiced doesn't work if this field isn't store.
-  Reset invoiced flag to fully_invoiced before invoice generation. Without this fix, it is not possible to invoice an already invoiced purchase order line whose invoice's line was deleted because the invoiced flag remains true on the purchase order line.
- Purchase order should be not invoiced if all lines aren't fully invoiced

EDIT:
-  Decimal precision on invoiced_qty must be the same as product_qty on purchase order line
