### PR TITLE
7.0 purchase request

### DIFF
--- a/purchase_request/__init__.py
+++ b/purchase_request/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import models

--- a/purchase_request/__openerp__.py
+++ b/purchase_request/__openerp__.py
@@ -112,6 +112,7 @@ To contribute to this module, please visit http://odoo-community.org.
         "security/purchase_request.xml",
         "security/ir.model.access.csv",
         "data/purchase_request_sequence.xml",
+        "data/purchase_request_data.xml",
         "views/purchase_request_view.xml",
     ],
     'demo_xml': [

--- a/purchase_request/__openerp__.py
+++ b/purchase_request/__openerp__.py
@@ -29,6 +29,83 @@
     "description": """
 Purchase Request
 ================
+You use this module if you wish to give notification of requirements of
+materials and/or external services and keep track of such requirements.
+
+Requests can be created either directly or indirectly. "Directly" means that
+someone from the requesting department enters a purchase request manually.
+
+The person creating the requisition determines what and how much to order,
+and the requested date.
+
+"Indirectly" means that the purchase request initiated by the application
+automatically, for example, from procurement orders.
+
+A purchase request is an instruction to Purchasing to procure a certain
+quantity of materials services, so that they are is available at a
+certain point in time.
+
+A line of a requisition contains the quantity and requested date of the
+material to be supplied or the quantity of the service to be performed. You
+can indicate the service specifications if needed.
+
+
+Installation
+============
+
+No specific instructions required.
+
+
+Configuration
+=============
+
+No specific instructions requied.
+
+Usage
+=====
+Purchase requests are accessible though a new menu entry 'Purchase
+Requests', and also from the 'Purchase' menu.
+
+Users can access to the list of Purchase Requests or Purchase Request Lines.
+
+It is possible to filter requests by it's approval status.
+
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+
+Known issues / Roadmap
+======================
+
+No issues have been identified
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+
     """,
     "init_xml": [],
     "update_xml": [
@@ -40,7 +117,11 @@ Purchase Request
     'demo_xml': [
         "demo/purchase_request_demo.xml",
     ],
-    'test': [],
+    'test': [
+        "test/purchase_request_users.yml",
+        "test/purchase_request_data.yml",
+        "test/purchase_request_status.yml"
+    ],
     'installable': True,
     'active': False,
     'certificate': '',

--- a/purchase_request/__openerp__.py
+++ b/purchase_request/__openerp__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Purchase Request",
+    "version": "1.0",
+    "author": "Eficent",
+    "website": "www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["purchase", "product"],
+    "description": """
+Purchase Request
+================
+    """,
+    "init_xml": [],
+    "update_xml": [
+        "security/purchase_request.xml",
+        "security/ir.model.access.csv",
+        "data/purchase_request_sequence.xml",
+        "views/purchase_request_view.xml",
+    ],
+    'demo_xml': [
+        "demo/purchase_request_demo.xml",
+    ],
+    'test': [],
+    'installable': True,
+    'active': False,
+    'certificate': '',
+}

--- a/purchase_request/__openerp__.py
+++ b/purchase_request/__openerp__.py
@@ -42,8 +42,8 @@ and the requested date.
 automatically, for example, from procurement orders.
 
 A purchase request is an instruction to Purchasing to procure a certain
-quantity of materials services, so that they are is available at a
-certain point in time.
+quantity of materials services, so that they are available at a certain
+point in time.
 
 A line of a requisition contains the quantity and requested date of the
 material to be supplied or the quantity of the service to be performed. You

--- a/purchase_request/data/purchase_request_data.xml
+++ b/purchase_request/data/purchase_request_data.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+
+    <data>
+        <!-- Request-related subtypes for messaging / Chatter -->
+        <record id="mt_request_to_approve" model="mail.message.subtype">
+            <field name="name">Purchase Request to be approved</field>
+            <field name="res_model">purchase.request</field>
+            <field name="default" eval="True"/>
+            <field name="description">Purchase Request to be approved</field>
+        </record>
+
+        <record id="mt_request_approved" model="mail.message.subtype">
+            <field name="name">Purchase Request approved</field>
+            <field name="res_model">purchase.request</field>
+            <field name="default" eval="True"/>
+            <field name="description">Purchase Request approved</field>
+        </record>
+
+        <record id="mt_request_rejected" model="mail.message.subtype">
+            <field name="name">Purchase Request rejected</field>
+            <field name="res_model">purchase.request</field>
+            <field name="default" eval="True"/>
+            <field name="description">Purchase Request Rejected</field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_request/data/purchase_request_sequence.xml
+++ b/purchase_request/data/purchase_request_sequence.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+        <!-- Sequences for purchase.order --> 
+        <record id="seq_type_purchase_request" model="ir.sequence.type">
+            <field name="name">Purchase Request</field>
+            <field name="code">purchase.request</field>
+        </record>
+        <record id="seq_purchase_request" model="ir.sequence">
+            <field name="name">Purchase Request</field>
+            <field name="code">purchase.request</field>
+            <field name="prefix">PR</field>
+            <field name="padding">5</field>
+        </record>
+    </data>
+</openerp>

--- a/purchase_request/demo/purchase_request_demo.xml
+++ b/purchase_request/demo/purchase_request_demo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="base.user_demo" model="res.users">
+            <field eval="[(4, ref('group_purchase_request_user'))]"
+                   name="groups_id"/>
+        </record>
+
+        <record id="product.product_product_13" model="product.product">
+            <field name="purchase_request" eval="True"/>
+        </record>
+
+        <record id="request1" model="purchase.request">
+            <field name="user_id" ref="base.user_root"/>
+            <field name="date_start" eval="time.strftime('%Y/%m/%d')"/>
+        </record>
+
+        <record id="request_line1" model="purchase.request.line">
+            <field name="request_id" ref="request1"/>
+            <field name="product_id" ref="product.product_product_13"/>
+            <field name="product_uom_id" ref="product.product_uom_unit"/>
+            <field name="product_qty">5</field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_request/demo/purchase_request_demo.xml
+++ b/purchase_request/demo/purchase_request_demo.xml
@@ -1,26 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-    <data noupdate="1">
+    <data noupdate="0">
 
         <record id="base.user_demo" model="res.users">
             <field eval="[(4, ref('group_purchase_request_user'))]"
                    name="groups_id"/>
-        </record>
-
-        <record id="product.product_product_13" model="product.product">
-            <field name="purchase_request" eval="True"/>
-        </record>
-
-        <record id="request1" model="purchase.request">
-            <field name="user_id" ref="base.user_root"/>
-            <field name="date_start" eval="time.strftime('%Y/%m/%d')"/>
-        </record>
-
-        <record id="request_line1" model="purchase.request.line">
-            <field name="request_id" ref="request1"/>
-            <field name="product_id" ref="product.product_product_13"/>
-            <field name="product_uom_id" ref="product.product_uom_unit"/>
-            <field name="product_qty">5</field>
         </record>
 
     </data>

--- a/purchase_request/models/__init__.py
+++ b/purchase_request/models/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import purchase_request

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -155,6 +155,15 @@ class PurchaseRequestLine(orm.Model):
                 res[line.id] = False
         return res
 
+    def _get_supplier(self, cr, uid, ids, names, arg, context=None):
+        res = dict.fromkeys(ids, False)
+        for line in self.browse(cr, uid, ids, context=context):
+            if line.product_id:
+                for product_supplier in line.product_id.seller_ids:
+                    res[line.id] = product_supplier.name.id
+                    break
+        return res
+
     _columns = {
         'product_id': fields.many2one(
             'product.product', 'Product',
@@ -222,7 +231,12 @@ class PurchaseRequestLine(orm.Model):
                                         readonly=True,
                                         type="selection",
                                         selection=_STATES,
-                                        store=True)
+                                        store=True),
+        'supplier_id': fields.function(_get_supplier,
+                                       string="Preferred supplier",
+                                       type="many2one",
+                                       relation="res.partner",
+                                       readonly=True),
     }
 
     _defaults = {

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -216,7 +216,13 @@ class PurchaseRequestLine(orm.Model):
         'is_editable': fields.function(_get_is_editable,
                                        string="Is editable",
                                        type="boolean"),
-        'specifications': fields.text('Specifications')
+        'specifications': fields.text('Specifications'),
+        'request_state': fields.related('request_id', 'state',
+                                        string="Request state",
+                                        readonly=True,
+                                        type="selection",
+                                        selection=_STATES,
+                                        store=True)
     }
 
     _defaults = {

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -231,7 +231,7 @@ class PurchaseRequestLine(orm.Model):
                                         readonly=True,
                                         type="selection",
                                         selection=_STATES,
-                                        store=True),
+                                        store={}),
         'supplier_id': fields.function(_get_supplier,
                                        string="Preferred supplier",
                                        type="many2one",

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -70,6 +70,15 @@ class PurchaseRequest(orm.Model):
                                   track_visibility='onchange'),
     }
 
+    def _get_default_warehouse(self, cr, uid, context=None):
+        warehouse_obj = self.pool['stock.warehouse']
+        company_id = self.pool.get('res.users').browse(
+            cr, uid, uid).company_id.id
+        warehouse_ids = warehouse_obj.search(
+            cr, uid, [('company_id', '=', company_id)], context=context)
+        warehouse_id = warehouse_ids and warehouse_ids[0] or False
+        return warehouse_id
+
     _defaults = {
         'date_start': lambda *args: time.strftime('%Y-%m-%d %H:%M:%S'),
         'company_id':
@@ -84,6 +93,8 @@ class PurchaseRequest(orm.Model):
             obj.pool.get('ir.sequence').get(
                 cr, uid, 'purchase.request'),
         'state': 'draft',
+        'is_editable': True,
+        'warehouse_id': _get_default_warehouse,
     }
 
     def copy(self, cr, uid, id, default=None, context=None):
