### PR TITLE
8.0 procurement purchase no grouping

### DIFF
--- a/procurement_purchase_no_grouping/README.rst
+++ b/procurement_purchase_no_grouping/README.rst
@@ -1,0 +1,26 @@
+No grouping on procurement purchases
+====================================
+
+This module allows to not group generated purchase orders from procurements.
+The grouping behaviour can be configurable at product category level.
+
+Configuration
+=============
+
+Go to each product category, and select one of these values in the field
+"Procured purchase grouping":
+
+* *Standard grouping (default)*: With this option, procurements will generate
+  purchase orders as always, grouping lines and orders when possible.
+* *No line grouping*: With this value, if there are any open purchase order
+  for the same supplier, it will be reused, but lines won't be merged.
+* *No order grouping*: This option will prevent any kind of grouping.
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <ajuaristo@gmail.com>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/procurement_purchase_no_grouping/README.rst
+++ b/procurement_purchase_no_grouping/README.rst
@@ -24,3 +24,4 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Ana Juaristi <ajuaristo@gmail.com>
 * Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
+* Ronald Portier <ronald@therp.nl>

--- a/procurement_purchase_no_grouping/__init__.py
+++ b/procurement_purchase_no_grouping/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import models

--- a/procurement_purchase_no_grouping/__init__.py
+++ b/procurement_purchase_no_grouping/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import models

--- a/procurement_purchase_no_grouping/__init__.py
+++ b/procurement_purchase_no_grouping/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# © 2015 Pedro M. Baeza (http://www.serviciosbaeza.com).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import models

--- a/procurement_purchase_no_grouping/__openerp__.py
+++ b/procurement_purchase_no_grouping/__openerp__.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Procurement Purchase No Grouping",
+    "version": "1.0",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    "website": "http://www.odoomrp.com",
+    "category": "Procurements",
+    "depends": ['purchase',
+                'procurement',
+                ],
+    "data": ['views/product_category_view.xml',
+             ],
+    "installable": True
+}

--- a/procurement_purchase_no_grouping/__openerp__.py
+++ b/procurement_purchase_no_grouping/__openerp__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# © 2015 Pedro M. Baeza (http://www.serviciosbaeza.com).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Procurement Purchase No Grouping',

--- a/procurement_purchase_no_grouping/__openerp__.py
+++ b/procurement_purchase_no_grouping/__openerp__.py
@@ -1,32 +1,23 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
-    "name": "Procurement Purchase No Grouping",
-    "version": "1.0",
-    "author": "OdooMRP team,"
-              "AvanzOSC,"
-              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
-    "website": "http://www.odoomrp.com",
-    "category": "Procurements",
-    "depends": ['purchase',
-                'procurement',
-                ],
-    "data": ['views/product_category_view.xml',
-             ],
-    "installable": True
+    'name': 'Procurement Purchase No Grouping',
+    'version': '8.0.1.0.1',
+    'license': 'AGPL-3',
+    'author':
+        'Odoo Community Association (OCA), '
+        'OdooMRP team,'
+        'AvanzOSC,'
+        'Serv. Tecnol. Avanzados - Pedro M. Baeza',
+    'website': 'http://github.com/oca/purchase-workflow',
+    'category': 'Procurements',
+    'depends': [
+        'purchase',
+        'procurement',
+    ],
+    'data': [
+        'views/product_category_view.xml',
+    ],
+    'installable': True
 }

--- a/procurement_purchase_no_grouping/i18n/es.po
+++ b/procurement_purchase_no_grouping/i18n/es.po
@@ -1,0 +1,68 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * procurement_purchase_no_grouping
+# 
+# Translators:
+# Pedro M. Baeza <pedro.baeza@gmail.com>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:44+0000\n"
+"PO-Revision-Date: 2015-10-09 10:59+0000\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/oca/odoomrp-wip-8-0/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No line grouping"
+msgstr "Sin agrupación de línea"
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No order grouping"
+msgstr "Sin agrupación de pedido"
+
+#. module: procurement_purchase_no_grouping
+#: field:product.category,procured_purchase_grouping:0
+msgid "Procured purchase grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
+msgid "Product Category"
+msgstr "Categoría de producto"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order
+msgid "Purchase Order"
+msgstr "Pedido de compra"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Línea pedido de compra"
+
+#. module: procurement_purchase_no_grouping
+#: help:product.category,procured_purchase_grouping:0
+msgid ""
+"Select the behaviour for grouping procured purchases for the the products of this category:\n"
+"* Standard grouping (default): Procurements will generate purchase orders as always, grouping lines and orders when possible.\n"
+"* No line grouping: If there are any open purchase order for the same supplier, it will be reused, but lines won't be merged.\n"
+"* No order grouping: This option will prevent any kind of grouping."
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "Standard grouping"
+msgstr ""

