### PR TITLE
8.0 add purchase secondary uom

### DIFF
--- a/purchase_secondary_uom/README.rst
+++ b/purchase_secondary_uom/README.rst
@@ -1,0 +1,49 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Purchase Secodary UoM
+=====================
+
+This module add a secondary unit of measure (purchase unit of measure) on product and on purchase order line.
+An user can define a particular unit of measure for particular product with a different measure category of default uom.
+This module introduce a feature we can find on sale order, too.
+
+Installation
+============
+
+To install this module, you need to:
+
+* Click on install button
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/purchase-workflow/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/purchase-workflow/issues/new?body=module:%20purchase_secondary_uom%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Francesco Apruzzese <f.apruzzese@apuliasoftware.it>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/purchase_secondary_uom/README.rst
+++ b/purchase_secondary_uom/README.rst
@@ -32,6 +32,7 @@ Contributors
 ------------
 
 * Francesco Apruzzese <f.apruzzese@apuliasoftware.it>
+* Andrea Gallina <a.gallina@apuliasoftware.it>
 
 Maintainer
 ----------

--- a/purchase_secondary_uom/__init__.py
+++ b/purchase_secondary_uom/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Francesco Apruzzese
+#    Copyright 2015 Apulia Software srl
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/purchase_secondary_uom/__init__.py
+++ b/purchase_secondary_uom/__init__.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Author: Francesco Apruzzese
-#    Copyright 2015 Apulia Software srl
+#    Copyright (C) 2015
+#    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.it>)
+#    All Rights Reserved
 #
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/purchase_secondary_uom/__openerp__.py
+++ b/purchase_secondary_uom/__openerp__.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015
+#    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.com>)
+#    All Rights Reserved
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': "Purchase Order Secondary UoM",
+    'version': '0.1',
+    'category': 'Purchase',
+    'author': 'Francesco OpenCode Apruzzese,Odoo Community Association (OCA)',
+    'website': 'https://www.apuliasoftware.it',
+    'license': 'AGPL-3',
+    "depends": [
+        'product',
+        'purchase',
+        ],
+    "data": [],
+    "update_xml": [],
+    "demo_xml": [],
+    "auto_install": False,
+    "installable": True
+}

--- a/purchase_secondary_uom/__openerp__.py
+++ b/purchase_secondary_uom/__openerp__.py
@@ -33,6 +33,7 @@
         ],
     "data": [
         'views/product_view.xml',
+        'views/purchase_view.xml',
         ],
     "update_xml": [],
     "demo_xml": [],

--- a/purchase_secondary_uom/__openerp__.py
+++ b/purchase_secondary_uom/__openerp__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Copyright (C) 2015
-#    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.com>)
+#    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.it>)
 #    All Rights Reserved
 #
 #    This program is free software: you can redistribute it and/or modify

--- a/purchase_secondary_uom/models/__init__.py
+++ b/purchase_secondary_uom/models/__init__.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Author: Francesco Apruzzese
-#    Copyright 2015 Apulia Software srl
+#    Copyright (C) 2015
+#    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.it>)
+#    All Rights Reserved
 #
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/purchase_secondary_uom/models/__init__.py
+++ b/purchase_secondary_uom/models/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Francesco Apruzzese
+#    Copyright 2015 Apulia Software srl
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import product

--- a/purchase_secondary_uom/models/__init__.py
+++ b/purchase_secondary_uom/models/__init__.py
@@ -22,3 +22,4 @@
 
 from . import product
 from . import purchase
+from . import procurement

--- a/purchase_secondary_uom/models/procurement.py
+++ b/purchase_secondary_uom/models/procurement.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015
+#    Andrea Gallina (<a.gallina@apuliasoftware.it>)
+#    All Rights Reserved
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api, _
+
+
+class ProcurementOrder(models.Model):
+
+    _inherit = 'procurement.order'
+
+    @api.v7
+    def _get_po_line_values_from_proc(self, cr, uid, procurement, partner,
+                                      company, schedule_date, context=None):
+        res = super(ProcurementOrder, self)._get_po_line_values_from_proc(
+            cr, uid, procurement, partner, company, schedule_date, context)
+        if not res:
+            return res
+        product_id = res.get('product_id', False)
+        if not product_id:
+            return res
+        qty = res.get('product_qty', 1.0)
+        product = self.pool['product.product'].browse(
+            cr, uid, product_id, context)
+        if product.uop_id:
+            res.update({'product_uop_id': product.uop_id.id,
+                        'product_uop_qty': (product.uop_coeff * qty) or qty})
+        return res

