### PR TITLE
[MIG] From 8.0 to 9.0: product supplierinfo discount

### DIFF
--- a/product_supplierinfo_discount/README.rst
+++ b/product_supplierinfo_discount/README.rst
@@ -4,11 +4,11 @@
 Discounts in product supplier info
 ==================================
 
-This module allows to put a discount in the supplier info form, and propagate
+This module allows to input a discount in the supplier info form, and propagate
 it to purchase order lines:
 
-* The discount is directly put on purchase orders instead of reducing the
-  unit price.
+* The discount appears explicitly in purchase orders instead of being directly
+discounted in price.
 * You can set prices and discounts on the same screen.
 
 Installation

--- a/product_supplierinfo_discount/README.rst
+++ b/product_supplierinfo_discount/README.rst
@@ -5,7 +5,7 @@ Discounts in product supplier info
 ==================================
 
 This module allows to put a discount in the supplier info form, and propagate
-it to purchase orders, having two advantages over pricelists:
+it to purchase order lines:
 
 * The discount is directly put on purchase orders instead of reducing the
   unit price.
@@ -47,6 +47,7 @@ Contributors
 ------------
 
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Jonathan Nemry <jonathan.nemry@acsone.eu>
 
 Maintainer
 ----------

--- a/product_supplierinfo_discount/__init__.py
+++ b/product_supplierinfo_discount/__init__.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (c) 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
-#                       Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
+#        Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import models

