### PR TITLE
8.0 add purchase delivery split date

### DIFF
--- a/purchase_delivery_split_date/README.rst
+++ b/purchase_delivery_split_date/README.rst
@@ -1,0 +1,40 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License AGPL-3
+
+Split Purchase Deliveries in one reception per expected date
+============================================================
+
+When this module is installed, each Purchase Order you confirm will
+generate one Reception Order per expected date indicated in the
+Purchase Order Lines.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/purchase-workflow/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/purchase-workflow/issues/new?body=module:%20purchase_delivery_split_date%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+* Philippe Rossi <pr@numerigraphe.com> (initial patch against v6.0)
+* Lionel Sausin <ls@numerigraphe.com> (modularization for v7+)
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/purchase_delivery_split_date/README.rst
+++ b/purchase_delivery_split_date/README.rst
@@ -1,6 +1,8 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License AGPL-3
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
+============================================================
 Split Purchase Deliveries in one reception per expected date
 ============================================================
 
@@ -24,12 +26,13 @@ Contributors
 * Philippe Rossi <pr@numerigraphe.com> (initial patch against v6.0)
 * Lionel Sausin <ls@numerigraphe.com> (modularization for v7+)
 
+
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
@@ -37,4 +40,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_delivery_split_date/__init__.py
+++ b/purchase_delivery_split_date/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import purchase

--- a/purchase_delivery_split_date/__init__.py
+++ b/purchase_delivery_split_date/__init__.py
@@ -1,21 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014-2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import purchase

--- a/purchase_delivery_split_date/__openerp__.py
+++ b/purchase_delivery_split_date/__openerp__.py
@@ -1,30 +1,15 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014-2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': "Purchase Deliveries split by date",
-    'version': '8.0.2.0.0',
+    'version': '8.0.1.0.0',
     'author': u'Numérigraphe, Odoo Community Association (OCA)',
     'category': 'Purchase Management',
     'license': 'AGPL-3',
     'depends': [
         'purchase',
     ],
+    'images': [],
 }

--- a/purchase_delivery_split_date/__openerp__.py
+++ b/purchase_delivery_split_date/__openerp__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': "Purchase Deliveries split by date",
+    'version': '1.0',
+    'author': u'Numérigraphe',
+    'category': 'Purchase Management',
+    'description': """
+Split Purchase Deliveries in one reception per expected date
+------------------------------------------------------------
+
+When this module is installed, each Purchase Order you confirm will generate
+one Reception Order per delivery date indicated in the Purchase Order Lines.
+
+Contributors
+------------
+
+ * Philippe Rossi <pr@numerigraphe.com> (initial patch against v6.0)
+ * Lionel Sausin <ls@numerigraphe.com> (modularization for v7.0)
+""",
+    'license': 'AGPL-3',
+    "depends": ['purchase'],
+}

--- a/purchase_delivery_split_date/__openerp__.py
+++ b/purchase_delivery_split_date/__openerp__.py
@@ -20,22 +20,9 @@
 
 {
     'name': "Purchase Deliveries split by date",
-    'version': '1.0',
-    'author': u'Numérigraphe',
+    'version': '2.0',
+    'author': u'Numérigraphe, Odoo Community Association (OCA)',
     'category': 'Purchase Management',
-    'description': """
-Split Purchase Deliveries in one reception per expected date
-------------------------------------------------------------
-
-When this module is installed, each Purchase Order you confirm will generate
-one Reception Order per delivery date indicated in the Purchase Order Lines.
-
-Contributors
-------------
-
- * Philippe Rossi <pr@numerigraphe.com> (initial patch against v6.0)
- * Lionel Sausin <ls@numerigraphe.com> (modularization for v7.0)
-""",
     'license': 'AGPL-3',
     "depends": ['purchase'],
 }

--- a/purchase_delivery_split_date/__openerp__.py
+++ b/purchase_delivery_split_date/__openerp__.py
@@ -20,9 +20,11 @@
 
 {
     'name': "Purchase Deliveries split by date",
-    'version': '2.0',
+    'version': '8.0.2.0.0',
     'author': u'Numérigraphe, Odoo Community Association (OCA)',
     'category': 'Purchase Management',
     'license': 'AGPL-3',
-    "depends": ['purchase'],
+    'depends': [
+        'purchase',
+    ],
 }

