### PR TITLE
[ADD] module to manage analytic on purchase order

### DIFF
--- a/purchase_analytic/README.rst
+++ b/purchase_analytic/README.rst
@@ -1,0 +1,76 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=================
+Purchase Analytic
+=================
+
+The goal of this module is to ease analytic account management on purchase order.
+This module add analytic account on purchase order.
+
+If all lines of the purchase order have the same analytic account, the analytic account on the purchase order is automatically set with this value.
+If a analytic account is set on the purchase order, all lines of the purchase will take this value.
+
+Installation
+============
+
+To install this module, you need to:
+
+* Click on install button
+
+Usage
+=====
+
+To use this module, you need to:
+
+* Go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/8.0
+
+Known issues / Roadmap
+======================
+
+* ...
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+purchase-workflow/issues/new?body=module:%20
+purchase_analytic%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Laetitia Gangloff <laetitia.gangloff@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_analytic/__init__.py
+++ b/purchase_analytic/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/purchase_analytic/__openerp__.py
+++ b/purchase_analytic/__openerp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Purchase Analytic",
+    "version": "8.0.1.0.0",
+    'author': "Acsone SA/NV,Odoo Community Association (OCA)",
+    "category": "Purchase Management",
+    "website": "http://www.acsone.eu",
+    "depends": ["purchase"
+                ],
+    "data": ["views/purchase_views.xml"],
+    "license": "AGPL-3",
+    "installable": True,
+    "application": False,
+}

--- a/purchase_analytic/i18n/fr.po
+++ b/purchase_analytic/i18n/fr.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_analytic
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-07 08:25+0000\n"
+"PO-Revision-Date: 2016-04-07 08:25+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_analytic
+#: field:purchase.order,project_id2:0
+msgid "Contract / Analytic"
+msgstr "Contrat / analytique"
+
+#. module: purchase_analytic
+#: model:ir.model,name:purchase_analytic.model_purchase_order
+msgid "Purchase Order"
+msgstr "Bon de commande"
+
+#. module: purchase_analytic
+#: help:purchase.order,project_id2:0
+msgid "Use to store the value of project_id if there is no lines"
+msgstr "Utilisé pour stocker la valeur du champs project_id lorsqu'il n'y a pas de lignes"
+
+#. module: purchase_analytic
+#: view:purchase.order:purchase_analytic.purchase_order_view_form_inherit_purchase_analytic
+msgid "{'default_account_analytic_id': project_id}"
+msgstr ""
+

--- a/purchase_analytic/i18n/purchase_analytic.pot
+++ b/purchase_analytic/i18n/purchase_analytic.pot
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_analytic
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-07 08:25+0000\n"
+"PO-Revision-Date: 2016-04-07 08:25+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_analytic
+#: field:purchase.order,project_id2:0
+msgid "Contract / Analytic"
+msgstr ""
+
+#. module: purchase_analytic
+#: model:ir.model,name:purchase_analytic.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: purchase_analytic
+#: help:purchase.order,project_id2:0
+msgid "Use to store the value of project_id if there is no lines"
+msgstr ""
+
+#. module: purchase_analytic
+#: view:purchase.order:purchase_analytic.purchase_order_view_form_inherit_purchase_analytic
+msgid "{'default_account_analytic_id': project_id}"
+msgstr ""
+

--- a/purchase_analytic/models/__init__.py
+++ b/purchase_analytic/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import purchase