--- a/procurement_purchase_no_grouping/i18n/fr.po
+++ b/procurement_purchase_no_grouping/i18n/fr.po
@@ -1,0 +1,67 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * procurement_purchase_no_grouping
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:44+0000\n"
+"PO-Revision-Date: 2015-09-10 16:36+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: French (http://www.transifex.com/oca/odoomrp-wip-8-0/language/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No line grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No order grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: field:product.category,procured_purchase_grouping:0
+msgid "Procured purchase grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_procurement_order
+msgid "Procurement"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
+msgid "Product Category"
+msgstr "Catégorie d'articles"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: help:product.category,procured_purchase_grouping:0
+msgid ""
+"Select the behaviour for grouping procured purchases for the the products of this category:\n"
+"* Standard grouping (default): Procurements will generate purchase orders as always, grouping lines and orders when possible.\n"
+"* No line grouping: If there are any open purchase order for the same supplier, it will be reused, but lines won't be merged.\n"
+"* No order grouping: This option will prevent any kind of grouping."
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "Standard grouping"
+msgstr ""

--- a/procurement_purchase_no_grouping/i18n/procurement_purchase_no_grouping.pot
+++ b/procurement_purchase_no_grouping/i18n/procurement_purchase_no_grouping.pot
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* procurement_purchase_no_grouping
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-08-03 14:49+0000\n"
+"PO-Revision-Date: 2015-08-03 14:49+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: procurement_purchase_no_grouping
+#: help:product.category,group_on_procured_purchases:0
+msgid "If this new field is checked, running the procurement acts like the standard way, adding the amount on existing line purchase order if the product and the UoM is the same, but if it is not checked, no grouping will be done, creating a new line each time"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_procurement_order
+msgid "Procurement"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+

--- a/procurement_purchase_no_grouping/i18n/pt_BR.po
+++ b/procurement_purchase_no_grouping/i18n/pt_BR.po
@@ -1,0 +1,67 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * procurement_purchase_no_grouping
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:44+0000\n"
+"PO-Revision-Date: 2015-10-09 03:36+0000\n"
+"Last-Translator: danimaribeiro <danimaribeiro@gmail.com>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/oca/odoomrp-wip-8-0/language/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No line grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No order grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: field:product.category,procured_purchase_grouping:0
+msgid "Procured purchase grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_procurement_order
+msgid "Procurement"
+msgstr "Aprovisionamento"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order
+msgid "Purchase Order"
+msgstr "Pedido de compra"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Linha pedido de compra"
+
+#. module: procurement_purchase_no_grouping
+#: help:product.category,procured_purchase_grouping:0
+msgid ""
+"Select the behaviour for grouping procured purchases for the the products of this category:\n"
+"* Standard grouping (default): Procurements will generate purchase orders as always, grouping lines and orders when possible.\n"
+"* No line grouping: If there are any open purchase order for the same supplier, it will be reused, but lines won't be merged.\n"
+"* No order grouping: This option will prevent any kind of grouping."
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "Standard grouping"
+msgstr ""

--- a/procurement_purchase_no_grouping/i18n/ro.po
+++ b/procurement_purchase_no_grouping/i18n/ro.po
@@ -1,0 +1,67 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * procurement_purchase_no_grouping
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-11-20 18:10+0000\n"
+"PO-Revision-Date: 2015-09-10 16:36+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Romanian (http://www.transifex.com/oca/odoomrp-wip-8-0/language/ro/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No line grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No order grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: field:product.category,procured_purchase_grouping:0
+msgid "Procured purchase grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_procurement_order
+msgid "Procurement"
+msgstr "Aprovizionare"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order
+msgid "Purchase Order"
+msgstr "Comandă achiziție"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Linie comandă achiziție"
+
+#. module: procurement_purchase_no_grouping
+#: help:product.category,procured_purchase_grouping:0
+msgid ""
+"Select the behaviour for grouping procured purchases for the the products of this category:\n"
+"* Standard grouping (default): Procurements will generate purchase orders as always, grouping lines and orders when possible.\n"
+"* No line grouping: If there are any open purchase order for the same supplier, it will be reused, but lines won't be merged.\n"
+"* No order grouping: This option will prevent any kind of grouping."
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "Standard grouping"
+msgstr ""