--- a/purchase_secondary_uom/models/product.py
+++ b/purchase_secondary_uom/models/product.py
@@ -29,7 +29,7 @@ class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
     uop_id = fields.Many2one('product.uom', string='Unit of Purchase')
-    uop_coeff = fields.Float(string='Unit of Measure -> UOP Coeff')
+    uop_coeff = fields.Float(string='Unit of Measure -> UOP Coeff',
+                             default=1.00)
     uop_type = fields.Selection(
         [('fixed', 'Fixed'), ('variable', 'Variable')])
-

--- a/purchase_secondary_uom/models/product.py
+++ b/purchase_secondary_uom/models/product.py
@@ -20,22 +20,16 @@
 #
 ##############################################################################
 
-{
-    'name': "Purchase Order Secondary UoM",
-    'version': '0.1',
-    'category': 'Purchase',
-    'author': 'Francesco OpenCode Apruzzese,Odoo Community Association (OCA)',
-    'website': 'https://www.apuliasoftware.it',
-    'license': 'AGPL-3',
-    "depends": [
-        'product',
-        'purchase',
-        ],
-    "data": [
-        'views/product_view.xml',
-        ],
-    "update_xml": [],
-    "demo_xml": [],
-    "auto_install": False,
-    "installable": True
-}
+
+from openerp import models, fields
+
+
+class ProductTemplate(models.Model):
+
+    _inherit = 'product.template'
+
+    uop_id = fields.Many2one('product.uom', string='Unit of Purchase')
+    uop_coeff = fields.Float(string='Unit of Measure -> UOP Coeff')
+    uop_type = fields.Selection(
+        [('fixed', 'Fixed'), ('variable', 'Variable')])
+

--- a/purchase_secondary_uom/models/purchase.py
+++ b/purchase_secondary_uom/models/purchase.py
@@ -24,6 +24,24 @@
 from openerp import models, fields, api
 
 
+class PurchaseOrder(models.Model):
+
+    _inherit = 'purchase.order'
+
+    @api.v7
+    def _prepare_order_line_move(self, cr, uid, order, order_line, picking_id,
+                                 group_id, context=None):
+        res = super(PurchaseOrder, self)._prepare_order_line_move(
+            cr, uid, order, order_line, picking_id, group_id, context)
+        for line in res:
+            for purchase_line in order_line:
+                if line['purchase_line_id'] == purchase_line.id and\
+                        purchase_line.product_uop_id:
+                    line['product_uos'] = purchase_line.product_uop_id.id
+                    line['product_uos_qty'] = purchase_line.product_uop_qty
+        return res
+
+
 class PurchaseOrderLine(models.Model):
 
     _inherit = 'purchase.order.line'

--- a/purchase_secondary_uom/models/purchase.py
+++ b/purchase_secondary_uom/models/purchase.py
@@ -21,7 +21,7 @@
 ##############################################################################
 
 
-from openerp import models, fields
+from openerp import models, fields, api
 
 
 class PurchaseOrderLine(models.Model):
@@ -29,4 +29,14 @@ class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
 
     product_uop_id = fields.Many2one('product.uom', string='Product UoP')
-    product_uop_qty = fields.Float(string='Quantity (UoP)')
+    product_uop_qty = fields.Float(string='Quantity (UoP)',
+                                   default=1.00)
+
+    @api.onchange('product_id', 'product_uop_qty', 'product_uop_id')
+    def on_change_secondary_uom(self):
+        if self.product_id:
+            try:
+                self.product_qty = (self.product_uop_qty /
+                                    self.product_id.uop_coeff)
+            except ZeroDivisionError:
+                pass