@@ -211,6 +222,7 @@ class PurchaseRequestLine(orm.Model):
     _defaults = {
         'date_required': lambda *args: time.strftime('%Y-%m-%d %H:%M:%S'),
         'name': '',
+        'is_editable': True,
     }
 
     def onchange_product_id(self, cr, uid, ids, product_id,

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, orm
+import time
+import openerp.addons.decimal_precision as dp
+
+
+class PurchaseRequest(orm.Model):
+
+    _name = 'purchase.request'
+    _description = 'Purchase Request'
+    _inherit = ['mail.thread', 'ir.needaction_mixin']
+    _columns = {
+        'name': fields.char('Request Reference', size=32, required=True),
+        'origin': fields.char('Source Document', size=32),
+        'created_on': fields.date('Created on',
+                                  help="Date that the request was created."),
+        'date_start': fields.date('Creation date',
+                                  help="Date when the user initiated the "
+                                       "request."),
+        'requested_by': fields.many2one('res.users',
+                                        'Requested by',
+                                        required=True,
+                                        track_visibility='onchange'),
+        'assigned_to': fields.many2one('res.users', 'Assigned to',
+                                       track_visibility='onchange'),
+        'description': fields.text('Description'),
+        'company_id': fields.many2one('res.company', 'Company', required=True),
+        'line_ids': fields.one2many('purchase.request.line', 'request_id',
+                                    'Products to Purchase',
+                                    readonly=False),
+        'warehouse_id': fields.many2one('stock.warehouse', 'Warehouse',
+                                        track_visibility='onchange'),
+    }
+
+    _defaults = {
+        'date_start': lambda *args: time.strftime('%Y-%m-%d %H:%M:%S'),
+        'company_id':
+            lambda self, cr, uid, c:
+            self.pool.get('res.company')._company_default_get(
+                cr, uid, 'purchase.request', context=c),
+        'requested_by':
+            lambda self, cr, uid, c:
+            self.pool.get('res.users').browse(cr, uid, uid, c).id,
+        'name':
+            lambda obj, cr, uid, context:
+            obj.pool.get('ir.sequence').get(
+                cr, uid, 'purchase.request'),
+    }
+
+    def copy(self, cr, uid, id, default=None, context=None):
+        if not default:
+            default = {}
+        default.update({
+            'name': self.pool.get('ir.sequence').get(cr, uid,
+                                                     'purchase.request'),
+        })
+        return super(PurchaseRequest, self).copy(
+            cr, uid, id, default, context)
+
+    def create(self, cr, uid, vals, context=None):
+        if vals.get('assigned_to'):
+            assigned_to = self.pool.get('res.users').browse(
+                cr, uid, vals.get('assigned_to'), context=context)
+            vals['message_follower_ids'] = [(4, assigned_to.partner_id.id)]
+        return super(PurchaseRequest, self).create(cr, uid, vals,
+                                                   context=context)
+
+    def write(self, cr, uid, ids, vals, context=None):
+        if vals.get('assigned_to'):
+            assigned_to = self.pool.get('res.users').browse(
+                cr, uid, vals.get('assigned_to'), context=context)
+            vals['message_follower_ids'] = [(4, assigned_to.partner_id.id)]
+        res = super(PurchaseRequest, self).write(cr, uid, ids, vals,
+                                                 context=context)
+        return res
+
+
+class PurchaseRequestLine(orm.Model):
+
+    _name = "purchase.request.line"
+    _description = "Purchase Request Line"
+    _inherit = ['mail.thread', 'ir.needaction_mixin']
+    _rec_name = 'product_id'
+
+    _columns = {
+        'product_id': fields.many2one(
+            'product.product', 'Product',
+            domain=[('purchase_ok', '=', True)]),
+        'name': fields.char('Description', size=256, required=True,
+                            track_visibility='onchange'),
+        'product_uom_id': fields.many2one(
+            'product.uom', 'Product Unit of Measure',
+            track_visibility='onchange'),
+        'product_qty': fields.float(
+            'Quantity',
+            digits_compute=dp.get_precision('Product Unit of Measure'),
+            track_visibility='onchange'),
+        'request_id': fields.many2one('purchase.request',
+                                      'Purchase Request',
+                                      ondelete='cascade', readonly=True),
+        'company_id': fields.related('request_id', 'company_id',
+                                     type='many2one',
+                                     relation='res.company',
+                                     string='Company',
+                                     store=True, readonly=True),
+        'analytic_account_id': fields.many2one(
+            'account.analytic.account', 'Analytic Account',
+            track_visibility='onchange'),
+        'requested_by': fields.related('request_id', 'requested_by',
+                                       string='Requested by',
+                                       readonly=True,
+                                       type="many2one",
+                                       relation="res.users",
+                                       store=True),
+        'assigned_to': fields.related('request_id', 'assigned_to',
+                                      string='Assigned to',
+                                      readonly=True,
+                                      type="many2one",
+                                      relation="res.users",
+                                      store=True),
+        'date_start': fields.related('request_id', 'date_start',
+                                     string='Request Date', readonly=True,
+                                     type="date",
+                                     store=True),
+        'description': fields.related('request_id', 'description',
+                                      string='Description', readonly=True,
+                                      type="text"),
+        'origin': fields.related('request_id', 'origin',
+                                 string='Source Document', readonly=True,
+                                 type="char", size=32, store=True),
+        'warehouse_id': fields.related('request_id', 'warehouse_id',
+                                       string='Warehouse',
+                                       readonly=True,
+                                       type="many2one",
+                                       relation="stock.warehouse",
+                                       store=True),
+        'date_required': fields.date('Required date',
+                                     help="Date that the products are "
+                                          "required to be received or "
+                                          "services rendered.",
+                                     required=True,
+                                     track_visibility='onchange'),
+    }
+
+    _defaults = {
+        'date_required': lambda *args: time.strftime('%Y-%m-%d %H:%M:%S'),
+        'name': '',
+    }
+
+    def onchange_product_id(self, cr, uid, ids, product_id,
+                            product_uom_id, context=None):
+        """ Changes UoM and name if product_id changes.
+        @param name: Name of the field
+        @param product_id: Changed product_id
+        @return:  Dictionary of changed values
+        """
+        value = {'product_uom_id': ''}
+        if product_id:
+            product_obj = self.pool['product.product']
+            prod = product_obj.browse(
+                cr, uid, product_id, context=context)
+            product_name = product_obj.name_get(cr, uid, product_id,
+                                                context=context)
+            dummy, name = product_name and product_name[0] or (False,
+                                                               False)
+            if prod.description_purchase:
+                name += '\n' + prod.description_purchase
+
+            value = {'product_uom_id': prod.uom_id.id,
+                     'product_qty': 1.0,
+                     'name': name}
+        return {'value': value}

--- a/purchase_request/security/ir.model.access.csv
+++ b/purchase_request/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_purchase_request_user,purchase.request,model_purchase_request,group_purchase_request_user,1,1,1,1
+access_purchase_request_manager,purchase.request,model_purchase_request,group_purchase_request_manager,1,1,1,1
+access_purchase_request_line_user,purchase.request.line,model_purchase_request_line,group_purchase_request_user,1,1,1,1
+access_purchase_request__line_manager,purchase.request.line,model_purchase_request_line,group_purchase_request_manager,1,1,1,1

--- a/purchase_request/security/ir.model.access.csv
+++ b/purchase_request/security/ir.model.access.csv
@@ -2,4 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_purchase_request_user,purchase.request,model_purchase_request,group_purchase_request_user,1,1,1,1
 access_purchase_request_manager,purchase.request,model_purchase_request,group_purchase_request_manager,1,1,1,1
 access_purchase_request_line_user,purchase.request.line,model_purchase_request_line,group_purchase_request_user,1,1,1,1
-access_purchase_request__line_manager,purchase.request.line,model_purchase_request_line,group_purchase_request_manager,1,1,1,1
+access_purchase_request_line_manager,purchase.request.line,model_purchase_request_line,group_purchase_request_manager,1,1,1,1

--- a/purchase_request/security/purchase_request.xml
+++ b/purchase_request/security/purchase_request.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data noupdate="0">
+
+    <record model="ir.module.category" id="module_category_purchase_request">
+        <field name="name">Purchase Request</field>
+        <field name="parent_id" ref="base.module_category_purchase_management"/>
+        <field name="sequence">10</field>
+    </record>
+
+    <record id="group_purchase_request_user" model="res.groups">
+        <field name="name">Purchase Request User</field>
+        <field name="category_id" ref="module_category_purchase_request"/>
+    </record>
+
+    <record id="group_purchase_request_manager" model="res.groups">
+        <field name="name">Purchase Request Manager</field>
+        <field name="category_id" ref="module_category_purchase_request"/>
+        <field name="implied_ids" eval="[(4, ref('group_purchase_request_user'))]"/>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+    </record>
+
+</data>
+<data noupdate="1">
+
+    <record model="ir.rule" id="purchase_request_comp_rule">
+        <field name="name">Purchase Request multi-company</field>
+        <field name="model_id" ref="model_purchase_request"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">['|',('company_id','=',False),
+            ('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+
+    <record model="ir.rule" id="purchase_request_line_comp_rule">
+        <field name="name">Purchase Request Line multi-company</field>
+        <field name="model_id" ref="model_purchase_request_line"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">['|',('company_id','=',False),
+            ('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+
+
+
+    <record id="purchase_request_followers_rule" model="ir.rule">
+        <field name="name">Follow Purchase Request</field>
+        <field name="model_id" ref="model_purchase_request"/>
+        <field name="groups" eval="[(6,0, [ref('group_purchase_request_user')])]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+        <field name="domain_force">['|',('requested_by','=',user.id),
+                                        ('message_follower_ids', 'in', [user.partner_id.id])]</field>
+    </record>
+    <record id="purchase_request_modify_rule" model="ir.rule">
+        <field name="name">Modify Purchase Request</field>
+        <field name="model_id" ref="model_purchase_request"/>
+        <field name="groups" eval="[(6,0, [ref('group_purchase_request_user')])]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+        <field name="domain_force">[('requested_by','=',user.id)]</field>
+    </record>
+
+    <record id="purchase_request_line_followers_rule" model="ir.rule">
+        <field name="name">Follow Purchase Request Line</field>
+        <field name="model_id" ref="model_purchase_request_line"/>
+        <field name="groups" eval="[(6,0, [ref('group_purchase_request_user')])]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+        <field name="domain_force">['|',('requested_by','=',user.id),
+                                        ('message_follower_ids', 'in', [user.partner_id.id])]</field>
+    </record>
+
+    <record id="purchase_request_line_modify_rule" model="ir.rule">
+        <field name="name">Modify Purchase Request Line</field>
+        <field name="model_id" ref="model_purchase_request_line"/>
+        <field name="groups" eval="[(6,0, [ref('group_purchase_request_user')])]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+        <field name="domain_force">[('requested_by','=',user.id)]</field>
+    </record>
+
+</data>
+</openerp>

--- a/purchase_request/security/purchase_request.xml
+++ b/purchase_request/security/purchase_request.xml
@@ -10,18 +10,18 @@
 
     <record id="group_purchase_request_user" model="res.groups">
         <field name="name">Purchase Request User</field>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="category_id" ref="module_category_purchase_request"/>
     </record>
 
     <record id="group_purchase_request_manager" model="res.groups">
         <field name="name">Purchase Request Manager</field>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="category_id" ref="module_category_purchase_request"/>
-        <field name="implied_ids" eval="[(4, ref('group_purchase_request_user'))]"/>
-        <field name="users" eval="[(4, ref('base.user_root'))]"/>
     </record>
 
 </data>
-<data noupdate="1">
+<data noupdate="0">
 
     <record model="ir.rule" id="purchase_request_comp_rule">
         <field name="name">Purchase Request multi-company</field>
@@ -38,8 +38,6 @@
         <field name="domain_force">['|',('company_id','=',False),
             ('company_id','child_of',[user.company_id.id])]</field>
     </record>
-
-
 
     <record id="purchase_request_followers_rule" model="ir.rule">
         <field name="name">Follow Purchase Request</field>

--- a/purchase_request/security/purchase_request.xml
+++ b/purchase_request/security/purchase_request.xml
@@ -69,8 +69,8 @@
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
-        <field name="domain_force">['|',('requested_by','=',user.id),
-                                        ('message_follower_ids', 'in', [user.partner_id.id])]</field>
+        <field name="domain_force">['|',('request_id.requested_by','=',user.id),
+                                        ('request_id.message_follower_ids', 'in', [user.partner_id.id])]</field>
     </record>
 
     <record id="purchase_request_line_modify_rule" model="ir.rule">
@@ -81,7 +81,7 @@
         <field name="perm_write" eval="True"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_unlink" eval="True"/>
-        <field name="domain_force">[('requested_by','=',user.id)]</field>
+        <field name="domain_force">[('request_id.requested_by','=',user.id)]</field>
     </record>
 
 </data>

--- a/purchase_request/test/purchase_request_data.yml
+++ b/purchase_request/test/purchase_request_data.yml
@@ -1,0 +1,15 @@
+-
+  I log as the Purchase Request User
+-
+  !context
+    uid: 'res_users_purchase_request_user'
+-
+  !record {model: purchase.request, id: request1}:
+    warehouse_id: stock.stock_warehouse_shop0
+    requested_by: res_users_purchase_request_user
+-
+  !record {model: purchase.request.line, id: request_line1}:
+    request_id: request1
+    product_id: product.product_product_13
+    product_uom_id: product.product_uom_unit
+    product_qty: 5.0

--- a/purchase_request/test/purchase_request_status.yml
+++ b/purchase_request/test/purchase_request_status.yml
@@ -1,0 +1,40 @@
+-
+  I log as the Purchase Request User
+-
+  !context
+    uid: 'res_users_purchase_request_user'
+-
+  I request approval of a purchase request.
+-
+  !python {model: purchase.request}: |
+    self.button_to_approve(cr, uid, [ref("request1")])
+-
+  I check the status of the request
+-
+  !assert {model: purchase.request, id: request1}:
+    - state == 'to_approve'
+-
+  I log as the Purchase Request Manager
+-
+  !context
+    uid: 'res_users_purchase_request_manager'
+-
+  I reset the request as "Draft".
+-
+  !python {model: purchase.request}: |
+    self.button_draft(cr, uid, [ref('request1')])
+-
+  I check the status of the request
+-
+  !assert {model: purchase.request, id: request1}:
+    - state == 'draft'
+-
+  I duplicate request.
+-
+  !python {model: purchase.request}: |
+    self.copy(cr, uid, ref('request1'))
+-
+  I delete request.
+-
+  !python {model: purchase.request}: |
+    self.unlink(cr, uid, [ref("request1")])

--- a/purchase_request/test/purchase_request_users.yml
+++ b/purchase_request/test/purchase_request_users.yml
@@ -1,0 +1,30 @@
+-
+   Create a user as 'Purchase Request Manager'
+-
+  !record {model: res.users, id: res_users_purchase_request_manager}:
+    company_id: base.main_company
+    name: Purchase Request Manager
+    login: prm
+    password: prm
+    email: purchase_request_manager@yourcompany.com
+-
+  I added groups for Purchase Request Manager.
+-
+  !record {model: res.users, id: res_users_purchase_request_manager}:
+    groups_id:
+      - group_purchase_request_manager
+-
+   Create a user as 'Purchase Request User'
+-
+  !record {model: res.users, id: res_users_purchase_request_user}:
+    company_id: base.main_company
+    name: Purchase Request User
+    login: pru
+    password: pru
+    email: purchase_request_user@yourcompany.com
+-
+  I added groups for Purchase Request User
+-
+  !record {model: res.users, id: res_users_purchase_request_user}:
+    groups_id:
+      - group_purchase_request_user

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -324,6 +324,7 @@
                 <field name="assigned_to"/>
                 <field name="date_start"/>
                 <field name="date_required"/>
+                <field name="analytic_account_id"/>
                 <filter name="request_state_draft" string="Draft"
                         domain="[('request_state','=','draft')]"
                         help="Request is to be approved"/>
@@ -348,6 +349,9 @@
                     <filter string="Request status"
                             domain="[]"
                             context="{'group_by':'request_state'}"/>
+                    <filter string="Analytic Account"
+                            domain="[]"
+                            context="{'group_by':'analytic_account_id'}"/>
                 </group>
             </search>
         </field>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -183,7 +183,7 @@
                 <group expand="0" string="Group By...">
                     <filter string="Requested by" icon="terp-personal"
                             domain="[]"
-                            context="{'group_by':'assigned_to'}"/>
+                            context="{'group_by':'requested_by'}"/>
                     <filter string="Assigned to" icon="terp-personal"
                             domain="[]"
                             context="{'group_by':'assigned_to'}"/>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -339,6 +339,9 @@
                     <filter string="Assigned to"
                             domain="[]"
                             context="{'group_by':'assigned_to'}"/>
+                    <filter string="Request status"
+                            domain="[]"
+                            context="{'group_by':'request_state'}"/>
                 </group>
             </search>
         </field>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -159,6 +159,12 @@
                 <filter name="unassigned" string="Unassigned"
                         domain="[('assigned_to','=', False)]"
                         help="Unassigned Request"/>
+                <filter name="assigned_to_me" string="Assigned to me"
+                        domain="[('assigned_to','=', uid)]"
+                        help="Requests assigned to me"/>
+                <filter name="requested_by_me" string="Requested by me"
+                        domain="[('requested_by','=', uid)]"
+                        help="Requested by me"/>
                 <filter name="state_draft" string="Draft"
                         domain="[('state','=','draft')]"
                         help="Request is to be approved"/>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -9,29 +9,61 @@
         <field name="model">purchase.request</field>
         <field name="arch" type="xml">
             <form string="Purchase Request" version="7.0">
+            <header>
+                <button name="button_draft"
+                        states="to_approve,approved,rejected"
+                        string="Reset"
+                        type="object"
+                        groups="purchase_request.group_purchase_request_manager"/>
+                <button name="button_to_approve" states="draft"
+                        string="Request approval" type="object"
+                        class="oe_highlight"/>
+                <button name="button_approved"
+                        states="to_approve"
+                        string="Approve"
+                        type="object"
+                        class="oe_highlight"
+                        groups="purchase_request.group_purchase_request_manager"/>
+                <button name="button_rejected"
+                        states="to_approve,approved"
+                        string="Reject"
+                        type="object"
+                        groups="purchase_request.group_purchase_request_manager"/>
+                <field name="state" widget="statusbar"
+                       statusbar_visible="draft,to_approve,approved,rejected"
+                       statusbar_colors='{"approved":"blue"}'/>
+            </header>
             <sheet>
                 <div class="oe_edit_only">
                     <label for="name" class="oe_inline"/>
                     <label for="origin" class="oe_inline"/>
                 </div>
                 <h1>
-                    <field name="name" class="oe_inline"/>
-                    <label string=","
-                           attrs="{'invisible':[('origin','=',False)]}"/>
-                    <field name="origin" class="oe_inline"/>
+                    <field name="is_editable" invisible="1"/>
+                    <field name="name" class="oe_inline"
+                           attrs="{'readonly': [('is_editable','=', False)]}"/>
+                    <label string=","/>
+                    <field name="origin" class="oe_inline"
+                           attrs="{'readonly': [('is_editable','=', False)]}"/>
                 </h1>
                 <group>
                     <group>
-                        <field name="requested_by"/>
-                        <field name="assigned_to"/>
+                        <field name="requested_by"
+                               attrs="{'readonly': [('is_editable','=', False)]}"/>
+                        <field name="assigned_to"
+                               attrs="{'readonly': [('is_editable','=', False)]}"/>
                     </group>
                     <group>
-                        <field name="description"/>
+                        <field name="description"
+                               attrs="{'readonly': [('is_editable','=', False)]}"/>
                     </group>
                     <group>
-                        <field name="date_start"/>
-                        <field name="warehouse_id"/>
-                        <field name="company_id" groups="base.group_multi_company" widget="selection"/>
+                        <field name="date_start"
+                                attrs="{'readonly': [('is_editable','=', False)]}"/>
+                        <field name="warehouse_id"
+                               attrs="{'readonly': [('is_editable','=', False)]}"/>
+                        <field name="company_id" groups="base.group_multi_company" widget="selection"
+                               attrs="{'readonly': [('is_editable','=', False)]}"/>
                     </group>
                 </group>
                 <notebook>
@@ -45,27 +77,43 @@
                                 <field name="analytic_account_id"
                                        groups="purchase.group_analytic_accounting"/>
                                 <field name="date_required"/>
+                                <field name="is_editable" invisible="1"/>
                             </tree>
                             <form>
                                 <sheet>
                                     <group>
                                         <group>
+                                            <field name="is_editable" invisible="1"/>
                                             <field name="product_id"
-                                                   on_change="onchange_product_id(product_id,product_uom_id)"/>
-                                            <field name="name"/>
-                                            <label for="product_qty"/>
+                                                   on_change="onchange_product_id(product_id,product_uom_id)"
+                                                   attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                            <field name="name"
+                                                   attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                            <label for="product_qty"
+                                                   attrs="{'readonly': [('is_editable','=', False)]}"/>
                                             <div>
                                                 <field name="product_qty"
-                                                       class="oe_inline"/>
+                                                       class="oe_inline"
+                                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
                                                 <field name="product_uom_id"
                                                        groups="product.group_uom"
-                                                       class="oe_inline"/>
+                                                       class="oe_inline"
+                                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
                                             </div>
                                             <field name="analytic_account_id"
                                                    groups="purchase.group_analytic_accounting"
-                                                   domain="[('type','not in',('view','template'))]"/>
-                                            <field name="date_required"/>
+                                                   domain="[('type','not in',('view','template'))]"
+                                                   attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                            <field name="date_required"
+                                                   attrs="{'readonly': [('is_editable','=', False)]}"/>
                                         </group>
+                                    </group>
+                                    <group>
+                                        <separator string="Specifications"/>
+                                        <newline/>
+                                        <field name="specifications"
+                                               nolabel="1"
+                                               attrs="{'readonly': [('is_editable','=', False)]}"/>
                                     </group>
                                     <group name="follow_up">
                                     </group>
@@ -95,37 +143,48 @@
                 <field name="requested_by"/>
                 <field name="company_id" groups="base.group_multi_company" widget="selection"/>
                 <field name="origin"/>
-                <field name="warehouse_id"/>
+                <field name="state"/>
             </tree>
       </field>
     </record>
 
-    <record id="view_purchase_request_filter" model="ir.ui.view">
-            <field name="name">purchase.request.list.select</field>
-            <field name="model">purchase.request</field>
-            <field name="arch" type="xml">
-                <search string="Search Purchase Request">
-                    <field name="name" string="Purchase Request"/>
-                    <separator/>
-                    <filter icon="terp-personal-" string="Unassigned"
-                            domain="[('assigned_to','=', False)]"
-                            help="Unassigned Request"/>
-                    <field name="requested_by" />
-                    <field name="assigned_to" />
-                    <field name="warehouse_id"/>
-                    <group expand="0" string="Group By...">
-                        <filter string="Requested by" icon="terp-personal"
-                                domain="[]"
-                                context="{'group_by':'assigned_to'}"/>
-                        <filter string="Assigned to" icon="terp-personal"
-                                domain="[]"
-                                context="{'group_by':'assigned_to'}"/>
-                        <filter string="Source" icon="terp-gtk-jump-to-rtl" domain="[]" context="{'group_by':'origin'}"/>
-                        <filter string="Start Date" icon="terp-go-month" domain="[]" context="{'group_by':'date_start'}"/>
-                    </group>
-                </search>
-            </field>
-        </record>
+    <record id="view_purchase_request_search" model="ir.ui.view">
+        <field name="name">purchase.request.list.select</field>
+        <field name="model">purchase.request</field>
+        <field name="arch" type="xml">
+            <search string="Search Purchase Request">
+                <field name="name" string="Purchase Request"/>
+                <separator/>
+                <field name="state"/>
+                <filter icon="terp-personal-" string="Unassigned"
+                        domain="[('assigned_to','=', False)]"
+                        name="unassigned"
+                        help="Unassigned Request"/>
+                <filter name="approval_to_approve" string="To Approve"
+                        domain="[('approval_state','=','to_approve')]"
+                        help="Request is to be approved"/>
+                <filter name="approval_approved" string="Approved"
+                        domain="[('approval_state','=','approved')]"
+                        help="Request is approved"/>
+                <filter name="approval_rejected" string="Rejected"
+                        domain="[('approval_state','=','rejected')]"
+                        help="Request is rejected"/>
+                <field name="requested_by" />
+                <field name="assigned_to" />
+                <field name="warehouse_id"/>
+                <group expand="0" string="Group By...">
+                    <filter string="Requested by" icon="terp-personal"
+                            domain="[]"
+                            context="{'group_by':'assigned_to'}"/>
+                    <filter string="Assigned to" icon="terp-personal"
+                            domain="[]"
+                            context="{'group_by':'assigned_to'}"/>
+                    <filter string="Source" icon="terp-gtk-jump-to-rtl" domain="[]" context="{'group_by':'origin'}"/>
+                    <filter string="Start Date" icon="terp-go-month" domain="[]" context="{'group_by':'date_start'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
 
 
     <record model="ir.actions.act_window" id="purchase_request_form_action">
@@ -135,7 +194,7 @@
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
         <field name="context">{"search_default_requested_by":uid}</field>
-        <field name="search_view_id" ref="view_purchase_request_filter"/>
+        <field name="search_view_id" ref="view_purchase_request_search"/>
         <field name="help" type="html">
           <p class="oe_view_nocontent_create">
             Click to start a new purchase request process. 
@@ -180,36 +239,59 @@
             <form string="Purchase Request Line" version="7.0">
                 <sheet>
                     <h1>
-                        <field name="request_id"/>
+                        <field name="request_id"
+                               attrs="{'readonly': [('is_editable','=', False)]}"/>
                     </h1>
                     <group>
                         <group>
                             <group>
-                                <field name="origin"/>
-                                <field name="requested_by"/>
-                                <field name="assigned_to"/>
-                                <field name="description"/>
-                                <field name="date_start"/>
-                                <field name="warehouse_id"/>
-                                <field name="company_id" groups="base.group_multi_company" widget="selection"/>
+                                <field name="origin"
+                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                <field name="requested_by"
+                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                <field name="assigned_to"
+                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                <field name="description"
+                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                <field name="date_start"
+                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                <field name="warehouse_id"
+                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                <field name="company_id" groups="base.group_multi_company" widget="selection"
+                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                <field name="is_editable" invisible="1"/>
                             </group>
                         </group>
                         <group>
-                            <field name="name"/>
-                            <field name="product_id"/>
+                            <field name="product_id"
+                                   on_change="onchange_product_id(product_id,product_uom_id)"
+                                   attrs="{'readonly': [('is_editable','=', False)]}"/>
+                            <field name="name"
+                                   attrs="{'readonly': [('is_editable','=', False)]}"/>
                             <label for="product_qty"/>
                             <div>
                                 <field name="product_qty"
-                                       class="oe_inline"/>
+                                       class="oe_inline"
+                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
                                 <field name="product_uom_id"
                                        groups="product.group_uom"
-                                       class="oe_inline"/>
+                                       class="oe_inline"
+                                       attrs="{'readonly': [('is_editable','=', False)]}"/>
                             </div>
                             <field name="analytic_account_id"
                                    groups="purchase.group_analytic_accounting"
-                                   domain="[('type','not in',('view','template'))]"/>
-                            <field name="date_required"/>
+                                   domain="[('type','not in',('view','template'))]"
+                                   attrs="{'readonly': [('is_editable','=', False)]}"/>
+                            <field name="date_required"
+                                   attrs="{'readonly': [('is_editable','=', False)]}"/>
                         </group>
+                    </group>
+                    <group>
+                        <separator string="Specifications"/>
+                        <newline/>
+                        <field name="specifications"
+                               nolabel="1"
+                               attrs="{'readonly': [('is_editable','=', False)]}"/>
                     </group>
                     <group name="follow_up">
                     </group>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -339,9 +339,6 @@
                     <filter string="Assigned to"
                             domain="[]"
                             context="{'group_by':'assigned_to'}"/>
-                    <filter string="Request state"
-                            domain="[]"
-                            context="{'group_by':'request_state'}"/>
                 </group>
             </search>
         </field>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -75,7 +75,7 @@
                                 <field name="product_qty"/>
                                 <field name="product_uom_id" groups="product.group_uom"/>
                                 <field name="analytic_account_id"
-                                       groups="purchase.group_analytic_accounting"/>
+                                       groups="analytic.group_analytic_accounting"/>
                                 <field name="date_required"/>
                                 <field name="is_editable" invisible="1"/>
                             </tree>
@@ -101,7 +101,7 @@
                                                        attrs="{'readonly': [('is_editable','=', False)]}"/>
                                             </div>
                                             <field name="analytic_account_id"
-                                                   groups="purchase.group_analytic_accounting"
+                                                   groups="analytic.group_analytic_accounting"
                                                    domain="[('type','not in',('view','template'))]"
                                                    attrs="{'readonly': [('is_editable','=', False)]}"/>
                                             <field name="date_required"
@@ -156,18 +156,20 @@
                 <field name="name" string="Purchase Request"/>
                 <separator/>
                 <field name="state"/>
-                <filter icon="terp-personal-" string="Unassigned"
+                <filter name="unassigned" string="Unassigned"
                         domain="[('assigned_to','=', False)]"
-                        name="unassigned"
                         help="Unassigned Request"/>
-                <filter name="approval_to_approve" string="To Approve"
-                        domain="[('approval_state','=','to_approve')]"
+                <filter name="state_draft" string="Draft"
+                        domain="[('state','=','draft')]"
                         help="Request is to be approved"/>
-                <filter name="approval_approved" string="Approved"
-                        domain="[('approval_state','=','approved')]"
+                <filter name="state_to_approve" string="To Approve"
+                        domain="[('state','=','to_approve')]"
+                        help="Request is to be approved"/>
+                <filter name="state_approved" string="Approved"
+                        domain="[('state','=','approved')]"
                         help="Request is approved"/>
-                <filter name="approval_rejected" string="Rejected"
-                        domain="[('approval_state','=','rejected')]"
+                <filter name="state_rejected" string="Rejected"
+                        domain="[('state','=','rejected')]"
                         help="Request is rejected"/>
                 <field name="requested_by" />
                 <field name="assigned_to" />
@@ -219,15 +221,16 @@
         <field name="arch" type="xml">
             <tree string="Purchase Request Lines" create="false">
                 <field name="request_id"/>
+                <field name="request_state"/>
                 <field name="requested_by"/>
                 <field name="assigned_to"/>
+                <field name="date_required"/>
                 <field name="product_id"/>
                 <field name="name"/>
                 <field name="product_qty"/>
                 <field name="product_uom_id" groups="product.group_uom"/>
-                <field name="date_required"/>
                 <field name="analytic_account_id"
-                       groups="purchase.group_analytic_accounting"/>
+                       groups="analytic.group_analytic_accounting"/>
             </tree>
         </field>
     </record>
@@ -239,8 +242,8 @@
             <form string="Purchase Request Line" version="7.0">
                 <sheet>
                     <h1>
-                        <field name="request_id"
-                               attrs="{'readonly': [('is_editable','=', False)]}"/>
+                        <field name="request_id"/>
+                        <field name="request_state"/>
                     </h1>
                     <group>
                         <group>
@@ -279,7 +282,7 @@
                                        attrs="{'readonly': [('is_editable','=', False)]}"/>
                             </div>
                             <field name="analytic_account_id"
-                                   groups="purchase.group_analytic_accounting"
+                                   groups="analytic.group_analytic_accounting"
                                    domain="[('type','not in',('view','template'))]"
                                    attrs="{'readonly': [('is_editable','=', False)]}"/>
                             <field name="date_required"
@@ -315,15 +318,30 @@
                 <field name="assigned_to"/>
                 <field name="date_start"/>
                 <field name="date_required"/>
+                <filter name="request_state_draft" string="Draft"
+                        domain="[('request_state','=','draft')]"
+                        help="Request is to be approved"/>
+                <filter name="request_state_to_approve" string="To Approve"
+                        domain="[('request_state','=','to_approve')]"
+                        help="Request is to be approved"/>
+                <filter name="request_state_approved" string="Approved"
+                        domain="[('request_state','=','approved')]"
+                        help="Request is approved"/>
+                <filter name="request_state_rejected" string="Rejected"
+                        domain="[('request_state','=','rejected')]"
+                        help="Request is rejected"/>
                 <group expand="0" string="Group By...">
-                    <filter string="Product" icon="terp-accessories-archiver"
+                    <filter string="Product"
                             domain="[]" context="{'group_by' : 'product_id'}" />
-                    <filter string="Requested by" icon="terp-personal"
+                    <filter string="Requested by"
                             domain="[]"
                             context="{'group_by':'assigned_to'}"/>
-                    <filter string="Assigned to" icon="terp-personal"
+                    <filter string="Assigned to"
                             domain="[]"
                             context="{'group_by':'assigned_to'}"/>
+                    <filter string="Request state"
+                            domain="[]"
+                            context="{'group_by':'request_state'}"/>
                 </group>
             </search>
         </field>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -115,8 +115,8 @@
                                                nolabel="1"
                                                attrs="{'readonly': [('is_editable','=', False)]}"/>
                                     </group>
-                                    <group name="follow_up">
-                                    </group>
+                                    <notebook>
+                                    </notebook>
                                 </sheet>
                             </form>
                         </field>
@@ -201,10 +201,9 @@
           <p class="oe_view_nocontent_create">
             Click to start a new purchase request process. 
           </p><p>
-            A purchase request is the step before a request for quotation.
-            In a purchase request (or purchase tender), you can record the
-            products you need to buy and trigger the creation of RfQs to
-            suppliers.
+            A purchase request is an instruction to Purchasing to procure
+            a certain quantity of materials services, so that they are
+            available at a certain point in time.
           </p>
         </field>
     </record>
@@ -231,6 +230,7 @@
                 <field name="product_uom_id" groups="product.group_uom"/>
                 <field name="analytic_account_id"
                        groups="analytic.group_analytic_accounting"/>
+                <field name="supplier_id"/>
             </tree>
         </field>
     </record>
@@ -296,8 +296,8 @@
                                nolabel="1"
                                attrs="{'readonly': [('is_editable','=', False)]}"/>
                     </group>
-                    <group name="follow_up">
-                    </group>
+                    <notebook>
+                    </notebook>
                 </sheet>
                 <div class="oe_chatter">
                   <field name="message_follower_ids" widget="mail_followers"/>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -1,0 +1,315 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+
+
+    <record model="ir.ui.view" id="view_purchase_request_form">
+        <field name="name">purchase.request.form</field>
+        <field name="model">purchase.request</field>
+        <field name="arch" type="xml">
+            <form string="Purchase Request" version="7.0">
+            <sheet>
+                <div class="oe_edit_only">
+                    <label for="name" class="oe_inline"/>
+                    <label for="origin" class="oe_inline"/>
+                </div>
+                <h1>
+                    <field name="name" class="oe_inline"/>
+                    <label string=","
+                           attrs="{'invisible':[('origin','=',False)]}"/>
+                    <field name="origin" class="oe_inline"/>
+                </h1>
+                <group>
+                    <group>
+                        <field name="requested_by"/>
+                        <field name="assigned_to"/>
+                    </group>
+                    <group>
+                        <field name="description"/>
+                    </group>
+                    <group>
+                        <field name="date_start"/>
+                        <field name="warehouse_id"/>
+                        <field name="company_id" groups="base.group_multi_company" widget="selection"/>
+                    </group>
+                </group>
+                <notebook>
+                    <page string="Products">
+                        <field name="line_ids">
+                            <tree>
+                                <field name="product_id"/>
+                                <field name="name"/>
+                                <field name="product_qty"/>
+                                <field name="product_uom_id" groups="product.group_uom"/>
+                                <field name="analytic_account_id"
+                                       groups="purchase.group_analytic_accounting"/>
+                                <field name="date_required"/>
+                            </tree>
+                            <form>
+                                <sheet>
+                                    <group>
+                                        <group>
+                                            <field name="product_id"
+                                                   on_change="onchange_product_id(product_id,product_uom_id)"/>
+                                            <field name="name"/>
+                                            <label for="product_qty"/>
+                                            <div>
+                                                <field name="product_qty"
+                                                       class="oe_inline"/>
+                                                <field name="product_uom_id"
+                                                       groups="product.group_uom"
+                                                       class="oe_inline"/>
+                                            </div>
+                                            <field name="analytic_account_id"
+                                                   groups="purchase.group_analytic_accounting"
+                                                   domain="[('type','not in',('view','template'))]"/>
+                                            <field name="date_required"/>
+                                        </group>
+                                    </group>
+                                    <group name="follow_up">
+                                    </group>
+                                </sheet>
+                            </form>
+                        </field>
+                    </page>
+                </notebook>
+            </sheet>
+            <div class="oe_chatter">
+              <field name="message_follower_ids" widget="mail_followers"/>
+              <field name="message_ids" widget="mail_thread"/>
+            </div> 
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_purchase_request_tree">
+        <field name="name">purchase.request.tree</field>
+        <field name="model">purchase.request</field>
+        <field name="arch" type="xml">
+            <tree fonts="bold:message_unread==True"
+                  string="Purchase Request">
+                <field name="message_unread" invisible="1"/>
+                <field name="name"/>
+                <field name="date_start"/>
+                <field name="requested_by"/>
+                <field name="company_id" groups="base.group_multi_company" widget="selection"/>
+                <field name="origin"/>
+                <field name="warehouse_id"/>
+            </tree>
+      </field>
+    </record>
+
+    <record id="view_purchase_request_filter" model="ir.ui.view">
+            <field name="name">purchase.request.list.select</field>
+            <field name="model">purchase.request</field>
+            <field name="arch" type="xml">
+                <search string="Search Purchase Request">
+                    <field name="name" string="Purchase Request"/>
+                    <separator/>
+                    <filter icon="terp-personal-" string="Unassigned"
+                            domain="[('assigned_to','=', False)]"
+                            help="Unassigned Request"/>
+                    <field name="requested_by" />
+                    <field name="assigned_to" />
+                    <field name="warehouse_id"/>
+                    <group expand="0" string="Group By...">
+                        <filter string="Requested by" icon="terp-personal"
+                                domain="[]"
+                                context="{'group_by':'assigned_to'}"/>
+                        <filter string="Assigned to" icon="terp-personal"
+                                domain="[]"
+                                context="{'group_by':'assigned_to'}"/>
+                        <filter string="Source" icon="terp-gtk-jump-to-rtl" domain="[]" context="{'group_by':'origin'}"/>
+                        <filter string="Start Date" icon="terp-go-month" domain="[]" context="{'group_by':'date_start'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
+
+    <record model="ir.actions.act_window" id="purchase_request_form_action">
+        <field name="name">Purchase Requests</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">purchase.request</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{"search_default_requested_by":uid}</field>
+        <field name="search_view_id" ref="view_purchase_request_filter"/>
+        <field name="help" type="html">
+          <p class="oe_view_nocontent_create">
+            Click to start a new purchase request process. 
+          </p><p>
+            A purchase request is the step before a request for quotation.
+            In a purchase request (or purchase tender), you can record the
+            products you need to buy and trigger the creation of RfQs to
+            suppliers.
+          </p>
+        </field>
+    </record>
+
+    <menuitem
+        id="menu_purchase_request_pro_mgt"
+        parent="purchase.menu_procurement_management"
+        action="purchase_request_form_action"/>
+
+
+    <record id="purchase_request_line_tree" model="ir.ui.view">
+        <field name="name">purchase.request.line.tree</field>
+        <field name="model">purchase.request.line</field>
+        <field name="arch" type="xml">
+            <tree string="Purchase Request Lines" create="false">
+                <field name="request_id"/>
+                <field name="requested_by"/>
+                <field name="assigned_to"/>
+                <field name="product_id"/>
+                <field name="name"/>
+                <field name="product_qty"/>
+                <field name="product_uom_id" groups="product.group_uom"/>
+                <field name="date_required"/>
+                <field name="analytic_account_id"
+                       groups="purchase.group_analytic_accounting"/>
+            </tree>
+        </field>
+    </record>
+    <record id="purchase_request_line_form" model="ir.ui.view">
+        <field name="name">purchase.request.line.form</field>
+        <field name="model">purchase.request.line</field>
+        <field name="priority" eval="20"/>
+        <field name="arch" type="xml">
+            <form string="Purchase Request Line" version="7.0">
+                <sheet>
+                    <h1>
+                        <field name="request_id"/>
+                    </h1>
+                    <group>
+                        <group>
+                            <group>
+                                <field name="origin"/>
+                                <field name="requested_by"/>
+                                <field name="assigned_to"/>
+                                <field name="description"/>
+                                <field name="date_start"/>
+                                <field name="warehouse_id"/>
+                                <field name="company_id" groups="base.group_multi_company" widget="selection"/>
+                            </group>
+                        </group>
+                        <group>
+                            <field name="name"/>
+                            <field name="product_id"/>
+                            <label for="product_qty"/>
+                            <div>
+                                <field name="product_qty"
+                                       class="oe_inline"/>
+                                <field name="product_uom_id"
+                                       groups="product.group_uom"
+                                       class="oe_inline"/>
+                            </div>
+                            <field name="analytic_account_id"
+                                   groups="purchase.group_analytic_accounting"
+                                   domain="[('type','not in',('view','template'))]"/>
+                            <field name="date_required"/>
+                        </group>
+                    </group>
+                    <group name="follow_up">
+                    </group>
+                </sheet>
+                <div class="oe_chatter">
+                  <field name="message_follower_ids" widget="mail_followers"/>
+                  <field name="message_ids" widget="mail_thread"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <record id="purchase_request_line_search" model="ir.ui.view">
+        <field name="name">purchase.request.line.search</field>
+        <field name="model">purchase.request.line</field>
+        <field name="arch" type="xml">
+            <search string="Search Purchase Request">
+                <field name="request_id"/>
+                <field name="product_id"/>
+                <field name="requested_by"/>
+                <field name="assigned_to"/>
+                <field name="date_start"/>
+                <field name="date_required"/>
+                <group expand="0" string="Group By...">
+                    <filter string="Product" icon="terp-accessories-archiver"
+                            domain="[]" context="{'group_by' : 'product_id'}" />
+                    <filter string="Requested by" icon="terp-personal"
+                            domain="[]"
+                            context="{'group_by':'assigned_to'}"/>
+                    <filter string="Assigned to" icon="terp-personal"
+                            domain="[]"
+                            context="{'group_by':'assigned_to'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <act_window
+        context="{'search_default_product_id': [active_id], 'default_product_id': active_id}"
+        id="action_purchase_request_line_product_tree"
+        name="Purchase Requests"
+        res_model="purchase.request.line"
+        src_model="product.product"
+        groups="group_purchase_request_user,group_purchase_request_manager"/>
+
+    <record id="purchase_request_line_form_action"
+            model="ir.actions.act_window">
+        <field name="name">Purchase Request Lines</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">purchase.request.line</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="purchase_request_line_search"/>
+    </record>
+
+    <record id="purchase_request_line_form_action_tree"
+            model="ir.actions.act_window.view">
+        <field eval="1" name="sequence"/>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="purchase_request_line_tree"/>
+        <field name="act_window_id"
+               ref="purchase_request_line_form_action"/>
+    </record>
+
+    <record id="purchase_request_line_form_action_form2"
+            model="ir.actions.act_window.view">
+        <field eval="2" name="sequence"/>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="purchase_request_line_form"/>
+        <field name="act_window_id" ref="purchase_request_line_form_action"/>
+    </record>
+
+    <menuitem
+        action="purchase_request_line_form_action"
+        id="menu_purchase_request_line"
+        parent="purchase.menu_procurement_management"/>
+
+
+    <menuitem id="parent_menu_purchase_request"
+        name="Purchase requests"
+        groups="group_purchase_request_user,group_purchase_request_manager"
+        />
+
+    <menuitem id="menu_purchase_request"
+        name="Purchase Requests"
+        parent="parent_menu_purchase_request"
+        groups="group_purchase_request_user,group_purchase_request_manager"
+        />
+    <menuitem
+        id="menu_purchase_request_act"
+        sequence="10"
+        parent="menu_purchase_request"
+        action="purchase_request_form_action"
+        />
+    <menuitem
+        id="menu_purchase_request_line_act"
+        sequence="20"
+        parent="menu_purchase_request"
+        action="purchase_request_line_form_action"
+        />
+
+    </data>
+</openerp>

--- a/purchase_request_to_requisition/__init__.py
+++ b/purchase_request_to_requisition/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import models
+from . import wizard

--- a/purchase_request_to_requisition/__openerp__.py
+++ b/purchase_request_to_requisition/__openerp__.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Purchase Request to Requisition",
+    "version": "1.0",
+    "author": "Eficent",
+    "website": "www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["purchase_request", "purchase_requisition"],
+    "description": """
+Purchase Request to Requisition
+===============================
+    """,
+    "init_xml": [],
+    "update_xml": [
+        "wizard/purchase_request_line_make_purchase_requisition_view.xml",
+        "views/purchase_request_view.xml",
+        "views/purchase_requisition_view.xml",
+        "views/product_view.xml",
+        "views/procurement_view.xml",
+    ],
+    'demo_xml': [],
+    'test': [],
+    'installable': True,
+    'active': False,
+    'certificate': '',
+}

