### PR TITLE
[7.0] Add condition to not retrieve framework agreements with no available quantity

### DIFF
--- a/framework_agreement/model/framework_agreement.py
+++ b/framework_agreement/model/framework_agreement.py
@@ -410,6 +410,8 @@ class framework_agreement(orm.Model):
                        ('draft', '=', False)]
         if qty:
             search_args.append(('available_quantity', '>=', qty))
+        else:
+            search_args.append(('available_quantity', '>', 0.0))
         agreement_ids = self.search(cr, uid, search_args)
         if agreement_ids:
             return self.browse(cr, uid, agreement_ids, context=context)


### PR DESCRIPTION
Issue found : when 2 framework agreements are active and on the same product, if the first one has no available quantity anymore, it is still retrieved and used for sourcing (for example).

This adds a small condition to avoid already consumed framework agreements.