--- a/purchase_secondary_uom/models/purchase.py
+++ b/purchase_secondary_uom/models/purchase.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Author: Francesco Apruzzese
-#    Copyright 2015 Apulia Software srl
+#    Copyright (C) 2015
+#    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.com>)
+#    All Rights Reserved
 #
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -19,5 +20,13 @@
 #
 ##############################################################################
 
-from . import product
-from . import purchase
+
+from openerp import models, fields
+
+
+class PurchaseOrderLine(models.Model):
+
+    _inherit = 'purchase.order.line'
+
+    product_uop_id = fields.Many2one('product.uom', string='Product UoP')
+    product_uop_qty = fields.Float(string='Quantity (UoP)')

--- a/purchase_secondary_uom/models/purchase.py
+++ b/purchase_secondary_uom/models/purchase.py
@@ -28,11 +28,11 @@ class PurchaseOrder(models.Model):
 
     _inherit = 'purchase.order'
 
-    @api.v7
-    def _prepare_order_line_move(self, cr, uid, order, order_line, picking_id,
-                                 group_id, context=None):
+    @api.model
+    def _prepare_order_line_move(self, order, order_line,
+                                 picking_id, group_id):
         res = super(PurchaseOrder, self)._prepare_order_line_move(
-            cr, uid, order, order_line, picking_id, group_id, context)
+            order, order_line, picking_id, group_id)
         for line in res:
             for purchase_line in order_line:
                 if line['purchase_line_id'] == purchase_line.id and\

--- a/purchase_secondary_uom/models/purchase.py
+++ b/purchase_secondary_uom/models/purchase.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Copyright (C) 2015
-#    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.com>)
+#    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.it>)
 #    All Rights Reserved
 #
 #    This program is free software: you can redistribute it and/or modify

--- a/purchase_secondary_uom/models/stock.py
+++ b/purchase_secondary_uom/models/stock.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Copyright (C) 2015
+#    Copyright (C) 2016
 #    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.it>)
 #    All Rights Reserved
 #
@@ -20,7 +20,20 @@
 #
 ##############################################################################
 
-from . import product
-from . import purchase
-from . import procurement
-from . import stock
+
+from openerp import models, api
+
+
+class StockMove(models.Model):
+
+    _inherit = 'stock.move'
+
+    @api.model
+    def _get_invoice_line_vals(self, move, partner, inv_type):
+        res = super(StockMove, self)._get_invoice_line_vals(
+            move, partner, inv_type)
+        if inv_type == 'in_invoice' and move.purchase_line_id:
+            purchase_line = move.purchase_line_id
+            if purchase_line.price_unit_uop:
+                res['price_unit'] = purchase_line.price_unit_uop
+        return res

--- a/purchase_secondary_uom/tests/__init__.py
+++ b/purchase_secondary_uom/tests/__init__.py
@@ -21,15 +21,4 @@
 ##############################################################################
 
 
-from openerp import models, fields
-
-
-class ProductTemplate(models.Model):
-
-    _inherit = 'product.template'
-
-    uop_id = fields.Many2one('product.uom', string='Unit of Purchase')
-    uop_coeff = fields.Float(string='Unit of Measure -> UOP Coeff',
-                             default=1.00)
-    uop_type = fields.Selection(
-        [('fixed', 'Fixed'), ('variable', 'Variable')])
+from . import test_purchase_secondary_uom