--- a/purchase_analytic/models/purchase.py
+++ b/purchase_analytic/models/purchase.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    project_id2 = fields.Many2one(
+        comodel_name='account.analytic.account',
+        string='Contract / Analytic',
+        help='Use to store the value of project_id if there is no lines')
+    project_id = fields.Many2one(
+        compute='_compute_project_id',
+        inverse='_inverse_project_id',
+        comodel_name='account.analytic.account',
+        string='Contract / Analytic', readonly=True,
+        states={'draft': [('readonly', False)]},
+        store=True,
+        help="The analytic account related to a sales order.")
+
+    @api.one
+    @api.depends('order_line.account_analytic_id')
+    def _compute_project_id(self):
+        """ If all order line have same analytic account set project_id
+        """
+        al = self.project_id2
+        if self.order_line:
+            al = (self.order_line[0].account_analytic_id) or False
+            for ol in self.order_line:
+                if ol.account_analytic_id != al:
+                    al = False
+                    break
+        self.project_id = al
+
+    @api.one
+    def _inverse_project_id(self):
+        """ When set project_id set analytic account on all order lines
+        """
+        if self.project_id:
+            self.order_line.write({'account_analytic_id': self.project_id.id})
+        self.project_id2 = self.project_id
+
+    @api.onchange('project_id')
+    def _onchange_project_id(self):
+        """ When change project_id set analytic account on all order lines
+            Do it in one operation to avoid to recompute the project_id field
+            during the change.
+            In case of new record, nothing is recomputed to avoid ugly message
+        """
+        r = []
+        for ol in self.order_line:
+            if isinstance(ol.id, int):
+                r.append((1, ol.id,
+                          {'account_analytic_id': self.project_id.id}))
+            else:
+                # this is new record, do nothing !
+                return
+        self.project_id2 = self.project_id
+        self.order_line = r
+
+    def _get_merge_order_key(self):
+        res = super(PurchaseOrder, self)._get_merge_order_key()
+        return res + ('project_id', )

--- a/purchase_analytic/tests/__init__.py
+++ b/purchase_analytic/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_purchase_analytic

--- a/purchase_analytic/tests/test_purchase_analytic.py
+++ b/purchase_analytic/tests/test_purchase_analytic.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import openerp.tests.common as common
+
+
+class TestPurchaseAnalytic(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseAnalytic, self).setUp()
+
+    def test_analytic_account(self):
+        """ Create a purchase order with line
+            Set analytic account on purchase
+            Check analytic account on line is set
+        """
+        po = self.env['purchase.order'].create(
+            {'partner_id': self.env.ref('base.res_partner_16').id,
+             'location_id': self.env.ref('stock.stock_location_stock').id,
+             'pricelist_id': self.env.ref('purchase.list0').id
+             })
+
+        vals = self.env['purchase.order.line'].onchange_product_id(
+            po.pricelist_id.id, self.env.ref('product.product_product_34').id,
+            0, False, po.partner_id.id, date_order=po.date_order,
+            fiscal_position_id=po.fiscal_position.id, date_planned=False,
+            name=False, price_unit=False, state=po.state)
+        vals['value']['order_id'] = po.id
+        vals['value']['product_id'] = self.env.ref(
+            'product.product_product_34').id
+        po_line = self.env['purchase.order.line'].create(vals['value'])
+        po.project_id = self.env.ref('account.analytic_project_1').id
+        self.assertEqual(po.project_id.id,
+                         self.env.ref('account.analytic_project_1').id)
+        self.assertEqual(po_line.account_analytic_id.id,
+                         self.env.ref('account.analytic_project_1').id)
+
+    def test_project_id(self):
+        """ Create a purchase order without line
+            Set analytic account on purchase
+            Check analytic account is on purchase
+        """
+        po = self.env['purchase.order'].new(
+            {'partner_id': self.env.ref('base.res_partner_16').id,
+             'location_id': self.env.ref('stock.stock_location_stock').id,
+             'pricelist_id': self.env.ref('purchase.list0').id,
+             'project_id': self.env.ref('account.analytic_project_1').id
+             })
+        po._onchange_project_id()
+        self.assertEqual(po.project_id.id,
+                         self.env.ref('account.analytic_project_1').id)
+
+    def _create_po(self, partner_id):
+        po = self.env['purchase.order'].create(
+            {'partner_id': partner_id,
+             'location_id': self.env.ref('stock.stock_location_stock').id,
+             'pricelist_id': self.env.ref('purchase.list0').id
+             })
+
+        vals = self.env['purchase.order.line'].onchange_product_id(
+            po.pricelist_id.id, self.env.ref('product.product_product_34').id,
+            0, False, po.partner_id.id, date_order=po.date_order,
+            fiscal_position_id=po.fiscal_position.id, date_planned=False,
+            name=False, price_unit=False, state=po.state)
+        vals['value']['order_id'] = po.id
+        vals['value']['product_id'] = self.env.ref(
+            'product.product_product_34').id
+        self.env['purchase.order.line'].create(vals['value'])
+        return po
+
+    def test_merge_po(self):
+        """ Create po1 with project1
+            Create po2 with project1
+            Create po3 with project2
+            Merge po1 with po2
+            Check po1 and po2 are cancelled
+            Check po4 is created with project1
+            Merge po4 with po3
+            Check po4 and po3 are draft
+        """
+        project1 = self.env.ref('account.analytic_project_1')
+        project2 = self.env.ref('account.analytic_project_2')
+        partner_id = self.env.ref('base.res_partner_4').id
+        po1 = self._create_po(partner_id)
+        po1.project_id = project1.id
+        po2 = self._create_po(partner_id)
+        po2.project_id = project1.id
+        po3 = self._create_po(partner_id)
+        po3.project_id = project2.id
+        po_merge = po1 + po2
+        new_order = po_merge.do_merge()
+        self.assertEqual(1, len(new_order))
+        old_po_id = new_order.values()[0]
+        self.assertTrue(po1.id in old_po_id)
+        self.assertTrue(po2.id in old_po_id)
+        self.assertEqual('cancel', po1.state)
+        self.assertEqual('cancel', po2.state)
+        po4 = self.env['purchase.order'].browse(new_order.keys()[0])
+        self.assertEqual(project1.id, po4.project_id.id)
+        po_merge = po3 + po4
+        new_order = po_merge.do_merge()
+        self.assertEqual(0, len(new_order))
+        self.assertEqual('draft', po3.state)
+        self.assertEqual('draft', po4.state)