--- a/procurement_purchase_no_grouping/i18n/sl.po
+++ b/procurement_purchase_no_grouping/i18n/sl.po
@@ -1,0 +1,68 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * procurement_purchase_no_grouping
+# 
+# Translators:
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:44+0000\n"
+"PO-Revision-Date: 2015-09-20 19:01+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
+"Language-Team: Slovenian (http://www.transifex.com/oca/odoomrp-wip-8-0/language/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No line grouping"
+msgstr "Brez združevanja postavk"
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "No order grouping"
+msgstr "Brez združevanja nalogov"
+
+#. module: procurement_purchase_no_grouping
+#: field:product.category,procured_purchase_grouping:0
+msgid "Procured purchase grouping"
+msgstr "Združevanje oskrbovalnih nabav"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_procurement_order
+msgid "Procurement"
+msgstr "Oskrbovanje"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
+msgid "Product Category"
+msgstr "Kategorija proizvoda"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order
+msgid "Purchase Order"
+msgstr "Nabavni nalog"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Postavka nabavnega naloga"
+
+#. module: procurement_purchase_no_grouping
+#: help:product.category,procured_purchase_grouping:0
+msgid ""
+"Select the behaviour for grouping procured purchases for the the products of this category:\n"
+"* Standard grouping (default): Procurements will generate purchase orders as always, grouping lines and orders when possible.\n"
+"* No line grouping: If there are any open purchase order for the same supplier, it will be reused, but lines won't be merged.\n"
+"* No order grouping: This option will prevent any kind of grouping."
+msgstr "Izbira obnašanja za združevanje oskrbovalnih nabav za proizvode te kategorije:\n* Standardno združevanje (privzeto): oskrbovanja ustvarijo nabavne naloge, združevanje postavk in nalogov, ko je to mogoče.\n* Brez združevanja postavk: če ni odprtih nabavnih nalogov za istega dobavitelja, se ponovno uporabi, a postavke ne bodo spojene.\n* Brez združevanja nalogov: ta opcija prepreči kakršnokoli združevanje."
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "Standard grouping"
+msgstr "Standardno združevanje"

--- a/procurement_purchase_no_grouping/models/__init__.py
+++ b/procurement_purchase_no_grouping/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import product_category
+from . import procurement_order
+from . import purchase_order

--- a/procurement_purchase_no_grouping/models/__init__.py
+++ b/procurement_purchase_no_grouping/models/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import product_category
 from . import procurement_order
 from . import purchase_order

--- a/procurement_purchase_no_grouping/models/__init__.py
+++ b/procurement_purchase_no_grouping/models/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# © 2015 Pedro M. Baeza (http://www.serviciosbaeza.com).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import product_category
 from . import procurement_order

--- a/procurement_purchase_no_grouping/models/procurement_order.py
+++ b/procurement_purchase_no_grouping/models/procurement_order.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def make_po(self):
+        import pdb
+        pdb.set_trace()
+        obj = self.with_context(
+            grouping=self.product_id.categ_id.procured_purchase_grouping)
+        return super(ProcurementOrder, obj).make_po()

--- a/procurement_purchase_no_grouping/models/procurement_order.py
+++ b/procurement_purchase_no_grouping/models/procurement_order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# © 2015 Pedro M. Baeza (http://www.serviciosbaeza.com).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openerp import api, models
 

--- a/procurement_purchase_no_grouping/models/procurement_order.py
+++ b/procurement_purchase_no_grouping/models/procurement_order.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
-from openerp import models, api
+# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, models
 
 
 class ProcurementOrder(models.Model):
@@ -10,8 +9,6 @@ class ProcurementOrder(models.Model):
 
     @api.multi
     def make_po(self):
-        import pdb
-        pdb.set_trace()
         obj = self.with_context(
             grouping=self.product_id.categ_id.procured_purchase_grouping)
         return super(ProcurementOrder, obj).make_po()

--- a/procurement_purchase_no_grouping/models/product_category.py
+++ b/procurement_purchase_no_grouping/models/product_category.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, fields
+
+
+class ProductCategory(models.Model):
+    _inherit = 'product.category'
+
+    procured_purchase_grouping = fields.Selection(
+        [('standard', 'Standard grouping'),
+         ('line', 'No line grouping'),
+         ('order', 'No order grouping')],
+        string='Procured purchase grouping', default='standard',
+        help="Select the behaviour for grouping procured purchases for the "
+             "the products of this category:\n"
+             "* Standard grouping (default): Procurements will generate "
+             "purchase orders as always, grouping lines and orders when "
+             "possible.\n"
+             "* No line grouping: If there are any open purchase order for "
+             "the same supplier, it will be reused, but lines won't be "
+             "merged.\n"
+             "* No order grouping: This option will prevent any kind of "
+             "grouping.")

