### PR TITLE
[ADD] add module to request procurement from sale

### DIFF
--- a/sale_to_purchase_order/README.rst
+++ b/sale_to_purchase_order/README.rst
@@ -1,0 +1,53 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Sale to purchase order
+======================
+
+This module adds a wizard on the confirmation of sale order to request procurements for product in the sale order.
+
+Installation
+============
+
+To install this module, you need to:
+
+* Click on install button
+
+Usage
+=====
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/sale-workflow/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/sale-workflow/issues/new?body=module:%20sale_to_purchase_order%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Laetitia Gangloff <laetitia.gangloff@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_to_purchase_order/__init__.py
+++ b/sale_to_purchase_order/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/sale_to_purchase_order/__openerp__.py
+++ b/sale_to_purchase_order/__openerp__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Authors: Laetitia Gangloff
+#    Copyright (c) 2015 Acsone SA/NV (http://www.acsone.eu)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Sale to purchase order",
+    "version": "0.1",
+    'author': "Acsone, Odoo Community Association (OCA)",
+    "category": "Other",
+    "website": "http://www.acsone.eu",
+    "depends": ["sale",
+                "purchase",
+                "procurement_batch_generator",
+                ],
+    "data": ["views/sale_order_views.xml",
+             ],
+    "license": "AGPL-3",
+    "installable": True,
+    "application": False,
+}

--- a/sale_to_purchase_order/models/__init__.py
+++ b/sale_to_purchase_order/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import procurement_batch_generator

--- a/sale_to_purchase_order/models/procurement_batch_generator.py
+++ b/sale_to_purchase_order/models/procurement_batch_generator.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Authors: Laetitia Gangloff
+#    Copyright (c) 2015 Acsone SA/NV (http://www.acsone.eu)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+from openerp import api, fields, models
+
+
+class ProcurementBatchGenerator(models.TransientModel):
+    _inherit = 'procurement.batch.generator'
+
+    @api.model
+    def _is_product_to_add(self, order_line):
+        """ You can add rules to determine if the product of the order line
+        should be in the default line
+        """
+        return True
+
+    @api.model
+    def _get_order_line(self, sale_order):
+        """ Take order line with product to initialize procurement line
+        """
+        res = []
+        for line in sale_order.order_line:
+            if line.product_id:
+                if self._is_product_to_add(line):
+                    res.append(line)
+        return res
+
+    @api.model
+    def _default_lines(self):
+        """ If active model is sale order
+            create procurement for product in sale order line
+        """
+        if self.env.context['active_model'] != 'sale.order':
+            return super(ProcurementBatchGenerator, self)._default_lines()
+
+        res = []
+        sale_obj = self.env['sale.order']
+        sale_order = sale_obj.browse(self.env.context['active_id'])
+        warehouse_id = sale_order.warehouse_id.id
+        today = fields.Date.context_today(self)
+        for line in self._get_order_line(sale_order):
+            res.append({
+                'product_id': line.product_id.id,
+                'partner_id': line.product_id.seller_id.id or False,
+                'qty_available': line.product_id.qty_available,
+                'outgoing_qty': line.product_id.outgoing_qty,
+                'incoming_qty': line.product_id.incoming_qty,
+                'uom_id': line.product_uom.id,
+                'procurement_qty': line.product_uom_qty,
+                'warehouse_id': warehouse_id,
+                'date_planned': today,
+            })
+        return res
+
+    line_ids = fields.One2many(default=_default_lines)
+
+    @api.multi
+    def validate(self):
+        """ When validate the wizard, validate sale order if valid_so is in
+        the context
+        """
+        res = super(ProcurementBatchGenerator, self).validate()
+        if self.env.context.get('valid_so'):
+            # confirm the sale order
+            sale_obj = self.env['sale.order']
+            sale_order = sale_obj.browse(self.env.context['active_id'])
+            sale_order.action_button_confirm()
+        return res

--- a/sale_to_purchase_order/tests/__init__.py
+++ b/sale_to_purchase_order/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_sale_to_purchase_order

--- a/sale_to_purchase_order/tests/test_sale_to_purchase_order.py
+++ b/sale_to_purchase_order/tests/test_sale_to_purchase_order.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Authors: Laetitia Gangloff
+#    Copyright (c) 2015 Acsone SA/NV (http://www.acsone.eu)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import openerp.tests.common as common
+
+
+class TestSaleToPurchaseOrder(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleToPurchaseOrder, self).setUp()
+
+    def test_procurement(self):
+        """ Create sale order :
+                * product.product_product_36
+            Confirm sale order
+            Check there is no po for the product_product_36
+            Create sale order :
+                * product.product_product_36
+            Confirm and reorder sale order
+            Check there is a po for the product_product_36
+        """
+
+        po_line_obj = self.env['purchase.order.line']
+        po_line = po_line_obj.search(
+            [('product_id', '=',
+              self.env.ref('product.product_product_36').id)])
+        po_line.order_id.signal_workflow("purchase_confirm")
+
+        so1 = self.env['sale.order'].create(
+            {'partner_id': self.env.ref('base.res_partner_3').id})
+        self.env['sale.order.line'].create(
+            {'order_id': so1.id,
+             'product_id': self.env.ref('product.product_product_36').id})
+        so1.action_button_confirm()
+        po_line = po_line_obj.search(
+            [('product_id', '=',
+              self.env.ref('product.product_product_36').id),
+             ('state', '=', 'draft')])
+        self.assertEqual(0, len(po_line))
+        self.assertEqual('manual', so1.state)
+
+        so2 = self.env['sale.order'].create(
+            {'partner_id': self.env.ref('base.res_partner_3').id})
+        self.env['sale.order.line'].create(
+            {'order_id': so2.id,
+             'product_id': self.env.ref('product.product_product_36').id})
+        proc_batch_gen_obj = self.env['procurement.batch.generator']
+        proc_batch_gen = proc_batch_gen_obj.with_context(
+            active_model='sale.order', active_id=so2.id,
+            valid_so=True).create({})
+        proc_batch_gen.validate()
+        po_line = po_line_obj.search(
+            [('product_id', '=',
+              self.env.ref('product.product_product_36').id),
+             ('state', '=', 'draft')])
+        self.assertEqual(1, len(po_line))
+        self.assertEqual('manual', so2.state)

--- a/sale_to_purchase_order/views/sale_order_views.xml
+++ b/sale_to_purchase_order/views/sale_order_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="procurement_batch_generator_action" model="ir.actions.act_window">
+            <field name="name">Request Procurements</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">procurement.batch.generator</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="context">{'valid_so': True}</field>
+        </record>
+
+        <record id="sale_order_view_form_inherit_sale_to_purchase_order" model="ir.ui.view">
+            <field name="name">sale.order.form (sale_to_purchase_order)</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="arch" type="xml">
+                <data>
+                    <button name="action_view_invoice" position="before">
+                        <button name="%(procurement_batch_generator_action)d" states="draft" string="Confirm and reorder" type="action" groups="base.group_user"/>
+                        <button name="%(procurement_batch_generator_action)d" states="sent" string="Confirm and reorder" class="oe_highlight" type="action" groups="base.group_user"/>
+                    </button>
+                </data>
+           </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
On sale order, at confirmation, it is possible to request procurement at the same time.

It is based on the wizard introduced in the module procurement_batch_generator.
