### PR TITLE
[FIX] Replace field discount instead of having 2 fields with the same…

### DIFF
--- a/purchase_discount/views/account_invoice_view.xml
+++ b/purchase_discount/views/account_invoice_view.xml
@@ -6,10 +6,7 @@
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_supplier_form"/>
             <field name="arch" type="xml">
-                <field name="discount" position="attributes">
-                    <attribute name="invisible">True</attribute>
-                </field>            
-                <field name="price_unit" position="after">
+                <field name="discount" position="replace">
                     <field name="discount"/>
                 </field>
             </field>

--- a/purchase_discount/views/account_invoice_view.xml
+++ b/purchase_discount/views/account_invoice_view.xml
@@ -6,8 +6,8 @@
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_supplier_form"/>
             <field name="arch" type="xml">
-                <field name="discount" position="replace">
-                    <field name="discount"/>
+                <field name="discount" position="attributes">
+                    <attribute name="groups"></attribute>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Replace field discount instead of having 2 fields with the same, it prevent that
the supplier invoice view is not correctly displayed if you have discount in sale order
activate.