--- a/procurement_purchase_no_grouping/models/product_category.py
+++ b/procurement_purchase_no_grouping/models/product_category.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
-from openerp import models, fields
+# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import fields, models
 
 
 class ProductCategory(models.Model):

--- a/procurement_purchase_no_grouping/models/product_category.py
+++ b/procurement_purchase_no_grouping/models/product_category.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# © 2015 Pedro M. Baeza (http://www.serviciosbaeza.com).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openerp import fields, models
 

--- a/procurement_purchase_no_grouping/models/purchase_order.py
+++ b/procurement_purchase_no_grouping/models/purchase_order.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    def search(self, cr, uid, args, offset=0, limit=None, order=None,
+               context=None, count=False):
+        make_po_conditions = {
+            'partner_id', 'state', 'picking_type_id', 'location_id',
+            'company_id', 'dest_address_id'}
+        # Restrict the empty return for these conditions
+        if (context and context.get('grouping', 'standard') == 'order' and
+                make_po_conditions.issubset(set(x[0] for x in args))):
+            return []
+        return super(PurchaseOrder, self).search(
+            cr, uid, args, offset=offset, limit=limit, order=order,
+            context=context, count=count)
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    def search(self, cr, uid, args, offset=0, limit=None, order=None,
+               context=None, count=False):
+        make_po_conditions = {'order_id', 'product_id', 'product_uom'}
+        # Restrict the empty return for these conditions
+        if (context and context.get('grouping', 'standard') == 'line' and
+                make_po_conditions.issubset(set(x[0] for x in args))):
+            return []
+        return super(PurchaseOrderLine, self).search(
+            cr, uid, args, offset=offset, limit=limit, order=order,
+            context=context, count=count)

--- a/procurement_purchase_no_grouping/models/purchase_order.py
+++ b/procurement_purchase_no_grouping/models/purchase_order.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-# For copyright and license notices, see __openerp__.py file in root directory
-##############################################################################
+# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openerp import models
 
 

--- a/procurement_purchase_no_grouping/models/purchase_order.py
+++ b/procurement_purchase_no_grouping/models/purchase_order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2015 Pedro M. Baeza (http://http://www.serviciosbaeza.com).
+# © 2015 Pedro M. Baeza (http://www.serviciosbaeza.com).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openerp import models
 

--- a/procurement_purchase_no_grouping/tests/__init__.py
+++ b/procurement_purchase_no_grouping/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_procurement_purchase_no_grouping

--- a/procurement_purchase_no_grouping/tests/__init__.py
+++ b/procurement_purchase_no_grouping/tests/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # (c) 2015 Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-
 from . import test_procurement_purchase_no_grouping

--- a/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
+++ b/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) 2015 Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-
 from openerp.tests.common import TransactionCase
 
 
@@ -32,12 +31,12 @@ class TestProcurementPurchaseNoGrouping(TransactionCase):
             'product_qty': 1.0,
         })
         procurement_2 = procurement_1.copy()
+        procurement_1.run()
+        procurement_2.run()
         return (procurement_1, procurement_2)
 
     def test_procurement_grouped_purchase(self):
         procurement_1, procurement_2 = self._make_procurements('standard')
-        procurement_1.run()
-        procurement_2.run()
         self.assertTrue(procurement_1.purchase_id)
         self.assertTrue(procurement_2.purchase_id)
         self.assertEqual(
@@ -48,28 +47,24 @@ class TestProcurementPurchaseNoGrouping(TransactionCase):
             procurement_1.purchase_line_id,
             procurement_2.purchase_line_id,
             'Procured purchase orders lines are not the same')
-        return True
 
     def test_procurement_no_grouping_line_purchase(self):
         procurement_1, procurement_2 = self._make_procurements('line')
-        procurement_1.run()
-        procurement_2.run()
         self.assertTrue(procurement_1.purchase_id)
         self.assertTrue(procurement_2.purchase_id)
         self.assertEqual(
             procurement_1.purchase_id,
             procurement_2.purchase_id,
-            'Procured purchase orders are not the same')
+            'Procured purchase orders are not the same'
+        )
         self.assertNotEqual(
             procurement_1.purchase_line_id,
             procurement_2.purchase_line_id,
-            'Procured purchase orders lines are the same')
-        return True
+            'Procured purchase orders lines are the same'
+        )
 
     def test_procurement_no_grouping_order_purchase(self):
         procurement_1, procurement_2 = self._make_procurements('order')
