### PR TITLE
[8.0] Fixes on purchase_partial_invoicing

### DIFF
--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -56,7 +56,8 @@ class PurchaseOrderLine(models.Model):
 
     cancelled_qty = fields.Float(
         string='Cancelled Quantity',
-        digits_compute=dp.get_precision('Product Unit of Measure'))
+        digits_compute=dp.get_precision('Product Unit of Measure'),
+        copy=False)
 
     fully_invoiced = fields.Boolean(
         compute='_compute_fully_invoiced', copy=False, store=True)

--- a/purchase_partial_invoicing/wizard/po_line_cancel_quantity.py
+++ b/purchase_partial_invoicing/wizard/po_line_cancel_quantity.py
@@ -18,7 +18,7 @@
 #
 ##############################################################################
 
-from openerp import models, fields, api, exceptions, _
+from openerp import models, fields, api, exceptions, _, workflow
 import openerp.addons.decimal_precision as dp
 
 
@@ -61,6 +61,8 @@ class PurchaseLineCancelQuantity(models.TransientModel):
                     _("""Quantity to cancel is greater
                     than quantity already cancelled"""))
             line.po_line_id.cancelled_qty += line.cancelled_qty
+            workflow.trg_write(self._uid, 'purchase.order',
+                               line.po_line_id.order_id.id, self._cr)
 
 
 class PurchaseLineCancelQuantityLine(models.TransientModel):


### PR DESCRIPTION
- Avoid to copy cancelled_qty field
- Trigger purchase order workflow when when there is a quantity cancellation