--- a/product_supplierinfo_discount/__openerp__.py
+++ b/product_supplierinfo_discount/__openerp__.py
@@ -7,8 +7,7 @@
 {
     "name": "Discounts in product supplier info",
     "version": "9.0.1.0.0",
-    "author": "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
-              "Antiun Ingeniería S.L., "
+    "author": "Tecnativa, "
               "Odoo Community Association (OCA)",
     "category": "Purchase Management",
     "website": "www.serviciosbaeza.com",

--- a/product_supplierinfo_discount/__openerp__.py
+++ b/product_supplierinfo_discount/__openerp__.py
@@ -1,28 +1,12 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (c) 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
-#                       Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
+#        Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {
     "name": "Discounts in product supplier info",
-    "version": "8.0.1.0.0",
+    "version": "9.0.1.0.0",
     "author": "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
               "Antiun Ingeniería S.L., "
               "Odoo Community Association (OCA)",
@@ -36,5 +20,5 @@
     "data": [
         'views/product_supplierinfo_view.xml',
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/product_supplierinfo_discount/models/__init__.py
+++ b/product_supplierinfo_discount/models/__init__.py
@@ -5,3 +5,4 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import product_supplierinfo
 from . import purchase_order
+from . import procurement_order

--- a/product_supplierinfo_discount/models/__init__.py
+++ b/product_supplierinfo_discount/models/__init__.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (c) 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
-#                       Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
+#        Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import product_supplierinfo
 from . import purchase_order

--- a/product_supplierinfo_discount/models/procurement_order.py
+++ b/product_supplierinfo_discount/models/procurement_order.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def _prepare_purchase_order_line(self, po, supplier):
+        """
+        Apply the discount to the created purchase order
+        """
+        res = super(ProcurementOrder, self)._prepare_purchase_order_line(
+            po, supplier)
+        seller = self.product_id._select_seller(
+            self.product_id,
+            partner_id=supplier.name,
+            quantity=self.product_qty,
+            date=po.date_order and po.date_order[:10],
+            uom_id=self.product_uom)
+        if seller:
+            res['discount'] = seller.discount
+        return res

--- a/product_supplierinfo_discount/models/product_supplierinfo.py
+++ b/product_supplierinfo_discount/models/product_supplierinfo.py
@@ -1,30 +1,14 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (c) 2015 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
-#                       Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
+#        Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from openerp import models, fields
 import openerp.addons.decimal_precision as dp
 
 
-class PricelistPartnerInfo(models.Model):
-    _inherit = "pricelist.partnerinfo"
+class ProductSupplierInfo(models.Model):
+    _inherit = 'product.supplierinfo'
 
     discount = fields.Float(
         string='Discount (%)', digits_compute=dp.get_precision('Discount'))

--- a/product_supplierinfo_discount/models/purchase_order.py
+++ b/product_supplierinfo_discount/models/purchase_order.py
@@ -1,67 +1,28 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (c) 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
-#                       Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
+#        Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from openerp import models, api
 
 
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
-    @api.multi
-    def onchange_product_id(
-            self, pricelist_id, product_id, qty, uom_id, partner_id,
-            date_order=False, fiscal_position_id=False,
-            date_planned=False, name=False, price_unit=False, state='draft'):
-        res = super(PurchaseOrderLine, self).onchange_product_id(
-            pricelist_id, product_id, qty, uom_id, partner_id,
-            date_order=date_order, fiscal_position_id=fiscal_position_id,
-            date_planned=date_planned, name=name, price_unit=price_unit,
-            state=state)
-        if not product_id:
-            return res
-        supplierinfo_obj = self.env['product.supplierinfo']
-        product_obj = self.env['product.product']
-        product_uom_obj = self.env['product.uom']
-        pl_pinfo_obj = self.env['pricelist.partnerinfo']
-        # Look for a possible discount
-        product = product_obj.browse(product_id)
-        from_uom = self.env.context.get('uom') or product.uom_id.id
-        qty_in_product_uom = qty
-        partner = self.env['res.partner'].browse(partner_id)
-        sinfos = supplierinfo_obj.search(
-            [('product_tmpl_id', '=', product.product_tmpl_id.id),
-             ('name', 'child_of', partner.commercial_partner_id.id)])
-        if not sinfos:
-            return res
-        seller_uom = sinfos.product_uom.id or False
-        if seller_uom and from_uom and from_uom != seller_uom:
-            qty_in_product_uom = product_uom_obj._compute_qty(
-                from_uom, qty, to_uom_id=seller_uom)
-        pl_pinfos = pl_pinfo_obj.search(
-            [('suppinfo_id', 'in', sinfos.ids)], order="min_quantity")
-        if 'value' not in res:
-            res['value'] = {}
-        for pl_pinfo in pl_pinfos:
-            if pl_pinfo.min_quantity <= qty_in_product_uom:
-                res['value']['discount'] = pl_pinfo.discount
-            else:
-                break
+    @api.onchange('product_qty', 'product_uom')
+    def _onchange_quantity(self):
+        """
+        Check if a discount is defined into the supplier info and if so then
+        apply it to the current purchase order line
+        """
+        res = super(PurchaseOrderLine, self)._onchange_quantity()
+        if self.product_id:
+            product_supplierinfo = self.product_id._select_seller(
+                self.product_id,
+                partner_id=self.partner_id, quantity=self.product_qty,
+                date=self.order_id.date_order and
+                self.order_id.date_order[:10],
+                uom_id=self.product_uom)
+            if product_supplierinfo:
+                self.discount = product_supplierinfo.discount
         return res

--- a/product_supplierinfo_discount/tests/__init__.py
+++ b/product_supplierinfo_discount/tests/__init__.py
@@ -1,17 +1,6 @@
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
+#        Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import test_product_supplierinfo_discount

--- a/product_supplierinfo_discount/tests/test_product_supplierinfo_discount.py
+++ b/product_supplierinfo_discount/tests/test_product_supplierinfo_discount.py
@@ -1,65 +1,66 @@
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
+#        Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 import openerp.tests.common as common
+from openerp import fields
 
 
 class TestProductSupplierinfoDiscount(common.TransactionCase):
 
     def setUp(self):
         super(TestProductSupplierinfoDiscount, self).setUp()
+        self.po_model = self.env['purchase.order.line']
         self.supplierinfo_model = self.env['product.supplierinfo']
         self.purchase_order_line_model = self.env['purchase.order.line']
         self.partner_1 = self.env.ref('base.res_partner_1')
         self.partner_3 = self.env.ref('base.res_partner_3')
         self.product = self.env.ref('product.product_product_6')
-        self.supplierinfo = self.supplierinfo_model.create(
-            {'min_qty': 1,
-             'name': self.partner_3.id,
-             'product_tmpl_id': self.product.product_tmpl_id.id,
-             'pricelist_ids': [
-                 (0, 0, {'min_quantity': 1,
-                         'price': 15,
-                         'discount': 10}),
-                 (0, 0, {'min_quantity': 10,
-                         'price': 15,
-                         'discount': 20}),
-             ]}
-        )
+        self.supplierinfo = self.supplierinfo_model.create({
+            'min_qty': 0.0,
+            'name': self.partner_3.id,
+            'product_tmpl_id': self.product.product_tmpl_id.id,
+            'discount': 10,
+        })
+        self.supplierinfo2 = self.supplierinfo_model.create({
+            'min_qty': 10.0,
+            'name': self.partner_3.id,
+            'product_tmpl_id': self.product.product_tmpl_id.id,
+            'discount': 20,
+        })
+        self.purchase_order = self.env['purchase.order'].create(
+            {'partner_id': self.partner_3.id})
+        self.po_line_1 = self.po_model.create(
+            {'order_id': self.purchase_order.id,
+             'product_id': self.product.id,
+             'date_planned': fields.Datetime.now(),
+             'name': 'Test',
+             'product_qty': 1.0,
+             'product_uom': self.env.ref('product.product_uom_categ_unit').id,
+             'price_unit': 10.0})
 
-    def test_purchase_order_partner_3_qty_1(self):
-        res = self.purchase_order_line_model.onchange_product_id(
-            self.partner_3.property_product_pricelist_purchase.id,
-            self.product.id, 1, self.product.uom_id.id, self.partner_3.id)
-        self.assertEqual(
-            res['value']['discount'], 10.0,
-            "Incorrect discount for product 6 with partner 3 and qty 1")
+    def test_001_purchase_order_partner_3_qty_1(self):
+        self.po_line_1._onchange_quantity()
+        self.assertEquals(
+            self.po_line_1.discount, 10,
+            "Incorrect discount for product 6 with partner 3 and qty 1: "
+            "Should be 10%")
 
-    def test_purchase_order_partner_3_qty_10(self):
-        res = self.purchase_order_line_model.onchange_product_id(
-            self.partner_3.property_product_pricelist_purchase.id,
-            self.product.id, 10, self.product.uom_id.id, self.partner_3.id)
-        self.assertEqual(
-            res['value']['discount'], 20.0,
-            "Incorrect discount for product 6 with partner 3 and qty 10")
+    def test_002_purchase_order_partner_3_qty_10(self):
+        self.po_line_1.write({'product_qty': 10})
+        self.po_line_1._onchange_quantity()
+        self.assertEquals(
+            self.po_line_1.discount, 20.0,
+            "Incorrect discount for product 6 with partner 3 and qty 10: "
+            "Should be 20%")
 
-    def test_purchase_order_partner_1_qty_1(self):
-        res = self.purchase_order_line_model.onchange_product_id(
-            self.partner_3.property_product_pricelist_purchase.id,
-            self.product.id, 1, self.product.uom_id.id, self.partner_1.id)
-        self.assertEqual(
-            res['value'].get('discount', 0.0), 0.0,
-            "Incorrect discount for product 6 with partner 1 and qty 1")
+    def test_003_purchase_order_partner_1_qty_1(self):
+        self.po_line_1.write({
+            'partner_id': self.partner_1.id,
+            'product_qty': 1,
+        })
+        self.po_line_1.onchange_product_id()
+        self.assertEquals(
+            self.po_line_1.discount, 0.0, "Incorrect discount for product "
+            "6 with partner 1 and qty 1")

--- a/product_supplierinfo_discount/tests/test_product_supplierinfo_discount.py
+++ b/product_supplierinfo_discount/tests/test_product_supplierinfo_discount.py
@@ -64,3 +64,37 @@ class TestProductSupplierinfoDiscount(common.TransactionCase):
         self.assertEquals(
             self.po_line_1.discount, 0.0, "Incorrect discount for product "
             "6 with partner 1 and qty 1")
+
+    def test_004_prepare_purchase_order_line(self):
+        vals = {
+            'sequence': 20,
+            'location_id': self.env.ref('stock.stock_location_locations').id,
+            'picking_type_id': self.env.ref('stock.chi_picking_type_in').id,
+            'warehouse_id': self.env.ref('stock.warehouse0').id,
+            'propagate': True,
+            'procure_method': 'make_to_stock',
+            'route_sequence': 5.0,
+            'name': 'YourCompany:  Buy',
+            'route_id': self.env.ref('stock.route_warehouse0_mto').id,
+            'action': 'buy',
+        }
+        procurement_rule = self.env['procurement.rule'].create(vals)
+        vals = {
+            'origin': 'SO012:WH: Stock -> Customers MTO',
+            'product_uom': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 50,
+            'location_id': self.env.ref('stock.stock_location_locations').id,
+            'company_id': self.env.ref('base.main_company').id,
+            'state': 'confirmed',
+            'warehouse_id': self.env.ref('stock.warehouse0').id,
+            'move_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'message_unread_counter': 0,
+            'name': 'WH: Stock -> Customers MTO',
+            'product_id': self.product.id,
+            'date_planned': fields.Datetime.now(),
+            'rule_id': procurement_rule.id,
+        }
+        procurement_order = self.env['procurement.order'].create(vals)
+        res = procurement_order._prepare_purchase_order_line(
+            self.purchase_order, self.supplierinfo)
+        self.assertTrue(res.get('discount'), 'Should have a discount key')

--- a/product_supplierinfo_discount/views/product_supplierinfo_view.xml
+++ b/product_supplierinfo_discount/views/product_supplierinfo_view.xml
@@ -1,15 +1,12 @@
 <openerp>
     <data>
 
-        <record model="ir.ui.view" id="purchase_discount_order_form">
-             <field name="name">product.supplierinfo.form.view.discount</field>
+        <record model="ir.ui.view" id="product_supplierinfo_form_view">
+             <field name="name">product.supplierinfo.form.view (product_supplierinfo_discount)</field>
              <field name="model">product.supplierinfo</field>
              <field name="inherit_id" ref="product.product_supplierinfo_form_view"/>
              <field name="arch" type="xml">
-                  <xpath expr="//field[@name='pricelist_ids']/tree//field[@name='price']" position="after">
-                      <field name="discount"/>
-                  </xpath>
-                  <xpath expr="//field[@name='pricelist_ids']/form//field[@name='price']" position="after">
+                  <xpath expr="//div[field[@name='price']]" position="after">
                       <field name="discount"/>
                   </xpath>
              </field>


### PR DESCRIPTION
depends on #214 
- Fix xml_id as Odoo removed the referenced one (purchase.purchase_order_line_form --> purchase.purchase_order_line_form2)
- Add account_invoice_line.py: datas of the invoice are managed from the invoice/invoice_line with the onchange of purchase_order_id and no more from the source model of the invoice creation
- Pass _calc_line_base_price into api.multi as Odoo is now into new api
- Redefine _compute_amount to add a depends on new column 'discount'
- Remove  StockMove there is no more a _get_invoice_line_vals and invoice creation process from the stock.move
- Fix and improve tests
- Add fr translations
- OCA headers convention
