### PR TITLE
[8.0] Product By Supplier issue

### DIFF
--- a/product_by_supplier/views/product_supplierinfo_view.xml
+++ b/product_by_supplier/views/product_supplierinfo_view.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data>
+        <record id="product_template_form_view" model="ir.ui.view">
+            <field name="name">product.template.common.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <field name="seller_ids" position="attributes">
+                    <attribute name="context">{'from_product_form':True}</attribute>
+                </field>
+            </field>
+        </record>
+
         <record id="view_product_supplierinfo_search" model="ir.ui.view">
             <field name="name">product.supplierinfo.search</field>
             <field name="model">product.supplierinfo</field>
@@ -47,7 +58,9 @@
             <field name="priority">99</field>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='sequence']" position="before">
-                    <field name="product_tmpl_id"  string="Product"/>
+                    <field name="product_tmpl_id" string="Product"
+                    invisible="context.get('from_product_form')"
+                    required="not context.get('from_product_form')"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Product By Supplier module add product_tmpl_id field (mandatory) on product_supplier_info form.

This can be disturbing when you want to create a product and specify the product supplier informations in the same transaction. The field added is mandatory and you are not able to fill it because the product does not exist yet.

In the same time, if you use the menu Product By supplier to create some product supplier informations, you must mention the related product.

The solution implemented by this fix:

Identify when you open the product supplier info form from the product form and drop the field from the view.