--- a/purchase_request_to_requisition/__openerp__.py
+++ b/purchase_request_to_requisition/__openerp__.py
@@ -20,15 +20,94 @@
 ##############################################################################
 
 {
-    "name": "Purchase Request to Requisition",
+    "name": "Purchase Request to Bid",
     "version": "1.0",
     "author": "Eficent",
     "website": "www.eficent.com",
     "category": "Purchase Management",
     "depends": ["purchase_request", "purchase_requisition"],
     "description": """
-Purchase Request to Requisition
-===============================
+Purchase Request to Bid
+=======================
+This module introduces the following features:
+* The possibility to create new Bids or update existing Bids from Purchase
+Request Lines.
+* The possibility to create Purchase Requests on the basis of Procurement
+Orders.
+
+Installation
+============
+
+No specific instructions required.
+
+
+Configuration
+=============
+
+No specific instructions requied.
+
+Usage
+=====
+Create Purchase Requests from Procurement Orders
+------------------------------------------------
+Go to the product form, in tab 'Procurement' and choose 'Purchase Request'.
+When a procurement order is created and the supply method is 'Make to Order'
+the application will now create a Purchase Request.
+
+
+Create Bids from Purchase Requests
+----------------------------------
+Go to the Purchase Request Lines from the menu entry 'Purchase Requests',
+and also from the 'Purchase' menu.
+
+Select the lines that you wish to initiate the RFQ for, then go to 'More'
+and press 'Create Purchase Bid'.
+
+You can choose to select an existing Draft Bid or create a new one.
+
+In case that you chose to select an existing Bid, the application will search
+for existing lines matching the request line, and will add the extra
+quantity to them.
+
+In case that you create a new RFQ, the request lines will also be
+consolidated into as few as possible lines in the RFQ.
+
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+Procurement Orders will no longer create Purchase Requisitions. The flag
+'Purchase requisition' in the product form now becomes invisible.
+
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
     """,
     "init_xml": [],
     "update_xml": [

--- a/purchase_request_to_requisition/__openerp__.py
+++ b/purchase_request_to_requisition/__openerp__.py
@@ -119,7 +119,10 @@ To contribute to this module, please visit http://odoo-community.org.
     ],
     'demo_xml': [],
     'test': [
-        "test/purchase_request_from_procurement.yml"
+        "test/purchase_request_from_procurement.yml",
+        'test/purchase_request_users.yml',
+        'test/purchase_request_data.yml',
+        'test/purchase_request.yml',
     ],
     'installable': True,
     'active': False,

--- a/purchase_request_to_requisition/__openerp__.py
+++ b/purchase_request_to_requisition/__openerp__.py
@@ -118,7 +118,11 @@ To contribute to this module, please visit http://odoo-community.org.
         "views/procurement_view.xml",
     ],
     'demo_xml': [],
-    'test': [],
+    'test': [
+        "test/purchase_request_users.yml",
+        "test/purchase_request_data.yml",
+        "test/purchase_request_from_procurement.yml"
+    ],
     'installable': True,
     'active': False,
     'certificate': '',

--- a/purchase_request_to_requisition/__openerp__.py
+++ b/purchase_request_to_requisition/__openerp__.py
@@ -119,8 +119,6 @@ To contribute to this module, please visit http://odoo-community.org.
     ],
     'demo_xml': [],
     'test': [
-        "test/purchase_request_users.yml",
-        "test/purchase_request_data.yml",
         "test/purchase_request_from_procurement.yml"
     ],
     'installable': True,

--- a/purchase_request_to_requisition/models/__init__.py
+++ b/purchase_request_to_requisition/models/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import purchase_request
+from . import purchase_requisition
+from . import procurement
+from . import product

--- a/purchase_request_to_requisition/models/procurement.py
+++ b/purchase_request_to_requisition/models/procurement.py
@@ -23,15 +23,20 @@ from openerp.tools.translate import _
 
 
 class Procurement(orm.Model):
-    _inherit = "procurement.order"
-
-
-class procurement_order(orm.Model):
     _inherit = 'procurement.order'
     _columns = {
         'request_id': fields.many2one('purchase.request',
                                       'Latest Purchase Request')
     }
