### PR TITLE
[FIX] Use suspend_security on search on purchase order for users that have no access right on purchases.

### DIFF
--- a/purchase_partial_invoicing/README.rst
+++ b/purchase_partial_invoicing/README.rst
@@ -12,6 +12,8 @@ To install this module, you need to:
 
 * Click on install button
 
+This module depends on base_suspend_security module which can be found on apps.odoo.com or on the OCA/server-tools github repository.
+
 Usage
 =====
 

--- a/purchase_partial_invoicing/__openerp__.py
+++ b/purchase_partial_invoicing/__openerp__.py
@@ -28,7 +28,8 @@
               "Odoo Community Association (OCA)",
     'website': 'http://www.agilebg.com',
     'license': 'AGPL-3',
-    "depends": ['purchase'],
+    "depends": ['purchase',
+                'base_suspend_security'],
     "data": [
         'wizard/po_line_invoice_view.xml',
         'wizard/po_line_cancel_quantity_view.xml',

--- a/purchase_partial_invoicing/purchase.py
+++ b/purchase_partial_invoicing/purchase.py
@@ -99,7 +99,8 @@ class AccountInvoice(models.Model):
     def invoice_validate(self):
         res = super(AccountInvoice, self).invoice_validate()
         purchase_order_obj = self.env['purchase.order']
-        po_ids = purchase_order_obj.search([('invoice_ids', 'in', self.ids)])
+        po_ids = purchase_order_obj.suspend_security()\
+            .search([('invoice_ids', 'in', self.ids)])
         for purchase_order in po_ids:
             for po_line in purchase_order.order_line:
                 if po_line.invoiced_qty != po_line.product_qty:

--- a/purchase_partial_invoicing/tests/test_purchase_partial_invoicing.py
+++ b/purchase_partial_invoicing/tests/test_purchase_partial_invoicing.py
@@ -29,6 +29,8 @@ class testPurchasePartialInvoicing(common.TransactionCase):
 
     def setUp(self):
         super(testPurchasePartialInvoicing, self).setUp()
+        # tests are called before register_hook
+        self.env['ir.rule']._register_hook()
         self.context = self.env['res.users'].context_get()
         self.po_obj = self.env['purchase.order']
         self.po_line_obj = self.env['purchase.order.line']


### PR DESCRIPTION
An other solution for #190 
