### PR TITLE
[FIX][purchase_partial_invoicing] Check access rights when validating…

### DIFF
--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -99,6 +99,10 @@ class AccountInvoice(models.Model):
     def invoice_validate(self):
         res = super(AccountInvoice, self).invoice_validate()
         purchase_order_obj = self.env['purchase.order']
+        # Users might not have access rights for Purchase Order (e.g. POS users)
+        if not purchase_order_obj.check_access_rights(
+                'read', raise_exception=False):
+            return res
         po_ids = purchase_order_obj.search([('invoice_ids', 'in', self.ids)])
         for purchase_order in po_ids:
             for po_line in purchase_order.order_line:


### PR DESCRIPTION
… invoice

If user has access to account.invoice but not purchase.order then invoice
can not be validated. This is even more relevant when invoice is issued in
POS because lack of access rights restricts from finishing an order