-        procurement_1.run()
-        procurement_2.run()
         self.assertTrue(procurement_1.purchase_id)
         self.assertTrue(procurement_2.purchase_id)
         self.assertNotEqual(
@@ -80,4 +75,3 @@ class TestProcurementPurchaseNoGrouping(TransactionCase):
             procurement_1.purchase_line_id,
             procurement_2.purchase_line_id,
             'Procured purchase orders lines are the same')
-        return True

--- a/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
+++ b/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp.tests.common import TransactionCase
+
+
+class TestProcurementPurchaseNoGrouping(TransactionCase):
+
+    def _make_procurements(self, procured_purchase_grouping):
+        category = self.env['product.category'].create({
+            'name': 'Test category %s' % procured_purchase_grouping,
+            'procured_purchase_grouping': procured_purchase_grouping,
+        })
+        product = self.env['product.product'].create({
+            'name': 'Test product',
+            'categ_id': category.id,
+            'seller_ids': [(0, 0, {
+                'name': self.env.ref('base.res_partner_1').id,
+                'min_qty': 1.0,
+            })],
+        })
+        procurement_1 = self.env['procurement.order'].create({
+            'name': 'Procurement test',
+            'product_id': product.id,
+            'product_uom': product.uom_id.id,
+            'warehouse_id': self.env.ref('stock.warehouse0').id,
+            'location_id': self.env.ref('stock.stock_location_stock').id,
+            'route_ids': [(6, 0, [
+                self.env.ref('purchase.route_warehouse0_buy').id
+            ])],
+            'product_qty': 1.0,
+        })
+        procurement_2 = procurement_1.copy()
+        return (procurement_1, procurement_2)
+
+    def test_procurement_grouped_purchase(self):
+        procurement_1, procurement_2 = self._make_procurements('standard')
+        procurement_1.run()
+        procurement_2.run()
+        self.assertTrue(procurement_1.purchase_id)
+        self.assertTrue(procurement_2.purchase_id)
+        self.assertEqual(
+            procurement_1.purchase_id,
+            procurement_2.purchase_id,
+            'Procured purchase orders are not the same')
+        self.assertEqual(
+            procurement_1.purchase_line_id,
+            procurement_2.purchase_line_id,
+            'Procured purchase orders lines are not the same')
+        return True
+
+    def test_procurement_no_grouping_line_purchase(self):
+        procurement_1, procurement_2 = self._make_procurements('line')
+        procurement_1.run()
+        procurement_2.run()
+        self.assertTrue(procurement_1.purchase_id)
+        self.assertTrue(procurement_2.purchase_id)
+        self.assertEqual(
+            procurement_1.purchase_id,
+            procurement_2.purchase_id,
+            'Procured purchase orders are not the same')
+        self.assertNotEqual(
+            procurement_1.purchase_line_id,
+            procurement_2.purchase_line_id,
+            'Procured purchase orders lines are the same')
+        return True
+
+    def test_procurement_no_grouping_order_purchase(self):
+        procurement_1, procurement_2 = self._make_procurements('order')
+        procurement_1.run()
+        procurement_2.run()
+        self.assertTrue(procurement_1.purchase_id)
+        self.assertTrue(procurement_2.purchase_id)
+        self.assertNotEqual(
+            procurement_1.purchase_id,
+            procurement_2.purchase_id,
+            'Procured purchase orders are the same')
+        self.assertNotEqual(
+            procurement_1.purchase_line_id,
+            procurement_2.purchase_line_id,
+            'Procured purchase orders lines are the same')
+        return True

--- a/procurement_purchase_no_grouping/views/product_category_view.xml
+++ b/procurement_purchase_no_grouping/views/product_category_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="product_category_form_view_inh_purchasenogroup" model="ir.ui.view" >
+            <field name="name">product.category.form.view.inh.purchasenogroup</field>
+            <field name="inherit_id" ref="product.product_category_form_view"/>
+            <field name="model">product.category</field>
+            <field name="arch" type="xml">
+                <field name="type" position="after">
+                    <field name="procured_purchase_grouping" />
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Move module procurement_purchase_no_group to OCA, while correcting tests.

See this discussion:
https://github.com/odoomrp/odoomrp-wip/issues/1141