--- a/purchase_analytic/views/purchase_views.xml
+++ b/purchase_analytic/views/purchase_views.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="purchase_order_view_search_inherit_purchase_analytic" model="ir.ui.view">
+            <field name="name">purchase.order.search (purchase_analytic)</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.view_purchase_order_filter"/>
+            <field name="arch" type="xml">
+                <data>
+                    <field name="create_uid" position="after">
+                        <field name="project_id" groups="purchase.group_analytic_accounting"/>
+                    </field>
+                </data>
+            </field>
+        </record>
+
+        <record id="purchase_order_view_tree_inherit_purchase_analytic" model="ir.ui.view">
+            <field name="name">purchase.order.tree (purchase_analytic)</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_tree"/>
+            <field name="arch" type="xml">
+                <data>
+                    <field name="origin" position="before">
+                        <field name="project_id" groups="purchase.group_analytic_accounting"/>
+                    </field>
+                </data>
+            </field>
+        </record>
+
+        <record id="purchase_order_view_form_inherit_purchase_analytic" model="ir.ui.view">
+            <field name="name">purchase.order.form (purchase_analytic)</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_form"/>
+            <field name="arch" type="xml">
+                <data>
+                    <field name="partner_ref" position="after">
+                        <field name="project_id2" invisible="1" />
+                        <field name="project_id" groups="purchase.group_analytic_accounting"
+                               domain="[('type','in',('view', 'normal', 'contract'))]"
+                               options="{'no_create': True}" />
+                    </field>
+                    <field name="order_line" position="attributes">
+                        <attribute name="context">{'default_account_analytic_id': project_id}</attribute>
+                    </field>
+                </data>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
This module allow user to set analytic account on purchase order instead of purchase order line.
When analytic account is set on purchase order, all lines of this purchase order will be on this analytic account.