--- a/purchase_delivery_split_date/purchase.py
+++ b/purchase_delivery_split_date/purchase.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class PurchaseOrder(orm.Model):
+    _inherit = "purchase.order"
+
+    def _create_pickings(self, cr, uid, order, order_lines, picking_id=False,
+                         context=None):
+        """Group the Purchase Order's receptions by expected date"""
+        picking_ids = []
+        delivery_dates = {}
+        # Triage the order lines by delivery date
+        for line in order_lines:
+            if line.date_planned in delivery_dates:
+                delivery_dates[line.date_planned].append(line)
+            else:
+                delivery_dates[line.date_planned] = [line]
+        # Process each group of lines
+        for lines in delivery_dates.itervalues():
+            picking_ids.extend(
+                super(PurchaseOrder, self)._create_pickings(
+                    cr, uid, order, lines, picking_id=picking_id,
+                    context=context))
+        return picking_ids

--- a/purchase_delivery_split_date/purchase.py
+++ b/purchase_delivery_split_date/purchase.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014-2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging
 from itertools import groupby

--- a/purchase_delivery_split_date/tests/__init__.py
+++ b/purchase_delivery_split_date/tests/__init__.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
+# © 2015-2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from purchase_delivery_split_date.tests import test_purchase_delivery

--- a/purchase_delivery_split_date/tests/__init__.py
+++ b/purchase_delivery_split_date/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from purchase_delivery_split_date.tests import test_purchase_delivery

--- a/purchase_delivery_split_date/tests/test_purchase_delivery.py
+++ b/purchase_delivery_split_date/tests/test_purchase_delivery.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tests.common import TransactionCase
+
+
+class TestDeliverySingle(TransactionCase):
+
+    def setUp(self):
+        super(TestDeliverySingle, self).setUp()
+        # Products
+        p1 = self.env.ref('product.product_product_15')
+        p2 = self.env.ref('product.product_product_25')
+
+        # 2 dates we can use to test the features
+        self.date_sooner = '2015-01-01'
+        self.date_later = '2015-12-13'
+
+        self.po = self.env['purchase.order'].create({
+            'partner_id': self.ref('base.res_partner_3'),
+            'location_id': self.ref('stock.stock_location_stock'),
+            'pricelist_id': self.ref('purchase.list0'),
+            'order_line': [
+                (0, 0, {'product_id': p1.id,
+                        'name': p1.name,
+                        'price_unit': p1.standard_price,
+                        'date_planned': self.date_sooner,
+                        'product_qty': 42.0}),
+                (0, 0, {'product_id': p2.id,
+                        'name': p2.name,
+                        'price_unit': p2.standard_price,
+                        'date_planned': self.date_sooner,
+                        'product_qty': 12.0}),
+                (0, 0, {'product_id': p1.id,
+                        'name': p1.name,
+                        'price_unit': p1.standard_price,
+                        'date_planned': self.date_sooner,
+                        'product_qty': 1.0})]})
+
+    def test_check_single_date(self):
+        self.assertEquals(
+            len(self.po.picking_ids), 0,
+            "There must not be pickings for the PO when draft")
+
+        self.po.signal_workflow('purchase_confirm')
+        self.assertEquals(
+            len(self.po.picking_ids), 1,
+            "There must be 1 picking for the PO when confirmed")
+        self.assertEquals(
+            self.po.picking_ids[0].min_date[:10], self.date_sooner,
+            "The picking must be planned at the expected date")
+
+    def test_check_multiple_dates(self):
+        # Change the date of the first line
+        self.po.order_line[0].date_planned = self.date_later
+
+        self.assertEquals(
+            len(self.po.picking_ids), 0,
+            "There must not be pickings for the PO when draft")
+
+        self.po.signal_workflow('purchase_confirm')
+        self.assertEquals(
+            len(self.po.picking_ids), 2,
+            "There must be 2 pickings for the PO when confirmed")
+
+        sorted_pickings = sorted(self.po.picking_ids, key=lambda x: x.min_date)
+        self.assertEquals(
+            sorted_pickings[0].min_date[:10], self.date_sooner,
+            "The first picking must be planned at the soonest date")
+        self.assertEquals(
+            sorted_pickings[1].min_date[:10], self.date_later,
+            "The second picking must be planned at the latest date")

--- a/purchase_delivery_split_date/tests/test_purchase_delivery.py
+++ b/purchase_delivery_split_date/tests/test_purchase_delivery.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014-2016 Numérigraphe SARL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp.tests.common import TransactionCase
 


### PR DESCRIPTION
New module which creates one reception picking for each expected date on the purchase order.
This way stock workers have a clear view of which goods should be received when.

This modules uses the modular design of purchase orders to create several pickings rather that a single one: to the best of my knowledge, this should be compatible with the other modules in this branch.

Proposed here for v8 with the same features as were proposed for v7 earlier: #40
Now comes with a unittest as demanded in https://github.com/OCA/purchase-workflow/pull/40#issuecomment-60617312.
