### PR TITLE
VCI - Allow to create Purchase invoice with invoice on incoming shipm…

### DIFF
--- a/vendor_consignment_stock/model/procurement.py
+++ b/vendor_consignment_stock/model/procurement.py
@@ -40,6 +40,11 @@ class Procurement(models.Model):
 
                 order_line.order_id.is_vci = True
 
+                # As no picking is generated for this kind
+                # of purchase, it must be generated on order
+                if order_line.order_id.invoice_method == 'picking':
+                    order_line.order_id.invoice_method = 'order'
+
         return result
 
     @api.model


### PR DESCRIPTION
…ent policy

If `Configuration / Purchases`, "Default invoicing control method is
set to "Based on incoming shipments", obviously it was impossible to generate a
supplier invoice for a Purchase created by a Vendor Consignement Inventory sale.
Simply because there is no incoming shipment.
Here we change purchase policy on creation to ensure the invoice is created once
purchase is confirmed.
