### PR TITLE
[FIX] reference to unknow partner field in purchase report;

### DIFF
--- a/purchase_discount/report/order.rml
+++ b/purchase_discount/report/order.rml
@@ -169,8 +169,8 @@
         <td>
           <para style="terp_default_9">[[ (o.partner_id and o.partner_id.title and o.partner_id.title.name) or '' ]] [[ (o.partner_id and o.partner_id.name) or '' ]] </para>
           <para style="terp_default_9">[[ o.partner_id and display_address(o.partner_id) ]] </para>
-          <para style="terp_default_9">Tél. : [[ (o.partner_address_id and o.partner_address_id.phone) or removeParentNode('para') ]]</para>
-          <para style="terp_default_9">Fax : [[ (o.partner_address_id and o.partner_address_id.fax) or removeParentNode('para') ]]</para>
+          <para style="terp_default_9">Tél. : [[ (o.partner_id and o.partner_id.phone) or removeParentNode('para') ]]</para>
+          <para style="terp_default_9">Fax : [[ (o.partner_id and o.partner_id.fax) or removeParentNode('para') ]]</para>
           <para style="terp_default_9">TVA : [[ (o.partner_id and o.partner_id.vat) or removeParentNode('para') ]]</para>
         </td>
       </tr>


### PR DESCRIPTION
this report use partner_address_id on purchase_order. This field doesn't exist if we install only the module 'purchase_discount'.