--- a/purchase_secondary_uom/tests/test_purchase_secondary_uom.py
+++ b/purchase_secondary_uom/tests/test_purchase_secondary_uom.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015
+#    Francesco OpenCode Apruzzese (<f.apruzzese@apuliasoftware.it>)
+#    All Rights Reserved
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+import openerp.tests.common as common
+from openerp import fields
+
+
+class TestPurchaseSecondaryUom(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseSecondaryUom, self).setUp()
+        # ----- models
+        self.purchase_model = self.env['purchase.order']
+        self.purchase_line_model = self.env['purchase.order.line']
+        # ----- demo datas
+        self.partner = self.env.ref('base.res_partner_1')
+        self.location = self.env.ref('stock.stock_location_suppliers')
+        self.picking_type = self.env.ref('stock.picking_type_in')
+        self.pricelist = self.env.ref('purchase.list0')
+        self.product = self.env.ref('product.product_product_31')
+        self.uom_kg = self.env.ref('product.product_uom_kgm')
+
+    def test_purchase_last_price_info_new_order(self):
+        # ----- set units of measure on product
+        self.product.uop_id = self.uom_kg.id
+        self.product.uop_coeff = 2.0
+        self.product.uop_type = 'fixed'
+        # ----- Create purchase order
+        purchase_order = self.purchase_model.create({
+            'partner_id': self.partner.id,
+            'location_id': self.location.id,
+            'picking_type_id': self.picking_type.id,
+            'pricelist_id': self.pricelist.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product.id,
+                'price_unit': self.product.standard_price,
+                'name': self.product.name,
+                'product_qty': 10.0,
+                'product_uop_id': self.uom_kg.id,
+                'product_uop_qty': 20.0,
+                'date_planned': fields.Datetime.now(),
+                })]
+            })
+        # ----- Confirm order and create picking
+        purchase_order.wkf_confirm_order()
+        purchase_order.action_picking_create()
+        # ----- Check quantity on stock move
+        self.assertEqual(
+            purchase_order.order_line[0].product_uop_id.id,
+            purchase_order.order_line[0].move_ids[0].product_uos.id)
+        self.assertEqual(
+            purchase_order.order_line[0].product_uop_qty,
+            purchase_order.order_line[0].move_ids[0].product_uos_qty)

--- a/purchase_secondary_uom/views/product_view.xml
+++ b/purchase_secondary_uom/views/product_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+    <record id="purchase_secondary_uom_product_template_form_view" model="ir.ui.view">
+        <field name="name">purchase.secondary.uom.product.template.common.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <group name="procurement_uom" position="after">
+                <group name="purchase_uom" groups="product.group_uom" string="Purchase Secondary UoM">
+                    <field name="uop_id"/>
+                    <field name="uop_coeff"/>
+                    <field name="uop_type"/>
+                </group>
+            </group>
+        </field>
+    </record>
+
+    </data>
+</openerp>

--- a/purchase_secondary_uom/views/purchase_view.xml
+++ b/purchase_secondary_uom/views/purchase_view.xml
@@ -11,7 +11,22 @@
                 <label for="product_uop_qty"/>
                 <div>
                     <field name="product_uop_qty" class="oe_inline"/>
-                    <field name="product_uop_id" groups="product.group_uom" class="oe_inline"/>
+                    <field name="product_uop_id"
+                           groups="product.group_uom" class="oe_inline"/>
+                </div>
+            </field>
+            <xpath expr="//form/sheet/group/group[2]" position="after">
+                <group>
+                    <button name="update_uom_price_data"
+                            string="Update Secondary UoP"
+                            type="object" class="oe_highlight"/>
+                </group>
+            </xpath>
+            <field name="price_unit" position="after">
+                <label for="price_unit_uop"/>
+                <div>
+                    <field name="price_unit_uop" groups="product.group_uom"
+                           class="oe_inline"/>
                 </div>
             </field>
         </field>

--- a/purchase_secondary_uom/views/purchase_view.xml
+++ b/purchase_secondary_uom/views/purchase_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+    <record id="purchase_secondary_uom_purchase_order_line_form" model="ir.ui.view">
+        <field name="name">purchase.secondary.uom.purchase.order.line.form</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_form"/>
+        <field name="arch" type="xml">
+            <field name="price_unit" position="before">
+                <label for="product_uop_qty"/>
+                <div>
+                    <field name="product_uop_qty" class="oe_inline"/>
+                    <field name="product_uop_id" groups="product.group_uom" class="oe_inline"/>
+                </div>
+            </field>
+        </field>
+    </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
This module add a secondary unit of measure (purchase unit of measure) on product and on purchase order line.
An user can define a particular unit of measure for particular product with a different measure category of default uom.
This module introduce a feature we can find on sale order, too.