+
+    def copy(self, cr, uid, id, default=None, context=None):
+        if context is None:
+            context = {}
+        if default is None:
+            default = {}
+        default['request_id'] = False
+        return super(Procurement, self).copy(cr, uid, id, default,
+                                                   context)
 
     def _get_warehouse(self, procurement, user_company):
         """
@@ -105,6 +110,6 @@ class procurement_order(orm.Model):
                 non_request.append(procurement.id)
 
         if non_request:
-            res.update(super(procurement_order, self).make_po(
+            res.update(super(Procurement, self).make_po(
                 cr, uid, non_request, context=context))
         return res

--- a/purchase_request_to_requisition/models/procurement.py
+++ b/purchase_request_to_requisition/models/procurement.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, orm
+from openerp.tools.translate import _
+
+
+class Procurement(orm.Model):
+    _inherit = "procurement.order"
+
+
+class procurement_order(orm.Model):
+    _inherit = 'procurement.order'
+    _columns = {
+        'request_id': fields.many2one('purchase.request',
+                                      'Latest Purchase Request')
+    }
+
+    def _get_warehouse(self, procurement, user_company):
+        """
+            Return the warehouse containing the procurment stock location
+            (or one of it ancestors)
+            If none match, returns then first warehouse of the company
+        """
+        company_id = (procurement.company_id or user_company).id
+        domains = [
+            [
+                '&', ('company_id', '=', company_id),
+                '|', '&', ('lot_stock_id.parent_left', '<',
+                           procurement.location_id.parent_left),
+                          ('lot_stock_id.parent_right', '>',
+                           procurement.location_id.parent_right),
+                     ('lot_stock_id', '=', procurement.location_id.id)
+            ],
+            [('company_id', '=', company_id)]
+        ]
+
+        cr, uid = procurement._cr, procurement._uid
+        context = procurement._context
+        Warehouse = self.pool['stock.warehouse']
+        for domain in domains:
+            ids = Warehouse.search(cr, uid, domain, context=context)
+            if ids:
+                return ids[0]
+        return False
+
+    def _prepare_purchase_request_line(self, cr, uid, procurement,
+                                       context=None):
+        return {
+                'product_id': procurement.product_id.id,
+                'name': procurement.product_id.name,
+                'date_required': procurement.date_planned,
+                'product_uom_id': procurement.product_uom.id,
+                'product_qty': procurement.product_qty
+        }
+
+    def _prepare_purchase_request(self, cr, uid, procurement, context=None):
+        user_company = self.pool['res.users'].browse(
+            cr, uid, uid, context=context).company_id
+        request_line_data = self._prepare_purchase_request_line(
+            cr, uid, procurement, context=context)
+        return {
+            'origin': procurement.origin,
+            'company_id': procurement.company_id.id,
+            'warehouse_id': self._get_warehouse(procurement, user_company),
+            'line_ids': [(0, 0, request_line_data)]
+        }
+
+    def make_po(self, cr, uid, ids, context=None):
+        res = {}
+        request_obj = self.pool['purchase.request']
+        non_request = []
+        for procurement in self.browse(cr, uid, ids, context=context):
+            if procurement.product_id.purchase_request:
+                request_data = self._prepare_purchase_request(
+                    cr, uid, procurement, context=context)
+                req = request_obj.create(cr, uid, request_data,
+                                         context=context),
+                self.message_post(cr, uid, [procurement.id],
+                                  body=_("Purchase Request created"),
+                                  context=context)
+                procurement.write({
+                    'state': 'running',
+                    'request_id': req
+                })
+                res[procurement.id] = 0
+            else:
+                non_request.append(procurement.id)
+
+        if non_request:
+            res.update(super(procurement_order, self).make_po(
+                cr, uid, non_request, context=context))
+        return res

--- a/purchase_request_to_requisition/models/product.py
+++ b/purchase_request_to_requisition/models/product.py
@@ -33,3 +33,14 @@ class Product(orm.Model):
     _defaults = {
         'purchase_request': False
     }
+
+    def _check_request_requisition(self, cr, uid, ids, context=None):
+        for product in self.browse(cr, uid, ids, context=context):
+            if product.purchase_request and product.purchase_requisition:
+                return False
+        return True
+
+    _constraints = [
+        (_check_request_requisition,
+         'Only one selection of Purchase Request or Purchase Requisition '
+         'is allowed', ['purchase_request', 'purchase_requisition'])]

--- a/purchase_request_to_requisition/models/product.py
+++ b/purchase_request_to_requisition/models/product.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, orm
+
+
+class Product(orm.Model):
+    _inherit = "product.product"
+
+    _columns = {
+        'purchase_request': fields.boolean(
+            'Purchase Request',
+            help="Check this box to generate purchase request instead of "
+                 "generating requests for quotation from procurement.")
+    }
+    _defaults = {
+        'purchase_request': False
+    }

--- a/purchase_request_to_requisition/models/purchase_request.py
+++ b/purchase_request_to_requisition/models/purchase_request.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, orm
+
+_PURCHASE_REQUISITION_STATE = [
+    ('none', 'No Bid'),
+    ('draft', 'New'),
+    ('in_progress', 'Sent to Suppliers'),
+    ('cancel', 'Cancelled'),
+    ('done', 'Purchase Done'),
+]
+
+
+class PurchaseRequestLine(orm.Model):
+
+    _inherit = "purchase.request.line"
+
+    def _requisition_qty(self, cursor, user, ids, name, arg, context=None):
+        res = {}
+        for request_line in self.browse(cursor, user, ids, context=context):
+            requisition_qty = 0.0
+            for requisition_line in request_line.requisition_lines:
+                if requisition_line.requisition_id.state != 'cancel':
+                    requisition_qty += requisition_line.product_qty
+            res[request_line.id] = requisition_qty
+        return res
+
+    def _get_requisition_state(self, cr, uid, ids, names, arg, context=None):
+        res = {}
+        for line in self.browse(cr, uid, ids, context=context):
+            res[line.id] = 'none'
+            if any([pr_line.requisition_id.state == 'done' for
+                    pr_line in
+                    line.requisition_lines]):
+                res[line.id] = 'done'
+            elif all([pr_line.requisition_id.state == 'cancel'
+                      for pr_line in line.requisition_lines]):
+                res[line.id] = 'cancel'
+            elif any([pr_line.requisition_id.state == 'in_progress'
+                      for pr_line in line.requisition_lines]):
+                res[line.id] = 'in_progress'
+            elif all([pr_line.requisition_id.state in ('draft', 'cancel')
+                      for pr_line in line.requisition_lines]):
+                res[line.id] = 'draft'
+        return res
+
+    def _get_request_lines_from_pr(self, cr, uid, ids, context=None):
+        request_line_ids = []
+        for requisition in self.pool['purchase.requisition'].browse(
+                cr, uid, ids, context=context):
+            for line in requisition.line_ids:
+                for request_line in line.purchase_request_lines:
+                    request_line_ids.append(request_line.id)
+        return list(set(request_line_ids))
+
+    def _get_request_lines_from_prl(self, cr, uid, ids, context=None):
+        request_line_ids = []
+        for rl in self.pool['purchase.requisition.line'].browse(
+                cr, uid, ids, context=context):
+            for request_line in rl.purchase_request_lines:
+                request_line_ids.append(request_line.id)
+        return list(set(request_line_ids))
+
+    _columns = {
+        'requisition_lines': fields.many2many(
+            'purchase.requisition.line',
+            'purchase_request_purchase_requisition_line_rel',
+            'purchase_request_line_id',
+            'purchase_requisition_line_id',
+            'Purchase Requisition Lines', readonly=True),
+        'requisition_qty': fields.function(_requisition_qty,
+                                           string='Quantity in a Bid',
+                                           type='float'),
+        'requisition_state': fields.function(
+            _get_requisition_state, string="Bid Status",
+            type="selection",
+            selection=_PURCHASE_REQUISITION_STATE,
+            store={'purchase.requisition': (
+                _get_request_lines_from_pr,
+                ['state', 'line_ids'], 10),
+                'purchase.requisition.line': (
+                _get_request_lines_from_prl, None, 10)},),
+    }
+
+    _defaults = {
+        'requisition_state': 'none',
+    }
+
+    def copy(self, cr, uid, id, default=None, context=None):
+        if default is None:
+            default = {}
+        default.update({
+            'requisition_lines': [],
+        })
+        return super(PurchaseRequestLine, self).copy(
+            cr, uid, id, default, context)

--- a/purchase_request_to_requisition/models/purchase_request.py
+++ b/purchase_request_to_requisition/models/purchase_request.py
@@ -19,6 +19,7 @@
 #
 ##############################################################################
 from openerp.osv import fields, orm
+from openerp.tools.translate import _
 
 _PURCHASE_REQUISITION_STATE = [
     ('none', 'No Bid'),
@@ -124,3 +125,13 @@ class PurchaseRequestLine(orm.Model):
         })
         return super(PurchaseRequestLine, self).copy(
             cr, uid, id, default, context)
+
+    def unlink(self, cr, uid, ids, context=None):
+        for line in self.browse(cr, uid, ids, context=context):
+            if line.requisition_lines:
+                raise orm.except_orm(
+                    _('Error!'),
+                    _('You cannot delete a record that refers to purchase '
+                      'requisition lines!'))
+        return super(PurchaseRequestLine, self).unlink(cr, uid, ids,
+                                                       context=context)

--- a/purchase_request_to_requisition/models/purchase_request.py
+++ b/purchase_request_to_requisition/models/purchase_request.py
@@ -33,6 +33,14 @@ class PurchaseRequestLine(orm.Model):
 
     _inherit = "purchase.request.line"
 
+    def _get_is_editable(self, cr, uid, ids, names, arg, context=None):
+        res = super(PurchaseRequestLine, self)._get_is_editable(
+            cr, uid, ids, names, arg, context=context)
+        for line in self.browse(cr, uid, ids, context=context):
+            if line.requisition_lines:
+                res[line.id] = False
+        return res
+
     def _requisition_qty(self, cursor, user, ids, name, arg, context=None):
         res = {}
         for request_line in self.browse(cursor, user, ids, context=context):
@@ -98,6 +106,9 @@ class PurchaseRequestLine(orm.Model):
                 ['state', 'line_ids'], 10),
                 'purchase.requisition.line': (
                 _get_request_lines_from_prl, None, 10)},),
+        'is_editable': fields.function(_get_is_editable,
+                                       string="Is editable",
+                                       type="boolean")
     }
 
     _defaults = {

--- a/purchase_request_to_requisition/models/purchase_request.py
+++ b/purchase_request_to_requisition/models/purchase_request.py
@@ -105,7 +105,8 @@ class PurchaseRequestLine(orm.Model):
                 _get_request_lines_from_pr,
                 ['state', 'line_ids'], 10),
                 'purchase.requisition.line': (
-                _get_request_lines_from_prl, None, 10)},),
+                _get_request_lines_from_prl, ['purchase_request_lines'],
+                10)},),
         'is_editable': fields.function(_get_is_editable,
                                        string="Is editable",
                                        type="boolean")

--- a/purchase_request_to_requisition/test/purchase_request.yml
+++ b/purchase_request_to_requisition/test/purchase_request.yml
@@ -1,0 +1,31 @@
+-
+  I create the procurement order and run that procurement.
+-
+  !python {model: make.procurement}: |
+    context.update({'active_model':'product.product', 'active_ids': [ref('product.product_product_13')], 'active_id': ref('product.product_product_13')})
+-
+  !record {model: make.procurement, id: procurement_product_hdd3}:
+    product_id: product.product_product_13
+    qty: 15
+    uom_id: product.product_uom_unit
+    warehouse_id: stock.stock_warehouse_shop0
+-
+  !python {model: make.procurement}: |
+    self.make_procurement(cr, uid, [ref('procurement_product_hdd3')], context)
+-
+  I run the scheduler.
+-
+  !python {model: procurement.order}: |
+    self.run_scheduler(cr, uid)
+-
+  I check request details which created after run procurement.
+-
+  !python {model: procurement.order}: |
+    procurement_ids = self.search(cr, uid, [('request_id','!=', False)])
+    for procurement in self.browse(cr, uid, procurement_ids, context=context):
+        request = procurement.request_id
+        assert len(request.line_ids) == 1, "Request Lines should be one."
+        line = request.line_ids[0]
+        assert line.product_id.id == procurement.product_id.id, "Product is not correspond."
+        assert line.product_uom_id.id == procurement.product_uom.id, "UOM is not correspond."
+        assert line.product_qty == procurement.product_qty, "Quantity is not correspond."

--- a/purchase_request_to_requisition/test/purchase_request.yml
+++ b/purchase_request_to_requisition/test/purchase_request.yml
@@ -1,31 +1,105 @@
 -
-  I create the procurement order and run that procurement.
+  I log as the Purchase User
 -
-  !python {model: make.procurement}: |
-    context.update({'active_model':'product.product', 'active_ids': [ref('product.product_product_13')], 'active_id': ref('product.product_product_13')})
+  !context
+    uid: 'res_users_purchase_user'
 -
-  !record {model: make.procurement, id: procurement_product_hdd3}:
-    product_id: product.product_product_13
-    qty: 15
-    uom_id: product.product_uom_unit
-    warehouse_id: stock.stock_warehouse_shop0
+  I create a Requisition
 -
-  !python {model: make.procurement}: |
-    self.make_procurement(cr, uid, [ref('procurement_product_hdd3')], context)
+  !python {model: purchase.request.line.make.purchase.requisition}: |
+    context.update({"active_model": "purchase.request.line","active_ids": [ref("request_line1")],"active_id": ref("request_line1")})
 -
-  I run the scheduler.
+  !record {model: purchase.request.line.make.purchase.requisition, id: request_line_make_pr_0}:
 -
-  !python {model: procurement.order}: |
-    self.run_scheduler(cr, uid)
+  !python {model: purchase.request.line.make.purchase.requisition}: |
+    self.make_purchase_requisition(cr, uid, [ref("request_line_make_pr_0")], context=context)
 -
-  I check request details which created after run procurement.
+  I check that the Requisition details which created for supplier.
 -
-  !python {model: procurement.order}: |
-    procurement_ids = self.search(cr, uid, [('request_id','!=', False)])
-    for procurement in self.browse(cr, uid, procurement_ids, context=context):
-        request = procurement.request_id
-        assert len(request.line_ids) == 1, "Request Lines should be one."
-        line = request.line_ids[0]
-        assert line.product_id.id == procurement.product_id.id, "Product is not correspond."
-        assert line.product_uom_id.id == procurement.product_uom.id, "UOM is not correspond."
-        assert line.product_qty == procurement.product_qty, "Quantity is not correspond."
+  !python {model: purchase.requisition.line}: |
+    request_obj = self.pool["purchase.request"]
+    request_line_obj = self.pool["purchase.request.line"]
+    request = request_obj.browse(cr, uid, ref("request1"), context=context)
+    requisition_line = False
+    for pr_line in request.line_ids:
+        assert len(pr_line.requisition_lines) == 1, "No purchase requisition line was created."
+        for requisition_l in pr_line.requisition_lines:
+            requisition_line = requisition_l
+    requisition = requisition_line.requisition_id
+    assert len(requisition.line_ids) == len(request.line_ids), "Lines do not match."
+    for requisition_line in requisition.line_ids:
+        for line in request.line_ids:
+            if requisition_line.product_id.id == line.product_id.id:
+                assert requisition_line.product_id == line.product_id, "Product does not match."
+                assert requisition_line.requisition_id.state == line.requisition_state, "State does not match"
+-
+  Set tender state to choose bidding line.
+-
+  !python {model: purchase.requisition}: |
+    request_obj = self.pool["purchase.request"]
+    request = request_obj.browse(cr, uid, ref("request1"), context=context)
+    requisition_line = False
+    for pr_line in request.line_ids:
+        assert len(pr_line.requisition_lines) == 1, "No purchase requisition line was created."
+        for requisition_l in pr_line.requisition_lines:
+            requisition_line = requisition_l
+    requisition = requisition_line.requisition_id
+    self.tender_in_progress(cr, uid, requisition.id, context=context)
+    self.tender_open(cr, uid, requisition.id, context=context)
+-
+  Supplier send one RFQ so I create requisition request of that supplier.
+-
+  !python {model: purchase.requisition.partner}: |
+    request_obj = self.pool["purchase.request"]
+    request = request_obj.browse(cr, uid, ref("request1"), context=context)
+    requisition_line = False
+    for pr_line in request.line_ids:
+        assert len(pr_line.requisition_lines) == 1, "No purchase requisition line was created."
+        for requisition_l in pr_line.requisition_lines:
+            requisition_line = requisition_l
+    requisition = requisition_line.requisition_id
+    context.update({"active_model": "purchase.requisition","active_ids": [requisition.id],"active_id": requisition.id})
+-
+  !record {model: purchase.requisition.partner, id: requisition_partner_0}:
+    partner_id: base.res_partner_12
+-
+  !python {model: purchase.requisition.partner}: |
+    context.update({"mail_create_nolog" : True })
+    self.create_order(cr, uid, [ref("requisition_partner_0")], context=context)
+-
+  I check that the RFQ details which created for supplier.
+-
+  !python {model: purchase.order}: |
+    request_obj = self.pool["purchase.request"]
+    request = request_obj.browse(cr, uid, ref("request1"), context=context)
+    requisition_line = False
+    for pr_line in request.line_ids:
+        assert len(pr_line.requisition_lines) == 1, "No purchase requisition line was created."
+        for requisition_l in pr_line.requisition_lines:
+            requisition_line = requisition_l
+    requisition = requisition_line.requisition_id
+    purchase_requisition = self.pool.get("purchase.requisition")
+    purchase_ids = self.search(cr, uid, [('requisition_id','=', requisition.id)])
+    assert purchase_ids, "RFQ is not created."
+    for rfq in self.browse(cr, uid, purchase_ids, context=context):
+        if rfq.partner_id.id == ref('base.res_partner_12'):
+            purchase = self.browse(cr, uid, rfq.id, context=context)
+            purchase.signal_workflow('purchase_confirm')
+            for order_line in purchase.order_line:
+                for request_line in order_line.purchase_request_lines:
+                    assert len(order_line.purchase_request_lines)>0, "No link between purchase order lines and request lines"
+        else:
+            assert False, "No PO found for res_partner_12."
+-
+  I check status of requisition after confirmed the RFQ.
+-
+  !python {model: purchase.requisition}: |
+    request_obj = self.pool["purchase.request"]
+    request = request_obj.browse(cr, uid, ref("request1"), context=context)
+    requisition_line = False
+    for pr_line in request.line_ids:
+        assert len(pr_line.requisition_lines) == 1, "No purchase requisition line was created."
+        for requisition_l in pr_line.requisition_lines:
+            requisition_line = requisition_l
+    requisition = requisition_line.requisition_id
+    requisition.state == 'done', "Requisition should be closed."

--- a/purchase_request_to_requisition/test/purchase_request_data.yml
+++ b/purchase_request_to_requisition/test/purchase_request_data.yml
@@ -1,0 +1,15 @@
+-
+  I log as the Purchase User
+-
+  !context
+    uid: 'res_users_purchase_user'
+-
+  !record {model: purchase.request, id: request1}:
+    warehouse_id: stock.stock_warehouse_shop0
+    requested_by: res_users_purchase_user
+-
+  !record {model: purchase.request.line, id: request_line1}:
+    request_id: request1
+    product_id: product.product_product_9
+    product_uom_id: product.product_uom_unit
+    product_qty: 5.0

--- a/purchase_request_to_requisition/test/purchase_request_from_procurement.yml
+++ b/purchase_request_to_requisition/test/purchase_request_from_procurement.yml
@@ -1,0 +1,31 @@
+-
+  I create the procurement order and run that procurement.
+-
+  !python {model: make.procurement}: |
+    context.update({'active_model':'product.product', 'active_ids': [ref('product.product_product_13')], 'active_id': ref('product.product_product_13')})
+-
+  !record {model: make.procurement, id: procurement_product_hdd3}:
+    product_id: product.product_product_13
+    qty: 15
+    uom_id: product.product_uom_unit
+    warehouse_id: stock.stock_warehouse_shop0
+-
+  !python {model: make.procurement}: |
+    self.make_procurement(cr, uid, [ref('procurement_product_hdd3')], context)
+-
+  I run the scheduler.
+-
+  !python {model: procurement.order}: |
+    self.run_scheduler(cr, uid)
+-
+  I check request details which created after run procurement.
+-
+  !python {model: procurement.order}: |
+    procurement_ids = self.search(cr, uid, [('request_id','!=', False)])
+    for procurement in self.browse(cr, uid, procurement_ids, context=context):
+        request = procurement.request_id
+        assert len(request.line_ids) == 1, "Request Lines should be one."
+        line = request.line_ids[0]
+        assert line.product_id.id == procurement.product_id.id, "Product is not correspond."
+        assert line.product_uom_id.id == procurement.product_uom.id, "UOM is not correspond."
+        assert line.product_qty == procurement.product_qty, "Quantity is not correspond."

--- a/purchase_request_to_requisition/test/purchase_request_users.yml
+++ b/purchase_request_to_requisition/test/purchase_request_users.yml
@@ -1,0 +1,17 @@
+-
+   Create a user as 'Purchase Requisition Manager, Purchase User and Request Manager'
+-
+  !record {model: res.users, id: res_users_purchase_user}:
+    company_id: base.main_company
+    name: Purchase User
+    login: prm
+    password: prm
+    email: purchase_user_manager@yourcompany.com
+-
+  I added groups for Purchase User and Request User.
+-
+  !record {model: res.users, id: res_users_purchase_user}:
+    groups_id:
+      - purchase.group_purchase_user
+      - purchase_request.group_purchase_request_manager
+      - purchase_requisition.group_purchase_requisition_manager

--- a/purchase_request_to_requisition/views/procurement_view.xml
+++ b/purchase_request_to_requisition/views/procurement_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+    <record model="ir.ui.view" id="procurement_normal_form_view">
+        <field name="name">procurement.form</field>
+        <field name="model">procurement.order</field>
+        <field name="inherit_id" ref="procurement.procurement_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='close_move']" position="after">
+                <field name="request_id"/>
+            </xpath>
+        </field>
+    </record>
+
+    </data>
+</openerp>

--- a/purchase_request_to_requisition/views/product_view.xml
+++ b/purchase_request_to_requisition/views/product_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+    <record model="ir.ui.view" id="product_normal_form_view_inherit">
+        <field name="name">product.form.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id"
+               ref="purchase_requisition.product_normal_form_view_inherit"/>
+        <field name="arch" type="xml">
+            <field name="purchase_requisition" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </field>
+            <field name="purchase_requisition" position="after">
+                <field name="purchase_request"/>
+            </field>
+        </field>
+    </record>
+
+    </data>
+</openerp>

--- a/purchase_request_to_requisition/views/product_view.xml
+++ b/purchase_request_to_requisition/views/product_view.xml
@@ -8,9 +8,6 @@
         <field name="inherit_id"
                ref="purchase_requisition.product_normal_form_view_inherit"/>
         <field name="arch" type="xml">
-            <field name="purchase_requisition" position="attributes">
-                <attribute name="invisible">True</attribute>
-            </field>
             <field name="purchase_requisition" position="after">
                 <field name="purchase_request"/>
             </field>

--- a/purchase_request_to_requisition/views/purchase_request_view.xml
+++ b/purchase_request_to_requisition/views/purchase_request_view.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="view_purchase_request_form">
+            <field name="name">purchase.request.form</field>
+            <field name="model">purchase.request</field>
+            <field name="inherit_id"
+                   ref="purchase_request.view_purchase_request_form"/>
+            <field name="arch" type="xml">
+                <xpath
+                        expr="//field[@name='line_ids']/tree//field[@name='date_required']"
+                        position="after">
+                    <field name="requisition_qty"/>
+                    <field name="requisition_state"/>
+                </xpath>
+                <xpath
+                        expr="//field[@name='line_ids']/form//group[@name='follow_up']"
+                        position="inside">
+                    <newline/>
+                    <separator string="Purchase Requisition Lines"/>
+                    <newline/>
+                    <field name="requisition_lines" nolabel="1">
+                        <tree string="Purchase Requisition Lines">
+                            <field name="product_id"/>
+                            <field name="product_qty"/>
+                            <field name="product_uom_id"
+                                   groups="product.group_uom"/>
+                        </tree>
+                    </field>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="purchase_request_line_tree" model="ir.ui.view">
+            <field name="name">purchase.request.line.tree</field>
+            <field name="model">purchase.request.line</field>
+            <field name="inherit_id"
+                   ref="purchase_request.purchase_request_line_tree"/>
+            <field name="arch" type="xml">
+                <field name="date_required" position="after">
+                    <field name="requisition_qty"/>
+                    <field name="requisition_state"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="purchase_request_line_form" model="ir.ui.view">
+            <field name="name">purchase.request.line.form</field>
+            <field name="model">purchase.request.line</field>
+            <field name="inherit_id"
+                   ref="purchase_request.purchase_request_line_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='date_required']"
+                       position="after">
+                    <field name="requisition_qty"/>
+                    <field name="requisition_state"/>
+                </xpath>
+                <xpath expr="//group[@name='follow_up']" position="inside">
+                    <newline/>
+                    <separator string="Purchase Requisition Lines"/>
+                    <newline/>
+                    <field name="requisition_lines" nolabel="1">
+                        <tree string="Purchase Requisition Lines">
+                            <field name="requisition_id"/>
+                            <field name="product_id"/>
+                            <field name="product_qty"/>
+                            <field name="product_uom_id"
+                                   groups="product.group_uom"/>
+                        </tree>
+                    </field>
+                </xpath>
+            </field>
+        </record>
+
+
+        <record id="purchase_request_line_search" model="ir.ui.view">
+            <field name="name">purchase.request.line.search</field>
+            <field name="model">purchase.request.line</field>
+            <field name="inherit_id" ref="purchase_request.purchase_request_line_search"/>
+            <field name="arch" type="xml">
+                    <field name="date_required" position="after">
+                        <filter name="requisition_state_none"
+                                string="No Bid"
+                                domain="[('requisition_state','=','none')]"
+                                help="No Bid has been created"/>
+                        <filter name="requisition_state_draft"
+                                string="New Bid"
+                                domain="[('requisition_state','=','draft')]"
+                                help="At least a Draft Bid has been created"/>
+                        <filter name="requisition_state_in_progress"
+                                string="Bid Sent to Suppliers"
+                                domain="[('requisition_state','=','in_progress')]"
+                                help="At least a PO has been confirmed"/>
+                        <filter name="requisition_state_done"
+                                string="Bid completed"
+                                domain="[('requisition_state','=','done')]"
+                                help="At least one of the Bids has been completed"/>
+                    </field>
+                    <group position="inside">
+                        <filter string="Requisition Status"
+                                domain="[]" context="{'group_by':'requisition_state'}"/>
+                        <filter string="Request"
+                                domain="[]" context="{'group_by':'request_id'}"/>
+                    </group>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_request_to_requisition/views/purchase_request_view.xml
+++ b/purchase_request_to_requisition/views/purchase_request_view.xml
@@ -57,13 +57,13 @@
                    ref="purchase_request.purchase_request_line_form"/>
             <field name="arch" type="xml">
                 <notebook position="inside">
-                    <group>
-                        <field name="requisition_qty"/>
-                        <field name="requisition_state"/>
-                    </group>
-                    <group>
-                        <page name="purchase_requisition_lines"
+                    <page name="purchase_requisition_lines"
                               string="Purchase Requisition Lines">
+                        <group>
+                            <field name="requisition_qty"/>
+                            <field name="requisition_state"/>
+                        </group>
+                        <group>
                             <group>
                                 <field name="requisition_lines" nolabel="1">
                                     <tree string="Purchase Requisition Lines">
@@ -82,8 +82,8 @@
                                     </form>
                                 </field>
                             </group>
-                        </page>
-                    </group>
+                        </group>
+                    </page>
                 </notebook>
             </field>
         </record>

--- a/purchase_request_to_requisition/views/purchase_request_view.xml
+++ b/purchase_request_to_requisition/views/purchase_request_view.xml
@@ -8,26 +8,31 @@
             <field name="inherit_id"
                    ref="purchase_request.view_purchase_request_form"/>
             <field name="arch" type="xml">
-                <xpath
-                        expr="//field[@name='line_ids']/tree//field[@name='date_required']"
-                        position="after">
+                <xpath expr="//field[@name='line_ids']/tree"
+                       position="inside">
                     <field name="requisition_qty"/>
                     <field name="requisition_state"/>
                 </xpath>
-                <xpath
-                        expr="//field[@name='line_ids']/form//group[@name='follow_up']"
-                        position="inside">
-                    <newline/>
-                    <separator string="Purchase Requisition Lines"/>
-                    <newline/>
-                    <field name="requisition_lines" nolabel="1">
-                        <tree string="Purchase Requisition Lines">
-                            <field name="product_id"/>
-                            <field name="product_qty"/>
-                            <field name="product_uom_id"
-                                   groups="product.group_uom"/>
-                        </tree>
-                    </field>
+                <xpath expr="//field[@name='line_ids']/form//notebook"
+                       position="inside">
+                    <page name="requisition_lines"
+                          string="Requisition Lines">
+                        <group>
+                            <field name="requisition_qty"/>
+                            <field name="requisition_state"/>
+                        </group>
+                        <newline/>
+                        <group>
+                            <field name="requisition_lines" nolabel="1">
+                                <tree string="Purchase Requisition Lines">
+                                    <field name="product_id"/>
+                                    <field name="product_qty"/>
+                                    <field name="product_uom_id"
+                                           groups="product.group_uom"/>
+                                </tree>
+                            </field>
+                        </group>
+                    </page>
                 </xpath>
             </field>
         </record>
@@ -51,25 +56,35 @@
             <field name="inherit_id"
                    ref="purchase_request.purchase_request_line_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='date_required']"
-                       position="after">
-                    <field name="requisition_qty"/>
-                    <field name="requisition_state"/>
-                </xpath>
-                <xpath expr="//group[@name='follow_up']" position="inside">
-                    <newline/>
-                    <separator string="Purchase Requisition Lines"/>
-                    <newline/>
-                    <field name="requisition_lines" nolabel="1">
-                        <tree string="Purchase Requisition Lines">
-                            <field name="requisition_id"/>
-                            <field name="product_id"/>
-                            <field name="product_qty"/>
-                            <field name="product_uom_id"
-                                   groups="product.group_uom"/>
-                        </tree>
-                    </field>
-                </xpath>
+                <notebook position="inside">
+                    <group>
+                        <field name="requisition_qty"/>
+                        <field name="requisition_state"/>
+                    </group>
+                    <group>
+                        <page name="purchase_requisition_lines"
+                              string="Purchase Requisition Lines">
+                            <group>
+                                <field name="requisition_lines" nolabel="1">
+                                    <tree string="Purchase Requisition Lines">
+                                        <field name="requisition_id"/>
+                                        <field name="product_id"/>
+                                        <field name="product_qty"/>
+                                        <field name="product_uom_id"
+                                               groups="product.group_uom"/>
+                                    </tree>
+                                    <form string="Purchase Requisition Lines">
+                                        <field name="requisition_id"/>
+                                        <field name="product_id"/>
+                                        <field name="product_qty"/>
+                                        <field name="product_uom_id"
+                                               groups="product.group_uom"/>
+                                    </form>
+                                </field>
+                            </group>
+                        </page>
+                    </group>
+                </notebook>
             </field>
         </record>
 

--- a/purchase_request_to_requisition/views/purchase_requisition_view.xml
+++ b/purchase_request_to_requisition/views/purchase_requisition_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+    <record model="ir.ui.view" id="view_purchase_requisition_form">
+        <field name="name">purchase.requisition.form</field>
+        <field name="model">purchase.requisition</field>
+        <field name="inherit_id"
+               ref="purchase_requisition.view_purchase_requisition_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='line_ids']/tree"
+                       position="inside">
+                    <field name="has_purchase_request_lines" invisible="1"/>
+                    <button string="Purchase Request lines"
+                        attrs="{'invisible':[('has_purchase_request_lines','=',False)]}"
+                        name="action_openRequestLineTreeView"
+                        type="object"
+                        icon="gtk-open"/>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_request_to_requisition/wizard/__init__.py
+++ b/purchase_request_to_requisition/wizard/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import purchase_request_line_make_purchase_requisition

--- a/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
+++ b/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
@@ -89,10 +89,10 @@ class PurchaseRequestLineMakePurchaseRequisition(orm.TransientModel):
         }
 
     def _get_requisition_line_search_domain(self, cr, uid, requisition_id,
-                                            requisition_line, context=None):
+                                            request_line, context=None):
         return [('requisition_id', '=', requisition_id),
-                ('product_id', '=', requisition_line.product_id.id),
-                ('product_uom_id', '=', requisition_line.product_uom_id.id)]
+                ('product_id', '=', request_line.product_id.id),
+                ('product_uom_id', '=', request_line.product_uom_id.id)]
 
     def make_purchase_requisition(self, cr, uid, ids, context=None):
         if context is None:

--- a/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
+++ b/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
@@ -86,7 +86,10 @@ class PurchaseRequestLineMakePurchaseRequisition(orm.TransientModel):
             'product_qty': item.product_qty,
             'product_id': item.product_id.id,
             'product_uom_id': item.product_uom_id.id,
-            'purchase_request_lines': [(4, item.line_id.id)]
+            'purchase_request_lines': [(4, item.line_id.id)],
+            'name': item.name,
+            'account_analytic_id': item.line_id.analytic_account_id.id or
+            False,
         }
 
     def _get_requisition_line_search_domain(self, cr, uid, requisition_id,

--- a/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
+++ b/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
@@ -91,8 +91,10 @@ class PurchaseRequestLineMakePurchaseRequisition(orm.TransientModel):
     def _get_requisition_line_search_domain(self, cr, uid, requisition_id,
                                             request_line, context=None):
         return [('requisition_id', '=', requisition_id),
-                ('product_id', '=', request_line.product_id.id),
-                ('product_uom_id', '=', request_line.product_uom_id.id)]
+                ('product_id', '=', request_line.product_id.id or False),
+                ('product_uom_id', '=',
+                 request_line.product_uom_id.id or False),
+                ('name', '=', )]
 
     def make_purchase_requisition(self, cr, uid, ids, context=None):
         if context is None:

--- a/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
+++ b/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.tools.translate import _
+from openerp.osv import fields, orm
+import openerp.addons.decimal_precision as dp
+
+
+class PurchaseRequestLineMakePurchaseRequisition(orm.TransientModel):
+    _name = "purchase.request.line.make.purchase.requisition"
+    _description = "Purchase Request Line Make Purchase Requisition"
+
+    _columns = {
+        'item_ids': fields.one2many(
+            'purchase.request.line.make.purchase.requisition.item',
+            'wiz_id', 'Items'),
+        'purchase_requisition_id': fields.many2one(
+            'purchase.requisition', 'Purchase Requisition',
+            required=False, domain=[('state', '=', 'draft')]),
+    }
+
+    def _prepare_item(self, cr, uid, line, context=None):
+        return [{
+            'line_id': line.id,
+            'product_id': line.product_id.id,
+            'name': line.name,
+            'product_qty': line.product_qty,
+            'product_uom_id': line.product_uom_id.id,
+        }]
+
+    def default_get(self, cr, uid, fields, context=None):
+        res = super(PurchaseRequestLineMakePurchaseRequisition,
+                    self).default_get(cr, uid, fields, context=context)
+        request_line_obj = self.pool['purchase.request.line']
+        request_line_ids = context.get('active_ids', [])
+        active_model = context.get('active_model')
+
+        if not request_line_ids:
+            return res
+        assert active_model == 'purchase.request.line', \
+            'Bad context propagation'
+
+        items = []
+        for line in request_line_obj.browse(cr, uid, request_line_ids,
+                                            context=context):
+                items += self._prepare_item(cr, uid, line, context=context)
+        res['item_ids'] = items
+
+        return res
+
+    def _prepare_purchase_requisition(self, cr, uid,
+                                      make_purchase_requisition,
+                                      warehouse_id,
+                                      company_id,
+                                      context=None):
+        data = {
+            'origin': '',
+            'warehouse_id': warehouse_id,
+            'company_id': company_id,
+            }
+        return data
+
+    def _prepare_purchase_requisition_line(self, cr, uid, pr_id,
+                                           make_purchase_order, item,
+                                           context=None):
+        return {
+            'requisition_id': pr_id,
+            'product_qty': item.product_qty,
+            'product_id': item.line_id.product_id.id,
+            'product_uom_id': item.line_id.product_uom_id.id,
+            'purchase_request_lines': [(4, item.line_id.id)]
+        }
+
+    def _get_requisition_line_search_domain(self, cr, uid, requisition_id,
+                                            requisition_line, context=None):
+        return [('requisition_id', '=', requisition_id),
+                ('product_id', '=', requisition_line.product_id.id),
+                ('product_uom_id', '=', requisition_line.product_uom_id.id)]
+
+    def make_purchase_requisition(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        res = []
+        make_purchase_requisition = self.browse(cr, uid, ids[0],
+                                                context=context)
+        pr_obj = self.pool['purchase.requisition']
+        pr_line_obj = self.pool['purchase.requisition.line']
+        company_id = False
+        warehouse_id = False
+        requisition_id = False
+        for item in make_purchase_requisition.item_ids:
+            line = item.line_id
+            if line.state == 'done':
+                raise orm.except_orm(
+                    _('Could not process !'),
+                    _('A related requisition has already been completed'))
+            if item.product_qty <= 0.0:
+                raise orm.except_orm(
+                    _('Could not process !'),
+                    _('Enter a positive quantity.'))
+            line_company_id = line.company_id \
+                and line.company_id.id or False
+            if company_id is not False \
+                    and line_company_id != company_id:
+                raise orm.except_orm(
+                    _('Could not process !'),
+                    _('You have to select lines '
+                      'from the same company.'))
+            else:
+                company_id = line_company_id
+
+            line_warehouse_id = line.request_id.warehouse_id \
+                and line.request_id.warehouse_id.id or False
+            if warehouse_id is not False \
+                    and line_warehouse_id != warehouse_id:
+                raise orm.except_orm(
+                    _('Could not process !'),
+                    _('You have to select lines '
+                      'from the same warehouse.'))
+            else:
+                warehouse_id = line_warehouse_id
+
+            if make_purchase_requisition.purchase_requisition_id:
+                requisition_id = \
+                    make_purchase_requisition.purchase_requisition_id.id
+            if not requisition_id:
+                preq_data = self._prepare_purchase_requisition(
+                    cr, uid, make_purchase_requisition, warehouse_id,
+                    company_id, context=context)
+                requisition_id = pr_obj.create(cr, uid, preq_data,
+                                               context=context)
+
+            # Look for any other PO line in the selected PO with same
+            # product and UoM to sum quantities instead of creating a new
+            # po line
+            domain = self._get_requisition_line_search_domain(
+                cr, uid, requisition_id, line, context=context)
+            available_pr_line_ids = pr_line_obj.search(
+                cr, uid, domain, context=context)
+            if available_pr_line_ids:
+                pr_line = pr_line_obj.browse(
+                    cr, uid, available_pr_line_ids[0], context=context)
+                new_qty = pr_line.product_qty + item.product_qty
+                pr_line_obj.write(cr, uid, [pr_line.id], {
+                    'product_qty': new_qty,
+                    'purchase_request_lines': [(4, line.id)]},
+                    context=context)
+            else:
+                po_line_data = self._prepare_purchase_requisition_line(
+                    cr, uid, requisition_id, make_purchase_requisition,
+                    item, context=context)
+                pr_line_obj.create(cr, uid, po_line_data, context=context)
+            res.append(requisition_id)
+
+        return {
+            'domain': "[('id','in', ["+','.join(map(str, res))+"])]",
+            'name': _('Purchase requisition'),
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'purchase.requisition',
+            'view_id': False,
+            'context': False,
+            'type': 'ir.actions.act_window'
+        }
+
+
+class PurchaseRequestLineMakePurchaseRequisitionItem(orm.TransientModel):
+    _name = "purchase.request.line.make.purchase.requisition.item"
+    _description = "Purchase Request Line Make Purchase Requisition Item"
+
+    _columns = {
+        'wiz_id': fields.many2one(
+            'purchase.request.line.make.purchase.requisition',
+            'Wizard', required=True, ondelete='cascade',
+            readonly=True),
+        'line_id': fields.many2one('purchase.request.line',
+                                   'Purchase Request Line',
+                                   required=True,
+                                   readonly=True),
+        'product_id': fields.related('line_id',
+                                     'product_id', type='many2one',
+                                     relation='product.product',
+                                     string='Product',
+                                     readonly=True),
+        'product_qty': fields.float(string='Quantity to deliver',
+                                    digits_compute=dp.get_precision(
+                                        'Product UoS')),
+        'product_uom_id': fields.related('line_id',
+                                         'product_uom_id', type='many2one',
+                                         relation='product.uom',
+                                         string='UoM',
+                                         readonly=True),
+        'name': fields.related('line_id',
+                               'name', type='char',
+                               string='Description',
+                               readonly=True)
+    }

--- a/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
+++ b/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition.py
@@ -39,6 +39,7 @@ class PurchaseRequestLineMakePurchaseRequisition(orm.TransientModel):
     def _prepare_item(self, cr, uid, line, context=None):
         return [{
             'line_id': line.id,
+            'request_id': line.request_id.id,
             'product_id': line.product_id.id,
             'name': line.name,
             'product_qty': line.product_qty,
@@ -83,18 +84,17 @@ class PurchaseRequestLineMakePurchaseRequisition(orm.TransientModel):
         return {
             'requisition_id': pr_id,
             'product_qty': item.product_qty,
-            'product_id': item.line_id.product_id.id,
-            'product_uom_id': item.line_id.product_uom_id.id,
+            'product_id': item.product_id.id,
+            'product_uom_id': item.product_uom_id.id,
             'purchase_request_lines': [(4, item.line_id.id)]
         }
 
     def _get_requisition_line_search_domain(self, cr, uid, requisition_id,
-                                            request_line, context=None):
+                                            item, context=None):
         return [('requisition_id', '=', requisition_id),
-                ('product_id', '=', request_line.product_id.id or False),
+                ('product_id', '=', item.product_id.id or False),
                 ('product_uom_id', '=',
-                 request_line.product_uom_id.id or False),
-                ('name', '=', )]
+                 item.product_uom_id.id or False)]
 
     def make_purchase_requisition(self, cr, uid, ids, context=None):
         if context is None:
@@ -109,10 +109,6 @@ class PurchaseRequestLineMakePurchaseRequisition(orm.TransientModel):
         requisition_id = False
         for item in make_purchase_requisition.item_ids:
             line = item.line_id
-            if line.state == 'done':
-                raise orm.except_orm(
-                    _('Could not process !'),
-                    _('A related requisition has already been completed'))
             if item.product_qty <= 0.0:
                 raise orm.except_orm(
                     _('Could not process !'),
@@ -153,7 +149,7 @@ class PurchaseRequestLineMakePurchaseRequisition(orm.TransientModel):
             # product and UoM to sum quantities instead of creating a new
             # po line
             domain = self._get_requisition_line_search_domain(
-                cr, uid, requisition_id, line, context=context)
+                cr, uid, requisition_id, item, context=context)
             available_pr_line_ids = pr_line_obj.search(
                 cr, uid, domain, context=context)
             if available_pr_line_ids:
@@ -196,21 +192,46 @@ class PurchaseRequestLineMakePurchaseRequisitionItem(orm.TransientModel):
                                    'Purchase Request Line',
                                    required=True,
                                    readonly=True),
+        'request_id': fields.related('line_id',
+                                     'request_id', type='many2one',
+                                     relation='purchase.request',
+                                     string='Purchase Request',
+                                     readonly=True),
         'product_id': fields.related('line_id',
                                      'product_id', type='many2one',
                                      relation='product.product',
-                                     string='Product',
-                                     readonly=True),
+                                     string='Product'),
         'product_qty': fields.float(string='Quantity to deliver',
                                     digits_compute=dp.get_precision(
                                         'Product UoS')),
         'product_uom_id': fields.related('line_id',
                                          'product_uom_id', type='many2one',
                                          relation='product.uom',
-                                         string='UoM',
-                                         readonly=True),
+                                         string='UoM'),
         'name': fields.related('line_id',
                                'name', type='char',
-                               string='Description',
-                               readonly=True)
+                               string='Description')
     }
+
+    def onchange_product_id(self, cr, uid, ids, product_id,
+                            product_uom_id, context=None):
+        """ Changes UoM and name if product_id changes.
+        @param name: Name of the field
+        @param product_id: Changed product_id
+        @return:  Dictionary of changed values
+        """
+        value = {'product_uom_id': ''}
+        if product_id:
+            product_obj = self.pool['product.product']
+            prod = product_obj.browse(
+                cr, uid, product_id, context=context)
+            product_name = product_obj.name_get(cr, uid, product_id,
+                                                context=context)
+            dummy, name = product_name and product_name[0] or (False,
+                                                               False)
+            if prod.description_purchase:
+                name += '\n' + prod.description_purchase
+
+            value = {'product_uom_id': prod.uom_id.id,
+                     'name': name}
+        return {'value': value}

--- a/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition_view.xml
+++ b/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition_view.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_purchase_request_line_make_purchase_requisition"
+                model="ir.ui.view">
+            <field name="name">Purchase Request Line Make Purchase Requisition</field>
+            <field name="model">purchase.request.line.make.purchase.requisition</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                 <form string="Create Purchase Bid">
+                     <separator
+                             string="Existing draft Purchase Bid to update:"/>
+                     <newline/>
+                     <group>
+                        <field name="purchase_requisition_id"/>
+                     </group>
+                     <newline/>
+                     <group>
+                         <field name="item_ids" nolabel="1" colspan="2">
+                              <tree string="Details" create="false" editable="bottom">
+                                <field name="line_id"
+                                       options="{'no_open': true}"
+                                       invisible="1"/>
+                                <field name="product_id"/>
+                                <field name="name"/>
+                                <field name="product_qty" readonly="1"/>
+                                <field name="product_uom_id" options="{'no_open': true}"/>
+                              </tree>
+                         </field>
+                     </group>
+                     <newline/>
+                     <group colspan="2">
+                         <button name="make_purchase_requisition"
+                                 string="Create Purchase Bid" type="object"
+                                 class="oe_highlight"/>
+                         <button special="cancel" string="Cancel" class="oe_link"/>
+                     </group>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_purchase_request_line_make_purchase_requisition"
+                model="ir.actions.act_window">
+            <field name="name">Create Purchase Bid</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">purchase.request.line.make.purchase.requisition</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id"
+                   ref="view_purchase_request_line_make_purchase_requisition"/>
+            <field name="target">new</field>
+        </record>
+
+        <record model="ir.values"
+                id="purchase_request_line_make_purchase_requisition">
+            <field name="model_id" ref="model_purchase_request_line" />
+            <field name="object" eval="1" />
+            <field name="name">Create Purchase Bid</field>
+            <field name="key2">client_action_multi</field>
+            <field name="value"
+                   eval="'ir.actions.act_window,' + str(ref('action_purchase_request_line_make_purchase_requisition'))" />
+            <field name="key">action</field>
+            <field name="model">purchase.request.line</field>
+        </record>
+   
+    </data>
+</openerp>
+

--- a/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition_view.xml
+++ b/purchase_request_to_requisition/wizard/purchase_request_line_make_purchase_requisition_view.xml
@@ -18,13 +18,15 @@
                      <group>
                          <field name="item_ids" nolabel="1" colspan="2">
                               <tree string="Details" create="false" editable="bottom">
-                                <field name="line_id"
+                                  <field name="request_id"/>
+                                  <field name="line_id"
                                        options="{'no_open': true}"
                                        invisible="1"/>
-                                <field name="product_id"/>
-                                <field name="name"/>
-                                <field name="product_qty" readonly="1"/>
-                                <field name="product_uom_id" options="{'no_open': true}"/>
+                                  <field name="product_id"
+                                       on_change="onchange_product_id(product_id,product_uom_id)"/>
+                                  <field name="name"/>
+                                  <field name="product_qty"/>
+                                  <field name="product_uom_id"/>
                               </tree>
                          </field>
                      </group>

--- a/purchase_request_to_rfq/__init__.py
+++ b/purchase_request_to_rfq/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import models
+from . import wizard

--- a/purchase_request_to_rfq/__openerp__.py
+++ b/purchase_request_to_rfq/__openerp__.py
@@ -29,6 +29,74 @@
     "description": """
 Purchase Request to RFQ
 =======================
+This module adds the possibility to create or update Requests for
+Quotation (RFQ) from Purchase Request Lines.
+
+Installation
+============
+
+No specific instructions required.
+
+
+Configuration
+=============
+
+No specific instructions requied.
+
+Usage
+=====
+Go to the Purchase Request Lines from the menu entry 'Purchase Requests',
+and also from the 'Purchase' menu.
+
+Select the lines that you wish to initiate the RFQ for, then go to 'More'
+and press 'Create RFQ'.
+
+You can choose to select an existing RFQ or create a new one. In the later,
+you have to choose a supplier.
+
+In case that you chose to select an existing RFQ, the application will search
+for existing lines matching the request line, and will add the extra
+quantity to them, recalculating the minimum order quantity,
+if it exists for the supplier of that RFQ.
+
+In case that you create a new RFQ, the request lines will also be
+consolidated into as few as possible lines in the RFQ.
+
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+
+Known issues / Roadmap
+======================
+
+No issues have been identified
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
     """,
     "init_xml": [],
     "update_xml": [
@@ -38,7 +106,8 @@ Purchase Request to RFQ
     ],
     'demo_xml': [],
     'test': [
-        'test/purchase_request_demo.yml',
+        'test/purchase_request_users.yml',
+        'test/purchase_request_data.yml',
         'test/purchase_request.yml',
     ],
     'installable': True,

--- a/purchase_request_to_rfq/__openerp__.py
+++ b/purchase_request_to_rfq/__openerp__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Purchase Request to RFQ",
+    "version": "1.0",
+    "author": "Eficent",
+    "website": "www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["purchase_request", "purchase", "purchase_group_hooks"],
+    "description": """
+Purchase Request to RFQ
+=======================
+    """,
+    "init_xml": [],
+    "update_xml": [
+        "wizard/purchase_request_line_make_purchase_order_view.xml",
+        "views/purchase_request_view.xml",
+        "views/purchase_order_view.xml",
+    ],
+    'demo_xml': [],
+    'test': [
+        'test/purchase_request_demo.yml',
+        'test/purchase_request.yml',
+    ],
+    'installable': True,
+    'active': False,
+    'certificate': '',
+}

--- a/purchase_request_to_rfq/models/__init__.py
+++ b/purchase_request_to_rfq/models/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import purchase_request
+from . import purchase_order
+from . import stock

--- a/purchase_request_to_rfq/models/purchase_order.py
+++ b/purchase_request_to_rfq/models/purchase_order.py
@@ -91,10 +91,12 @@ class PurchaseOrder(orm.Model):
     def _purchase_request_line_check(self, cr, uid, ids, context=None):
         for po in self.browse(cr, uid, ids, context=context):
             for line in po.order_line:
-                if line.purchase_state == 'done':
-                    raise orm.except_orm(
-                        _('Warning !'),
-                        _('Purchase Request %s has already been completed'))
+                for request_line in line.purchase_request_lines:
+                    if request_line.purchase_state == 'done':
+                        raise orm.except_orm(
+                            _('Warning !'),
+                            _('Purchase Request %s has already '
+                              'been completed'))
         return True
 
     def wkf_confirm_order(self, cr, uid, ids, context=None):

--- a/purchase_request_to_rfq/models/purchase_order.py
+++ b/purchase_request_to_rfq/models/purchase_order.py
@@ -21,6 +21,7 @@
 from openerp.osv import fields, orm
 from openerp.tools.translate import _
 
+
 class PurchaseOrder(orm.Model):
     _inherit = "purchase.order"
 
@@ -97,12 +98,10 @@ class PurchaseOrder(orm.Model):
         return True
 
     def wkf_confirm_order(self, cr, uid, ids, context=None):
-        self._purchase_request_line_check(
-                cr, uid, ids, context=context)
+        self._purchase_request_line_check(cr, uid, ids, context=context)
         res = super(PurchaseOrder, self).wkf_confirm_order(cr, uid, ids,
                                                            context=context)
-        self._purchase_request_confirm_message(
-                cr, uid, ids, context=context)
+        self._purchase_request_confirm_message(cr, uid, ids, context=context)
         return res
 
 

--- a/purchase_request_to_rfq/models/purchase_order.py
+++ b/purchase_request_to_rfq/models/purchase_order.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, orm
+from openerp.tools.translate import _
+
+class PurchaseOrder(orm.Model):
+    _inherit = "purchase.order"
+
+    def _key_fields_for_grouping_lines(self):
+        """Return a list of fields used to identify order lines that can be
+        merged.
+
+        Lines that have this fields equal can be merged.
+
+        This function can be extended by other modules to modify the list.
+        """
+        res = super(PurchaseOrder, self)._key_fields_for_grouping_lines()
+        res = list(res)
+        res.append('purchase_request_lines')
+        return tuple(res)
+
+    def _purchase_request_confirm_message_content(self, cr, uid, po,
+                                                  request, request_dict,
+                                                  context=None):
+        if not request_dict:
+            request_dict = {}
+        title = _('Order confirmation %s for your Request %s') % (
+            po.name, request.name)
+        message = '<h3>%s</h3><ul>' % title
+        message += _('The following requested items from Purchase Request %s '
+                     'have now been confirmed in Purchase Order %s:') % (
+            request.name, po.name)
+
+        for line in request_dict.values():
+            message += _(
+                '<li><b>%s</b>: Ordered quantity %s %s, Planned date %s</li>'
+            ) % (line['name'],
+                 line['product_qty'],
+                 line['product_uom'],
+                 line['date_planned'],
+                 )
+        message += '</ul>'
+        return message
+
+    def _purchase_request_confirm_message(self, cr, uid, ids, context=None):
+        request_obj = self.pool['purchase.request']
+        for po in self.browse(cr, uid, ids, context=context):
+            requests_dict = {}
+            for line in po.order_line:
+                for request_line in line.purchase_request_lines:
+                    request_id = request_line.request_id.id
+                    if request_id not in requests_dict:
+                        requests_dict[request_id] = {}
+                    date_planned = "%s" % line.date_planned
+                    data = {
+                        'name': request_line.name,
+                        'product_qty': line.product_qty,
+                        'product_uom': line.product_uom.name,
+                        'date_planned': date_planned,
+                    }
+                    requests_dict[request_id][request_line.id] = data
+            for request_id in requests_dict.keys():
+                request = request_obj.browse(cr, uid, request_id,
+                                             context=context)
+                message = self._purchase_request_confirm_message_content(
+                    cr, uid, po, request, requests_dict[request_id],
+                    context=context)
+                request_obj.message_post(cr, uid, [request_id],
+                                         body=message)
+        return True
+
+    def _purchase_request_line_check(self, cr, uid, ids, context=None):
+        for po in self.browse(cr, uid, ids, context=context):
+            for line in po.order_line:
+                if line.purchase_state == 'done':
+                    raise orm.except_orm(
+                        _('Warning !'),
+                        _('Purchase Request %s has already been completed'))
+        return True
+
+    def wkf_confirm_order(self, cr, uid, ids, context=None):
+        self._purchase_request_line_check(
+                cr, uid, ids, context=context)
+        res = super(PurchaseOrder, self).wkf_confirm_order(cr, uid, ids,
+                                                           context=context)
+        self._purchase_request_confirm_message(
+                cr, uid, ids, context=context)
+        return res
+
+
+class PurchaseOrderLine(orm.Model):
+    _inherit = "purchase.order.line"
+
+    def _has_purchase_request_lines(self, cr, uid, ids, field_names, arg,
+                                    context=None):
+        res = {}
+        for line in self.browse(cr, uid, ids, context=context):
+            if line.purchase_request_lines:
+                res[line.id] = True
+            else:
+                res[line.id] = False
+        return res
+
+    _columns = {
+        'purchase_request_lines': fields.many2many(
+            'purchase.request.line',
+            'purchase_request_purchase_order_line_rel',
+            'purchase_order_line_id',
+            'purchase_request_line_id',
+            'Purchase Request Lines', readonly=True),
+        'has_purchase_request_lines': fields.function(
+            _has_purchase_request_lines, type='boolean',
+            string="Has Purchase Request Lines")
+    }
+
+    def copy(self, cr, uid, id, default=None, context=None):
+        if default is None:
+            default = {}
+        default.update({
+            'purchase_request_lines': [],
+        })
+        return super(PurchaseOrderLine, self).copy(
+            cr, uid, id, default, context)
+
+    def action_openRequestLineTreeView(self, cr, uid, ids, context=None):
+        """
+        :return dict: dictionary value for created view
+        """
+        if context is None:
+            context = {}
+        order_line = self.browse(cr, uid, ids[0], context)
+        res = self.pool.get('ir.actions.act_window').for_xml_id(
+            cr, uid, 'purchase_request',
+            'purchase_request_line_form_action', context)
+        request_line_ids = [request_line.id for request_line
+                            in order_line.purchase_request_lines]
+        res['domain'] = "[('id', 'in', ["+','.join(
+            map(str, request_line_ids))+"])]"
+        res['nodestroy'] = False
+        return res

--- a/purchase_request_to_rfq/models/purchase_request.py
+++ b/purchase_request_to_rfq/models/purchase_request.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, orm
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+_PURCHASE_ORDER_LINE_STATE = [
+    ('none', 'No Purchase'),
+    ('draft', 'RFQ'),
+    ('confirmed', 'Confirmed'),
+    ('done', 'Done'),
+    ('cancel', 'Cancelled')
+]
+
+
+class PurchaseRequestLine(orm.Model):
+
+    _inherit = "purchase.request.line"
+
+    def _purchased_qty(self, cursor, user, ids, name, arg, context=None):
+        res = {}
+        for request_line in self.browse(cursor, user, ids, context=context):
+            purchased_qty = 0.0
+            for purchase_line in request_line.purchase_lines:
+                if purchase_line.state != 'cancel':
+                    purchased_qty += purchase_line.product_qty
+            res[request_line.id] = purchased_qty
+        return res
+
+    def _get_purchase_state(self, cr, uid, ids, names, arg, context=None):
+        res = {}
+        for line in self.browse(cr, uid, ids, context=context):
+            res[line.id] = 'none'
+            if any([po_line.state == 'done' for po_line in
+                    line.purchase_lines]):
+                res[line.id] = 'done'
+            elif all([po_line.state == 'cancel' for po_line in
+                      line.purchase_lines]):
+                res[line.id] = 'cancel'
+            elif any([po_line.state == 'confirmed' for po_line in
+                      line.purchase_lines]):
+                res[line.id] = 'confirmed'
+            elif all([po_line.state in ('draft', 'cancel') for po_line in
+                      line.purchase_lines]):
+                res[line.id] = 'draft'
+        return res
+
+    def _get_request_lines_from_po_lines(self, cr, uid, ids, context=None):
+        request_line_ids = []
+        for order_line in self.pool['purchase.order.line'].browse(
+                cr, uid, ids, context=context):
+            for request_line in order_line.purchase_request_lines:
+                request_line_ids.append(request_line.id)
+        return list(set(request_line_ids))
+
+    _columns = {
+        'purchased_qty': fields.function(_purchased_qty,
+                                         string='Quantity in RFQ or PO',
+                                         type='float'),
+        'purchase_lines': fields.many2many(
+            'purchase.order.line',
+            'purchase_request_purchase_order_line_rel',
+            'purchase_request_line_id',
+            'purchase_order_line_id',
+            'Purchase Order Lines', readonly=True),
+        'purchase_state': fields.function(
+            _get_purchase_state, string="Purchase Status",
+            type="selection",
+            selection=_PURCHASE_ORDER_LINE_STATE,
+            store={'purchase.order.line': (
+                _get_request_lines_from_po_lines,
+                ['state'], 10)}),
+    }
+
+    _defaults = {
+        'purchase_state': 'none',
+    }
+
+    def copy(self, cr, uid, id, default=None, context=None):
+        if default is None:
+            default = {}
+        default.update({
+            'purchase_lines': [],
+        })
+        return super(PurchaseRequestLine, self).copy(
+            cr, uid, id, default, context)
+
+    def _planned_date(self, request_line, delay=0.0):
+        company = request_line.company_id
+        date_planned = datetime.strptime(
+            request_line.date_required, '%Y-%m-%d') - \
+            relativedelta(days=company.po_lead)
+        if delay:
+            date_planned -= relativedelta(days=delay)
+        return date_planned and date_planned.strftime('%Y-%m-%d') \
+            or False
+
+    def _seller_details(self, cr, uid, request_line, supplier,
+                        context=None):
+        product_uom = self.pool.get('product.uom')
+        pricelist = self.pool.get('product.pricelist')
+        product = request_line.product_id
+        default_uom_po_id = product.uom_po_id.id
+        qty = product_uom._compute_qty(cr, uid,
+                                       request_line.product_uom_id.id,
+                                       request_line.product_qty,
+                                       default_uom_po_id)
+        seller_delay = 0.0
+        seller_qty = False
+        for product_supplier in product.seller_ids:
+            if supplier.id == product_supplier.name \
+                    and qty >= product_supplier.qty:
+                seller_delay = product_supplier.delay
+                seller_qty = product_supplier.qty
+        supplier_pricelist = supplier.property_product_pricelist_purchase \
+            or False
+        seller_price = pricelist.price_get(
+            cr, uid, [supplier_pricelist.id],
+            product.id, qty, supplier.id,
+            {'uom': default_uom_po_id})[supplier_pricelist.id]
+        if seller_qty:
+            qty = max(qty, seller_qty)
+        date_planned = self._planned_date(request_line,
+                                          seller_delay)
+        return seller_price, qty, default_uom_po_id, date_planned
+
+    def _calc_new_qty_price(self, cr, uid, request_line,
+                            po_line=None,
+                            cancel=False, context=None):
+        uom_obj = self.pool.get('product.uom')
+        qty = uom_obj._compute_qty(cr, uid, request_line.product_uom_id.id,
+                                   request_line.product_qty,
+                                   request_line.product_id.uom_po_id.id)
+        # Make sure we use the minimum quantity of the partner corresponding
+        # to the PO. This does not apply in case of dropshipping
+        supplierinfo_min_qty = 0.0
+        if po_line.order_id.location_id.usage != 'customer':
+            if po_line.product_id.seller_id.id == \
+                    po_line.order_id.partner_id.id:
+                supplierinfo_min_qty = po_line.product_id.seller_qty
+            else:
+                supplierinfo_obj = self.pool['product.supplierinfo']
+                supplierinfo_ids = supplierinfo_obj.search(
+                    cr, uid, [('name', '=', po_line.order_id.partner_id.id),
+                              ('product_id', '=',
+                               po_line.product_id.id)], context=context)
+                if supplierinfo_ids:
+                    supplierinfo_min_qty = supplierinfo_obj.browse(
+                        cr, uid, supplierinfo_ids, context=context).min_qty
+
+        if supplierinfo_min_qty == 0.0:
+            qty += po_line.product_qty
+        else:
+            # Recompute quantity by adding existing running procurements.
+            for rl in po_line.purchase_request_lines:
+                qty += uom_obj._compute_qty(cr, uid, rl.product_uom_id.id,
+                                            rl.product_qty,
+                                            rl.product_id.uom_po_id.id)
+            qty = max(qty, supplierinfo_min_qty) if qty > 0.0 else 0.0
+
+        price = po_line.price_unit
+        if qty != po_line.product_qty:
+            pricelist_obj = self.pool['product.pricelist']
+            pricelist_id = po_line.order_id.partner_id.\
+                property_product_pricelist_purchase.id
+            price = pricelist_obj.price_get(
+                cr, uid, [pricelist_id], request_line.product_id.id, qty,
+                po_line.order_id.partner_id.id,
+                {'uom': request_line.product_id.uom_po_id.id})[pricelist_id]
+
+        return qty, price

--- a/purchase_request_to_rfq/models/stock.py
+++ b/purchase_request_to_rfq/models/stock.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, orm
+from openerp.tools.translate import _
+
+
+class StockPicking(orm.Model):
+    _inherit = "stock.picking"
+
+    def _purchase_request_picking_confirm_message_content(self, cr, uid,
+                                                          picking, request,
+                                                          request_dict,
+                                                          context=None):
+        if not request_dict:
+            request_dict = {}
+        title = _('Receipt confirmation %s for your Request %s') % (
+            picking.name, request.name)
+        message = '<h3>%s</h3>' % title
+        message += _('The following requested items from Purchase Request %s '
+                     'have now been received in Incoming Shipment %s:') % (
+            request.name, picking.name)
+        message += '<ul>'
+        for line in request_dict.values():
+            message += _(
+                '<li><b>%s</b>: Received quantity %s %s</li>'
+            ) % (line['name'],
+                 line['product_qty'],
+                 line['product_uom'],
+                 )
+        message += '</ul>'
+        return message
+
+    def action_done(self, cr, uid, ids, context=None):
+        res = super(StockPicking, self).action_done(cr, uid, ids,
+                                                    context=context)
+        request_obj = self.pool['purchase.request']
+        for picking in self.browse(cr, uid, ids, context=context):
+            requests_dict = {}
+            if picking.type != 'in':
+                continue
+            for move in picking.move_lines:
+                if move.purchase_line_id:
+                    for request_line in \
+                            move.purchase_line_id.purchase_request_lines:
+                        request_id = request_line.request_id.id
+                        if request_id not in requests_dict:
+                            requests_dict[request_id] = {}
+                        data = {
+                            'name': request_line.name,
+                            'product_qty': move.product_qty,
+                            'product_uom': move.product_uom.name,
+                        }
+                        requests_dict[request_id][request_line.id] = data
+                for request_id in requests_dict.keys():
+                    request = request_obj.browse(cr, uid, request_id,
+                                                 context=context)
+                    message = \
+                        self._purchase_request_picking_confirm_message_content(
+                            cr, uid, picking, request,
+                            requests_dict[request_id], context=context)
+                    request_obj.message_post(cr, uid, [request_id],
+                                             body=message)
+        return res

--- a/purchase_request_to_rfq/models/stock.py
+++ b/purchase_request_to_rfq/models/stock.py
@@ -69,13 +69,13 @@ class StockPicking(orm.Model):
                             'product_uom': move.product_uom.name,
                         }
                         requests_dict[request_id][request_line.id] = data
-                for request_id in requests_dict.keys():
-                    request = request_obj.browse(cr, uid, request_id,
-                                                 context=context)
-                    message = \
-                        self._purchase_request_picking_confirm_message_content(
-                            cr, uid, picking, request,
-                            requests_dict[request_id], context=context)
-                    request_obj.message_post(cr, uid, [request_id],
-                                             body=message)
+            for request_id in requests_dict.keys():
+                request = request_obj.browse(cr, uid, request_id,
+                                             context=context)
+                message = \
+                    self._purchase_request_picking_confirm_message_content(
+                        cr, uid, picking, request,
+                        requests_dict[request_id], context=context)
+                request_obj.message_post(cr, uid, [request_id],
+                                         body=message)
         return res

--- a/purchase_request_to_rfq/test/purchase_request.yml
+++ b/purchase_request_to_rfq/test/purchase_request.yml
@@ -33,7 +33,8 @@
     for rfq_line in rfq.order_line:
         for line in request.line_ids:
             if rfq_line.product_id.id == line.product_id.id:
-                seller_price, qty, default_uom_po_id, date_planned = request_line_obj._seller_details(cr, uid, line, supplier, context=context)
+
+                seller_price, qty, default_uom_po_id, date_planned = request_line_obj._seller_details(cr, uid, line, line.product_id, line.product_qty, line.product_uom_id, supplier, context=context)
                 assert rfq_line.product_qty == qty, "Quantity does not match."
                 assert rfq_line.product_uom.id == default_uom_po_id, "UOM does not match."
                 assert rfq_line.price_unit == seller_price, "Unit Price does not match."

--- a/purchase_request_to_rfq/test/purchase_request.yml
+++ b/purchase_request_to_rfq/test/purchase_request.yml
@@ -1,0 +1,36 @@
+-
+  I open a request.
+-
+  I create an RFQ.
+-
+  !python {model: purchase.request.line.make.purchase.order}: |
+    context.update({"active_model": "purchase.request.line","active_ids": [ref("request1")],"active_id": ref("request1")})
+-
+  !record {model: purchase.request.line.make.purchase.order, id: request_line_make_po_0}:
+    supplier_id: base.res_partner_12
+-
+  !python {model: purchase.request.line.make.purchase.order}: |
+    self.make_purchase_order(cr, uid, [ref("request_line_make_po_0")], context=context)
+-
+  I check that the RFQ details which created for supplier.
+-
+  !python {model: purchase.order.line}: |
+    request_obj = self.pool["purchase.request"]
+    request_line_obj = self.pool["purchase.request.line"]
+    request = request_obj.browse(cr, uid, ref("request1"), context=context)
+    rfq_line = False
+    for pr_line in request.line_ids:
+        assert len(pr_line.purchase_lines) == 1, "No purchase order line was created."
+        for po_line in pr_line.purchase_lines:
+            rfq_line = po_line
+    rfq = rfq_line.order_id
+    supplier = rfq.partner_id
+    assert supplier.id == ref('base.res_partner_12'), "RFQ Partner does not match."
+    assert len(rfq.order_line) == len(request.line_ids), "Lines do not match."
+    for rfq_line in rfq.order_line:
+        for line in request.line_ids:
+            if rfq_line.product_id.id == line.product_id.id:
+                seller_price, qty, default_uom_po_id, date_planned = request_line_obj._seller_details(cr, uid, line, supplier, context=context)
+                assert rfq_line.product_qty == qty, "Quantity does not match."
+                assert rfq_line.product_uom.id == default_uom_po_id, "UOM does not match."
+                assert rfq_line.price_unit == seller_price, "Unit Price does not match."

--- a/purchase_request_to_rfq/test/purchase_request.yml
+++ b/purchase_request_to_rfq/test/purchase_request.yml
@@ -1,10 +1,13 @@
 -
-  I open a request.
+  I log as the Purchase User
+-
+  !context
+    uid: 'res_users_purchase_user'
 -
   I create an RFQ.
 -
   !python {model: purchase.request.line.make.purchase.order}: |
-    context.update({"active_model": "purchase.request.line","active_ids": [ref("request1")],"active_id": ref("request1")})
+    context.update({"active_model": "purchase.request.line","active_ids": [ref("request_line1")],"active_id": ref("request_line1")})
 -
   !record {model: purchase.request.line.make.purchase.order, id: request_line_make_po_0}:
     supplier_id: base.res_partner_12
@@ -34,3 +37,4 @@
                 assert rfq_line.product_qty == qty, "Quantity does not match."
                 assert rfq_line.product_uom.id == default_uom_po_id, "UOM does not match."
                 assert rfq_line.price_unit == seller_price, "Unit Price does not match."
+                assert rfq_line.state == line.purchase_state, "State does not match"

--- a/purchase_request_to_rfq/test/purchase_request_data.yml
+++ b/purchase_request_to_rfq/test/purchase_request_data.yml
@@ -1,0 +1,9 @@
+-
+  !record {model: purchase.request, id: request1}:
+    warehouse_id: stock.stock_warehouse_shop0
+-
+  !record {model: purchase.request.line, id: request_line1}:
+    request_id: request1
+    product_id: product.product_product_13
+    product_uom_id: product.product_uom_unit
+    product_qty: 5.0

--- a/purchase_request_to_rfq/test/purchase_request_demo.yml
+++ b/purchase_request_to_rfq/test/purchase_request_demo.yml
@@ -1,0 +1,9 @@
+-
+  In order to test process of the purchase request ,I create a request
+- 
+  !record {model: purchase.request, id: request2}:
+    line_ids:
+      - product_id: product.product_product_9
+        product_qty: 10.0
+        product_uom_id: product.product_uom_unit
+  

--- a/purchase_request_to_rfq/test/purchase_request_users.yml
+++ b/purchase_request_to_rfq/test/purchase_request_users.yml
@@ -1,0 +1,16 @@
+-
+   Create a user as 'Purchase User and Request Manager'
+-
+  !record {model: res.users, id: res_users_purchase_user}:
+    company_id: base.main_company
+    name: Purchase User
+    login: prm
+    password: prm
+    email: purchase_user_manager@yourcompany.com
+-
+  I added groups for Purchase User and Request User.
+-
+  !record {model: res.users, id: res_users_purchase_user}:
+    groups_id:
+      - purchase.group_purchase_user
+      - purchase_request.group_purchase_request_manager

--- a/purchase_request_to_rfq/views/purchase_order_view.xml
+++ b/purchase_request_to_rfq/views/purchase_order_view.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="purchase_order_form" model="ir.ui.view">
+            <field name="name">purchase.order.form</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='order_line']/tree"
+                       position="inside">
+                    <field name="has_purchase_request_lines" invisible="1"/>
+                    <button string="Purchase Request lines"
+                        attrs="{'invisible':[('has_purchase_request_lines','=',False)]}"
+                        name="action_openRequestLineTreeView"
+                        type="object"
+                        icon="gtk-open"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="purchase_order_line_form" model="ir.ui.view">
+            <field name="name">purchase.order.line.form</field>
+            <field name="model">purchase.order.line</field>
+            <field name="inherit_id" ref="purchase.purchase_order_line_form"/>
+            <field name="arch" type="xml">
+                <notebook position="inside">
+                    <page name="purchase_request_lines"
+                          string="Purchase Request Lines">
+                            <field name="purchase_request_lines"/>
+                        </page>
+                </notebook>
+            </field>
+        </record>
+
+        <record id="purchase_order_line_form2" model="ir.ui.view">
+            <field name="name">purchase.order.line.form2</field>
+            <field name="model">purchase.order.line</field>
+            <field name="inherit_id" ref="purchase.purchase_order_line_form2"/>
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                    <separator string="Purchase Request Lines"/>
+                    <field name="purchase_request_lines"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="purchase_order_line_tree" model="ir.ui.view">
+            <field name="name">purchase.order.line.tree</field>
+            <field name="model">purchase.order.line</field>
+            <field name="inherit_id" ref="purchase.purchase_order_line_tree"/>
+            <field name="arch" type="xml">
+                <tree position="inside">
+                    <field name="has_purchase_request_lines" invisible="1"/>
+                    <button string="Purchase Request lines"
+                        attrs="{'invisible':[('has_purchase_request_lines','=',False)]}"
+                        name="action_openRequestLineTreeView"
+                        type="object"
+                        icon="gtk-open"/>
+                </tree>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_request_to_rfq/views/purchase_request_view.xml
+++ b/purchase_request_to_rfq/views/purchase_request_view.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="view_purchase_request_form">
+            <field name="name">purchase.request.form</field>
+            <field name="model">purchase.request</field>
+            <field name="inherit_id"
+                   ref="purchase_request.view_purchase_request_form"/>
+            <field name="arch" type="xml">
+                <xpath
+                        expr="//field[@name='line_ids']/tree//field[@name='date_required']"
+                        position="after">
+                    <field name="purchased_qty"/>
+                    <field name="purchase_state"/>
+                </xpath>
+                <xpath
+                        expr="//field[@name='line_ids']/form//group[@name='follow_up']"
+                        position="inside">
+                    <newline/>
+                    <separator string="Purchase Order Lines"/>
+                    <newline/>
+                    <field name="purchase_lines" nolabel="1">
+                        <tree string="Purchase Order Lines">
+                            <field name="order_id"/>
+                            <field name="product_id"/>
+                            <field name="name"/>
+                            <field name="account_analytic_id"
+                                   groups="purchase.group_analytic_accounting"
+                                   domain="[('type','not in',('view','template'))]"/>
+                            <field name="product_qty"/>
+                            <field name="product_uom"
+                                   groups="product.group_uom"/>
+                            <field name="state"/>
+                        </tree>
+                    </field>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="purchase_request_line_tree" model="ir.ui.view">
+            <field name="name">purchase.request.line.tree</field>
+            <field name="model">purchase.request.line</field>
+            <field name="inherit_id"
+                   ref="purchase_request.purchase_request_line_tree"/>
+            <field name="arch" type="xml">
+                <field name="date_required" position="after">
+                    <field name="purchased_qty"/>
+                    <field name="purchase_state"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="purchase_request_line_form" model="ir.ui.view">
+            <field name="name">purchase.request.line.form</field>
+            <field name="model">purchase.request.line</field>
+            <field name="inherit_id"
+                   ref="purchase_request.purchase_request_line_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='date_required']"
+                       position="after">
+                    <field name="purchased_qty"/>
+                    <field name="purchase_state"/>
+                </xpath>
+                <xpath expr="//group[@name='follow_up']" position="inside">
+                    <newline/>
+                    <separator string="Purchase Order Lines"/>
+                    <newline/>
+                    <field name="purchase_lines" nolabel="1">
+                        <tree string="Purchase Order Lines">
+                            <field name="order_id"/>
+                            <field name="product_id"/>
+                            <field name="name"/>
+                            <field name="account_analytic_id"
+                                   groups="purchase.group_analytic_accounting"
+                                   domain="[('type','not in',('view','template'))]"/>
+                            <field name="product_qty"/>
+                            <field name="product_uom"
+                                   groups="product.group_uom"/>
+                            <field name="state"/>
+                        </tree>
+                    </field>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="purchase_request_line_search" model="ir.ui.view">
+            <field name="name">purchase.request.line.search</field>
+            <field name="model">purchase.request.line</field>
+            <field name="inherit_id" ref="purchase_request.purchase_request_line_search"/>
+            <field name="arch" type="xml">
+                    <field name="date_required" position="after">
+                        <filter name="purchase_state_none"
+                                string="No Purchase"
+                                domain="[('purchase_state','=','none')]"
+                                help="No RFQ or Purchase has been created"/>
+                        <filter name="purchase_state_draft"
+                                string="Requested for Quotation"
+                                domain="[('purchase_state','=','draft')]"
+                                help="At least a Draft PO has been created"/>
+                        <filter name="purchase_state_confirmed"
+                                string="Purchase Confirmed"
+                                domain="[('purchase_state','=','confirmed')]"
+                                help="At least a PO has been confirmed"/>
+                        <filter name="purchase_state_done"
+                                string="Purchase Done"
+                                domain="[('purchase_state','=','done')]"
+                                help="At least a PO has been completed"/>
+                    </field>
+                    <group position="inside">
+                        <filter string="Purchase Status"
+                                domain="[]" context="{'group_by':'purchase_state'}"/>
+                        <filter string="Request"
+                                domain="[]" context="{'group_by':'request_id'}"/>
+                    </group>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_request_to_rfq/views/purchase_request_view.xml
+++ b/purchase_request_to_rfq/views/purchase_request_view.xml
@@ -8,32 +8,37 @@
             <field name="inherit_id"
                    ref="purchase_request.view_purchase_request_form"/>
             <field name="arch" type="xml">
-                <xpath
-                        expr="//field[@name='line_ids']/tree//field[@name='date_required']"
-                        position="after">
+                <xpath expr="//field[@name='line_ids']/tree"
+                       position="inside">
                     <field name="purchased_qty"/>
                     <field name="purchase_state"/>
                 </xpath>
-                <xpath
-                        expr="//field[@name='line_ids']/form//group[@name='follow_up']"
-                        position="inside">
-                    <newline/>
-                    <separator string="Purchase Order Lines"/>
-                    <newline/>
-                    <field name="purchase_lines" nolabel="1">
-                        <tree string="Purchase Order Lines">
-                            <field name="order_id"/>
-                            <field name="product_id"/>
-                            <field name="name"/>
-                            <field name="account_analytic_id"
-                                   groups="purchase.group_analytic_accounting"
-                                   domain="[('type','not in',('view','template'))]"/>
-                            <field name="product_qty"/>
-                            <field name="product_uom"
-                                   groups="product.group_uom"/>
-                            <field name="state"/>
-                        </tree>
-                    </field>
+                <xpath expr="//field[@name='line_ids']/form//notebook"
+                       position="inside">
+                    <page name="purchase_lines"
+                          string="Purchase Order Lines">
+                        <group>
+                            <field name="purchased_qty"/>
+                            <field name="purchase_state"/>
+                        </group>
+                        <newline/>
+                        <group>
+                            <field name="purchase_lines" nolabel="1">
+                                <tree string="Purchase Order Lines">
+                                    <field name="order_id"/>
+                                    <field name="product_id"/>
+                                    <field name="name"/>
+                                    <field name="account_analytic_id"
+                                           groups="purchase.group_analytic_accounting"
+                                           domain="[('type','not in',('view','template'))]"/>
+                                    <field name="product_qty"/>
+                                    <field name="product_uom"
+                                           groups="product.group_uom"/>
+                                    <field name="state"/>
+                                </tree>
+                            </field>
+                        </group>
+                    </page>
                 </xpath>
             </field>
         </record>
@@ -57,30 +62,45 @@
             <field name="inherit_id"
                    ref="purchase_request.purchase_request_line_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='date_required']"
-                       position="after">
-                    <field name="purchased_qty"/>
-                    <field name="purchase_state"/>
-                </xpath>
-                <xpath expr="//group[@name='follow_up']" position="inside">
-                    <newline/>
-                    <separator string="Purchase Order Lines"/>
-                    <newline/>
-                    <field name="purchase_lines" nolabel="1">
-                        <tree string="Purchase Order Lines">
-                            <field name="order_id"/>
-                            <field name="product_id"/>
-                            <field name="name"/>
-                            <field name="account_analytic_id"
-                                   groups="purchase.group_analytic_accounting"
-                                   domain="[('type','not in',('view','template'))]"/>
-                            <field name="product_qty"/>
-                            <field name="product_uom"
-                                   groups="product.group_uom"/>
-                            <field name="state"/>
-                        </tree>
-                    </field>
-                </xpath>
+                <notebook position="inside">
+                    <group>
+                        <field name="purchased_qty"/>
+                        <field name="purchase_state"/>
+                    </group>
+                    <group>
+                        <page name="purchase_lines"
+                              string="Purchase Order Lines">
+                            <group>
+                                <field name="purchase_lines" nolabel="1">
+                                    <tree string="Purchase Order Lines">
+                                        <field name="order_id"/>
+                                        <field name="product_id"/>
+                                        <field name="name"/>
+                                        <field name="account_analytic_id"
+                                               groups="purchase.group_analytic_accounting"
+                                               domain="[('type','not in',('view','template'))]"/>
+                                        <field name="product_qty"/>
+                                        <field name="product_uom"
+                                               groups="product.group_uom"/>
+                                        <field name="state"/>
+                                    </tree>
+                                    <form string="Purchase Order Lines">
+                                        <field name="order_id"/>
+                                        <field name="product_id"/>
+                                        <field name="name"/>
+                                        <field name="account_analytic_id"
+                                               groups="purchase.group_analytic_accounting"
+                                               domain="[('type','not in',('view','template'))]"/>
+                                        <field name="product_qty"/>
+                                        <field name="product_uom"
+                                               groups="product.group_uom"/>
+                                        <field name="state"/>
+                                    </form>
+                                </field>
+                            </group>
+                        </page>
+                    </group>
+                </notebook>
             </field>
         </record>
 

--- a/purchase_request_to_rfq/views/purchase_request_view.xml
+++ b/purchase_request_to_rfq/views/purchase_request_view.xml
@@ -63,13 +63,13 @@
                    ref="purchase_request.purchase_request_line_form"/>
             <field name="arch" type="xml">
                 <notebook position="inside">
-                    <group>
-                        <field name="purchased_qty"/>
-                        <field name="purchase_state"/>
-                    </group>
-                    <group>
-                        <page name="purchase_lines"
-                              string="Purchase Order Lines">
+                    <page name="purchase_lines"
+                          string="Purchase Order Lines">
+                        <group>
+                            <field name="purchased_qty"/>
+                            <field name="purchase_state"/>
+                        </group>
+                        <group>
                             <group>
                                 <field name="purchase_lines" nolabel="1">
                                     <tree string="Purchase Order Lines">
@@ -98,8 +98,8 @@
                                     </form>
                                 </field>
                             </group>
-                        </page>
-                    </group>
+                        </group>
+                    </page>
                 </notebook>
             </field>
         </record>

--- a/purchase_request_to_rfq/views/purchase_request_view.xml
+++ b/purchase_request_to_rfq/views/purchase_request_view.xml
@@ -111,7 +111,7 @@
             <field name="arch" type="xml">
                     <field name="date_required" position="after">
                         <filter name="purchase_state_none"
-                                string="No Purchase"
+                                string="Purchasing not started"
                                 domain="[('purchase_state','=','none')]"
                                 help="No RFQ or Purchase has been created"/>
                         <filter name="purchase_state_draft"

--- a/purchase_request_to_rfq/wizard/__init__.py
+++ b/purchase_request_to_rfq/wizard/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import purchase_request_line_make_purchase_order

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -148,6 +148,12 @@ class PurchaseRequestLineMakePurchaseOrder(orm.TransientModel):
             'purchase_request_lines': [(4, item.line_id.id)]
         }
 
+    def _get_order_line_search_domain(self, cr, uid, order_id, request_line,
+                                      context=None):
+        return [('requisition_id', '=', order_id),
+                ('product_id', '=', request_line.product_id.id),
+                ('product_uom_id', '=', request_line.product_uom_id.id)]
+
     def make_purchase_order(self, cr, uid, ids, context=None):
         if context is None:
             context = {}
@@ -209,13 +215,10 @@ class PurchaseRequestLineMakePurchaseOrder(orm.TransientModel):
             # Look for any other PO line in the selected PO with same
             # product and UoM to sum quantities instead of creating a new
             # po line
+            domain = self._get_order_line_search_domain(
+                cr, uid, purchase_id, line, context=context)
             available_po_line_ids = po_line_obj.search(
-                cr, uid, [('order_id', '=', purchase_id),
-                          ('product_id', '=', line.product_id.id),
-                          ('product_uom', '=', line.product_uom_id.id),
-                          ('state', '!=', 'cancel'),
-                          ('move_dest_id', '=', False)],
-                context=context)
+                cr, uid, domain, context=context)
             if available_po_line_ids:
                 po_line = po_line_obj.browse(
                     cr, uid, available_po_line_ids[0], context=context)

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.tools.translate import _
+from openerp.osv import fields, orm
+import openerp.addons.decimal_precision as dp
+
+
+class PurchaseRequestLineMakePurchaseOrder(orm.TransientModel):
+    _name = "purchase.request.line.make.purchase.order"
+    _description = "Purchase Request Line Make Purchase Order"
+
+    _columns = {
+        'supplier_id': fields.many2one('res.partner', 'Supplier',
+                                       required=False,
+                                       domain=[('supplier', '=', True)]),
+        'item_ids': fields.one2many(
+            'purchase.request.line.make.purchase.order.item',
+            'wiz_id', 'Items'),
+        'purchase_order_id': fields.many2one('purchase.order',
+                                             'Purchase Order',
+                                             required=False,
+                                             domain=[('state', '=', 'draft')]),
+    }
+
+    def _default_warehouse(self, cr, uid, context=None):
+        warehouse_obj = self.pool.get('stock.warehouse')
+        company_obj = self.pool.get('res.company')
+        company_id = company_obj._company_default_get(cr, uid,
+                                                      'stock.warehouse',
+                                                      context=context)
+        if context is None:
+            context = {}
+
+        warehouse_ids = warehouse_obj.search(
+            cr, uid, [('company_id', '=', company_id)], limit=1,
+            context=context) or []
+
+        if warehouse_ids:
+            return warehouse_ids[0]
+        else:
+            return False
+
+    def _prepare_item(self, cr, uid, line, context=None):
+        return [{
+            'line_id': line.id,
+            'product_id': line.product_id.id,
+            'name': line.name,
+            'product_qty': line.product_qty,
+            'product_uom_id': line.product_uom_id.id,
+            'account_analytic_id': line.analytic_account_id.id,
+        }]
+
+    def default_get(self, cr, uid, fields, context=None):
+        res = super(PurchaseRequestLineMakePurchaseOrder, self).default_get(
+            cr, uid, fields, context=context)
+        request_line_obj = self.pool['purchase.request.line']
+        request_line_ids = context.get('active_ids', [])
+        active_model = context.get('active_model')
+
+        if not request_line_ids:
+            return res
+        assert active_model == 'purchase.request.line', \
+            'Bad context propagation'
+
+        items = []
+        for line in request_line_obj.browse(cr, uid, request_line_ids,
+                                            context=context):
+                items += self._prepare_item(cr, uid, line, context=context)
+        res['item_ids'] = items
+
+        return res
+
+    def _prepare_purchase_order(self, cr, uid, make_purchase_order,
+                                warehouse_id, company_id,
+                                context=None):
+        warehouse_obj = self.pool['stock.warehouse']
+        if not make_purchase_order.supplier_id:
+                raise orm.except_orm(
+                    _('Could not create purchase order !'),
+                    _('Enter a supplier.'))
+        warehouse = warehouse_obj.browse(cr, uid, warehouse_id,
+                                         context=context)
+        supplier = make_purchase_order.supplier_id
+        location_id = warehouse.lot_input_id.id
+        supplier_pricelist = supplier.property_product_pricelist_purchase \
+            or False
+        data = {
+            'origin': '',
+            'partner_id': make_purchase_order.supplier_id.id,
+            'pricelist_id': supplier_pricelist.id,
+            'location_id': location_id,
+            'fiscal_position': supplier.property_account_position and
+            supplier.property_account_position.id or False,
+            'warehouse_id': warehouse_id,
+            'company_id': company_id,
+            }
+        return data
+
+    def _prepare_purchase_order_line(self, cr, uid, po_id,
+                                     make_purchase_order, item,
+                                     context=None):
+        fiscal_position = self.pool['account.fiscal.position']
+        purchase_req_line_obj = self.pool['purchase.request.line']
+        po_obj = self.pool['purchase.order']
+        if po_id:
+            po = po_obj.browse(cr, uid, po_id, context=context)
+            supplier = po.partner_id
+        else:
+            supplier = make_purchase_order.supplier_id
+        product = item.product_id
+        seller_price, qty, default_uom_po_id, date_planned = \
+            purchase_req_line_obj._seller_details(cr, uid, item.line_id,
+                                                  supplier, context=context)
+        taxes_ids = product.supplier_taxes_id
+        taxes = fiscal_position.map_tax(
+            cr, uid, supplier.property_account_position, taxes_ids)
+
+        analytic_id = item.line_id.analytic_account_id and \
+            item.line_id.analytic_account_id.id or False
+        return {
+            'order_id': po_id,
+            'name': product.partner_ref,
+            'product_qty': qty,
+            'product_id': product.id,
+            'product_uom': default_uom_po_id,
+            'price_unit': seller_price,
+            'date_planned': date_planned,
+            'taxes_id': [(6, 0, taxes)],
+            'account_analytic_id': analytic_id,
+            'purchase_request_lines': [(4, item.line_id.id)]
+        }
+
+    def make_purchase_order(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        res = []
+        make_purchase_order = self.browse(cr, uid, ids[0], context=context)
+        purchase_obj = self.pool['purchase.order']
+        po_line_obj = self.pool['purchase.order.line']
+        pr_line_obj = self.pool['purchase.request.line']
+        company_id = False
+        warehouse_id = False
+        purchase_id = False
+        for item in make_purchase_order.item_ids:
+            line = item.line_id
+            if line.purchase_state == 'done':
+                raise orm.except_orm(
+                    _('Could not process !'),
+                    _('The purchase has already been completed.'))
+            if item.product_qty <= 0.0:
+                raise orm.except_orm(
+                    _('Could not process !'),
+                    _('Enter a positive quantity.'))
+            line_company_id = line.company_id \
+                and line.company_id.id or False
+            if company_id is not False \
+                    and line_company_id != company_id:
+                raise orm.except_orm(
+                    _('Could not process !'),
+                    _('You have to select lines '
+                      'from the same company.'))
+            else:
+                company_id = line_company_id
+
+            line_warehouse_id = line.request_id.warehouse_id \
+                and line.request_id.warehouse_id.id or False
+            if not line_warehouse_id:
+                raise orm.except_orm(
+                    _('Could not process !'),
+                    _('You have to enter a Warehouse.'))
+            if warehouse_id is not False \
+                    and line_warehouse_id != warehouse_id:
+                raise orm.except_orm(
+                    _('Could not process !'),
+                    _('You have to select lines '
+                      'from the same Warehouse.'))
+            else:
+                warehouse_id = line_warehouse_id
+
+            if make_purchase_order.purchase_order_id:
+                purchase_id = make_purchase_order.purchase_order_id.id
+            if not purchase_id:
+                po_data = self._prepare_purchase_order(cr, uid,
+                                                       make_purchase_order,
+                                                       warehouse_id,
+                                                       company_id,
+                                                       context=context)
+                purchase_id = purchase_obj.create(cr, uid, po_data,
+                                                  context=context)
+
+            # Look for any other PO line in the selected PO with same
+            # product and UoM to sum quantities instead of creating a new
+            # po line
+            available_po_line_ids = po_line_obj.search(
+                cr, uid, [('order_id', '=', purchase_id),
+                          ('product_id', '=', line.product_id.id),
+                          ('product_uom', '=', line.product_uom_id.id),
+                          ('state', '!=', 'cancel'),
+                          ('move_dest_id', '=', False)],
+                context=context)
+            if available_po_line_ids:
+                po_line = po_line_obj.browse(
+                    cr, uid, available_po_line_ids[0], context=context)
+                new_qty, new_price = pr_line_obj._calc_new_qty_price(
+                        cr, uid, line, po_line=po_line,
+                        context=context)
+                if new_qty > po_line.product_qty:
+                        po_line_obj.write(
+                            cr, uid, po_line.id,
+                            {'product_qty': new_qty,
+                             'price_unit': new_price},
+                            context=context)
+            else:
+                po_line_data = self._prepare_purchase_order_line(
+                    cr, uid, purchase_id, make_purchase_order,
+                    item, context=context)
+                po_line_obj.create(cr, uid, po_line_data, context=context)
+            res.append(purchase_id)
+
+        return {
+            'domain': "[('id','in', ["+','.join(map(str, res))+"])]",
+            'name': _('Purchase order'),
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'purchase.order',
+            'view_id': False,
+            'context': False,
+            'type': 'ir.actions.act_window'
+        }
+
+
+class PurchaseRequestLineMakePurchaseOrderItem(orm.TransientModel):
+    _name = "purchase.request.line.make.purchase.order.item"
+    _description = "Purchase Request Line Make Purchase Order Item"
+
+    _columns = {
+        'wiz_id': fields.many2one(
+            'purchase.request.line.make.purchase.order',
+            'Wizard', required=True, ondelete='cascade',
+            readonly=True),
+        'line_id': fields.many2one('purchase.request.line',
+                                   'Purchase Request Line',
+                                   required=True,
+                                   readonly=True),
+        'product_id': fields.related('line_id',
+                                     'product_id', type='many2one',
+                                     relation='product.product',
+                                     string='Product',
+                                     readonly=True),
+        'product_qty': fields.float(string='Quantity to deliver',
+                                    digits_compute=dp.get_precision(
+                                        'Product UoS')),
+        'product_uom_id': fields.related('line_id',
+                                         'product_uom_id', type='many2one',
+                                         relation='product.uom',
+                                         string='UoM',
+                                         readonly=True),
+        'name': fields.related('line_id',
+                               'name', type='char',
+                               string='Description',
+                               readonly=True)
+
+    }

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_purchase_request_line_make_purchase_order" model="ir.ui.view">
+            <field name="name">Purchase Request Line Make Purchase Order</field>
+            <field name="model">purchase.request.line.make.purchase.order</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                 <form string="Create Purchase Order">
+                     <separator string="Existing draft PO to update:"/>
+                     <newline/>
+                     <group>
+                        <field name="purchase_order_id"/>
+                     </group>
+                     <newline/>
+                     <separator
+                             string="New PO details:"/>
+                     <newline/>
+                     <group>
+                         <field name="supplier_id"/>
+                     </group>
+                     <newline/>
+                     <group>
+                         <field name="item_ids" nolabel="1" colspan="2">
+                              <tree string="Details" create="false" editable="bottom">
+                                <field name="line_id"
+                                       options="{'no_open': true}"
+                                       invisible="1"/>
+                                <field name="product_id"/>
+                                <field name="name"/>
+                                <field name="product_qty" readonly="1"/>
+                                <field name="product_uom_id" options="{'no_open': true}"/>
+                              </tree>
+                         </field>
+                     </group>
+                     <newline/>
+                     <group colspan="2">
+                         <button name="make_purchase_order"
+                                 string="Create Purchase Order" type="object"
+                                 class="oe_highlight"/>
+                         <button special="cancel" string="Cancel" class="oe_link"/>
+                     </group>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_purchase_request_line_make_purchase_order" model="ir.actions.act_window">
+            <field name="name">Create Purchase Order</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">purchase.request.line.make.purchase.order</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="view_purchase_request_line_make_purchase_order"/>
+            <field name="target">new</field>
+        </record>
+
+        <record model="ir.values" id="purchase_request_line_make_purchase_order">
+            <field name="model_id" ref="model_purchase_request_line" />
+            <field name="object" eval="1" />
+            <field name="name">Create Purchase Order</field>
+            <field name="key2">client_action_multi</field>
+            <field name="value" eval="'ir.actions.act_window,' + str(ref('action_purchase_request_line_make_purchase_order'))" />
+            <field name="key">action</field>
+            <field name="model">purchase.request.line</field>
+        </record>
+   
+    </data>
+</openerp>
+

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -6,15 +6,15 @@
             <field name="model">purchase.request.line.make.purchase.order</field>
             <field name="type">form</field>
             <field name="arch" type="xml">
-                 <form string="Create Purchase Order">
-                     <separator string="Existing draft PO to update:"/>
+                 <form string="Create RFQ">
+                     <separator string="Existing RFQ to update:"/>
                      <newline/>
                      <group>
                         <field name="purchase_order_id"/>
                      </group>
                      <newline/>
                      <separator
-                             string="New PO details:"/>
+                             string="New RFQ details:"/>
                      <newline/>
                      <group>
                          <field name="supplier_id"/>
@@ -39,7 +39,7 @@
                      <newline/>
                      <group colspan="2">
                          <button name="make_purchase_order"
-                                 string="Create Purchase Order" type="object"
+                                 string="Create RFQ" type="object"
                                  class="oe_highlight"/>
                          <button special="cancel" string="Cancel" class="oe_link"/>
                      </group>
@@ -48,7 +48,7 @@
         </record>
 
         <record id="action_purchase_request_line_make_purchase_order" model="ir.actions.act_window">
-            <field name="name">Create Purchase Order</field>
+            <field name="name">Create Request for Quotation</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">purchase.request.line.make.purchase.order</field>
             <field name="view_type">form</field>
@@ -60,7 +60,7 @@
         <record model="ir.values" id="purchase_request_line_make_purchase_order">
             <field name="model_id" ref="model_purchase_request_line" />
             <field name="object" eval="1" />
-            <field name="name">Create RFQ</field>
+            <field name="name">Create Request for Quotation</field>
             <field name="key2">client_action_multi</field>
             <field name="value" eval="'ir.actions.act_window,' + str(ref('action_purchase_request_line_make_purchase_order'))" />
             <field name="key">action</field>

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -57,7 +57,7 @@
         <record model="ir.values" id="purchase_request_line_make_purchase_order">
             <field name="model_id" ref="model_purchase_request_line" />
             <field name="object" eval="1" />
-            <field name="name">Create Purchase Order</field>
+            <field name="name">Create RFQ</field>
             <field name="key2">client_action_multi</field>
             <field name="value" eval="'ir.actions.act_window,' + str(ref('action_purchase_request_line_make_purchase_order'))" />
             <field name="key">action</field>

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -23,13 +23,16 @@
                      <group>
                          <field name="item_ids" nolabel="1" colspan="2">
                               <tree string="Details" create="false" editable="bottom">
-                                <field name="line_id"
+                                  <field name="line_id"
                                        options="{'no_open': true}"
                                        invisible="1"/>
-                                <field name="product_id"/>
-                                <field name="name"/>
-                                <field name="product_qty" readonly="1"/>
-                                <field name="product_uom_id" options="{'no_open': true}"/>
+                                  <field name="request_id"/>
+                                  <field name="product_id"
+                                         on_change="onchange_product_id(product_id,product_uom_id)"/>
+                                  <field name="name"/>
+                                  <field name="product_qty"/>
+                                  <field name="product_uom_id"
+                                         groups="product.group_uom"/>
                               </tree>
                          </field>
                      </group>

--- a/purchase_request_webkit/__init__.py
+++ b/purchase_request_webkit/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import report

--- a/purchase_request_webkit/__openerp__.py
+++ b/purchase_request_webkit/__openerp__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Purchase Request Webkit Report",
+    "version": "1.0",
+    "author": "Eficent",
+    "website": "www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["purchase_request",
+                "base_headers_webkit"],
+    "description": """
+Purchase Request Webkit
+=======================
+Report to print purchase requests.
+
+    """,
+    "init_xml": [],
+    "update_xml": [
+        "report/purchase_request_report_view.xml",
+    ],
+    'demo_xml': [],
+    'test': [],
+    'installable': True,
+    'active': False,
+    'certificate': '',
+}

--- a/purchase_request_webkit/report/__init__.py
+++ b/purchase_request_webkit/report/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################

--- a/purchase_request_webkit/report/purchase_request.mako
+++ b/purchase_request_webkit/report/purchase_request.mako
@@ -1,0 +1,172 @@
+## -*- coding: utf-8 -*-
+<html>
+<head>
+     <style type="text/css">
+        ${css}
+
+.list_main_table {
+border:thin solid #E3E4EA;
+text-align:center;
+border-collapse: collapse;
+}
+table.list_main_table {
+    margin-top: 20px;
+}
+.list_main_headers {
+    padding: 0;
+}
+.list_main_headers th {
+    border: thin solid #000000;
+    padding-right:3px;
+    padding-left:3px;
+    background-color: #EEEEEE;
+    text-align:center;
+    font-size:12;
+    font-weight:bold;
+}
+.list_main_table td {
+    padding-right:3px;
+    padding-left:3px;
+    padding-top:3px;
+    padding-bottom:3px;
+}
+.list_main_lines
+.list_main_lines td,
+.list_main_lines td {
+    border-bottom:thin solid #EEEEEE
+}
+.nobreak {
+    page-break-inside: avoid;
+}
+caption.formatted_note {
+    text-align:left;
+    border-right:thin solid #EEEEEE;
+    border-left:thin solid #EEEEEE;
+    border-top:thin solid #EEEEEE;
+    padding-left:10px;
+    font-size:11;
+    caption-side: bottom;
+}
+caption.formatted_note p {
+    margin: 0;
+}
+.address {
+    font-size: 12px;
+    margin-left: 350px;
+    margin-right: 120px;
+    float: right;
+}
+.req_line_col1 {
+    width: 40%;
+    text-align:left;
+    vertical-align:top;
+}
+.req_line_col2 {
+    width: 20%;
+    text-align:center;
+    vertical-align:top;
+}
+.req_line_col3 {
+    width: 20%;
+    text-align:center;
+    vertical-align:top;
+}
+.req_line_col4 {
+    width: 20%;
+    text-align:center;
+    vertical-align:top;
+}
+
+.po_line_col1 {
+    width: 60%;
+    text-align:left;
+    vertical-align:top;
+}
+.po_line_col2 {
+    width: 20%;
+    text-align:center;
+    vertical-align:top;
+}
+.po_line_col3 {
+    width: 20%;
+    text-align:center;
+    vertical-align:top;
+}
+    </style>
+
+</head>
+<body>
+    <%page expression_filter="entity"/>
+
+    <%def name="address(partner, commercial_partner=None)">
+        <%doc>
+            XXX add a helper for address in report_webkit module as this won't be suported in v8.0
+        </%doc>
+        <% company_partner = False %>
+        %if commercial_partner:
+            %if commercial_partner.id != partner.id:
+                <% company_partner = commercial_partner %>
+            %endif
+        %elif partner.parent_id:
+            <% company_partner = partner.parent_id %>
+        %endif
+
+        %if company_partner:
+            <tr><td class="name">${company_partner.name or ''}</td></tr>
+            <tr><td>${partner.title and partner.title.name or ''} ${partner.name}</td></tr>
+            <% address_lines = partner.contact_address.split("\n")[1:] %>
+        %else:
+            <tr><td class="name">${partner.title and partner.title.name or ''} ${partner.name}</td></tr>
+            <% address_lines = partner.contact_address.split("\n") %>
+        %endif
+        %for part in address_lines:
+            % if part:
+                <tr><td>${part}</td></tr>
+            % endif
+        %endfor
+    </%def>
+
+    %for request in objects :
+        <h3 style="clear: both; padding-top: 20px;">
+        	${_(u'Purchase Request') } ${request.name}
+        </h3>
+        <table class="basic_table" width="100%">
+            <tr>
+                <th style="text-align:center">${_("Request Reference")}</th>
+                <th class="date">${_("Request Date")}</th>
+                <th style="text-align:center">${_("Origin")}</th>
+            </tr>
+            <tr>
+                <td style="text-align:center">${request.name}</td>
+                <td class="date">${formatLang(request.date_start, date=True)}</td>
+                <th style="text-align:center">${request.origin or ''}</th>
+            </tr>
+        </table>
+        <h4 style="clear: both; padding-top: 20px;">
+            ${_(u'Product Detail')}
+        </h4>
+        <table class="list_main_table" width="100%" >
+            <thead>
+              <tr class="list_main_headers">
+                <th class="req_line_col1">${_("Description")}</th>
+                <th class="req_line_col2">${_("Qty")}</th>
+                <th class="req_line_col3">${_("UoM")}</th>
+                <th class="date">${_("Date Required")}</th>
+              </tr>
+            </thead>
+            <tbody>
+            %for req_line in request.line_ids :
+              <tr class="list_main_lines">
+                <td class="req_line_col1">${req_line.name and req_line.name.replace('\n','<br/>') or '' | n}</td>
+                <td style="text-align:center" class="amount req_line_col2">${formatLang(req_line.product_qty)}</td>
+                <td style="text-align:center" class="req_line_col3">${req_line.product_uom_id.name}</td>
+                <td style="text-align:center" class="date">${formatLang(req_line.date_required, date=True)}</td>
+              </tr>
+           %endfor
+            </tbody>
+        </table>
+        <p style="page-break-after:always"/>
+        <br/>
+	%endfor
+</body>
+</html>

--- a/purchase_request_webkit/report/purchase_request_report_view.xml
+++ b/purchase_request_webkit/report/purchase_request_report_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+    <report id="purchase_request_webkit.report_purchase_request"
+            name="purchase.request.webkit"
+            auto="False"
+            model="purchase.request"
+            file="purchase_request_webkit/report/purchase_request.mako"
+            string="Purchase Request"
+            report_type="webkit" />
+
+    <record id="purchase_request_webkit.report_purchase_request" model="ir.actions.report.xml">
+      <field name="webkit_header" ref="base_headers_webkit.base_reports_portrait_header"/>
+    </record>
+  </data>
+</openerp>


### PR DESCRIPTION
This PR adds a new entity 'Purchase Request'.

The following modules are added:
- purchase_request
- purchase_request_to_requisition
- purchase_request_to_rfq
- purchase_request_webkit
# Purchase Request

You use this module if you wish to give notification of requirements of
materials and/or external services and keep track of such requirements.

Requests can be created either directly or indirectly. "Directly" means that
someone from the requesting department enters a purchase request manually.

The person creating the requisition determines what and how much to order,
and the requested date.

"Indirectly" means that the purchase request initiated by the application
automatically, for example, from procurement orders.

A purchase request is an instruction to Purchasing to procure a certain
quantity of materials services, so that they are is available at a
certain point in time.

A line of a requisition contains the quantity and requested date of the
material to be supplied or the quantity of the service to be performed. You
can indicate the service specifications if needed.
# Purchase Request to Bid

This module introduces the following features:
- The possibility to create new Bids or update existing Bids from Purchase
  Request Lines.
- The possibility to create Purchase Requests on the basis of Procurement
  Orders.
# Purchase Request to RFQ

This module adds the possibility to create or update Requests for
Quotation (RFQ) from Purchase Request Lines.
# Purchase Request Webkit

Report to print purchase requests.
