### PR TITLE
[ADD][9.0] Module 'product_supplierinfo_editable'

### DIFF
--- a/product_supplierinfo_editable/README.rst
+++ b/product_supplierinfo_editable/README.rst
@@ -1,0 +1,66 @@
+.. image:: https://img.shields.io/badge/license-LGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/lgpl.html
+   :alt: License: LGPL-3
+
+============================
+Product Supplerinfo Editable
+============================
+
+This module provides the framework to define if a Supplier Pricelist is
+editable. This module used as standalone will not provide any visual effect.
+
+
+
+Installation
+============
+
+No external library is used.
+
+Configuration
+=============
+
+Other modules should implement method `_compute_is_editable` of model
+`product.supplierinfo` introduced here to define when is the pricelist not
+editable.
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Eficent Business and IT Consulting Services S.L. <contact@eficent.com>
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/product_supplierinfo_editable/__init__.py
+++ b/product_supplierinfo_editable/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import models

--- a/product_supplierinfo_editable/__openerp__.py
+++ b/product_supplierinfo_editable/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Product Supplierinfo Editable",
+    "summary": "Allows to to define if a Supplier Pricelist is editable",
+    "version": "9.0.1.0.0",
+    "category": "Generic Modules",
+    "author": "Eficent Business and IT Consulting Services S.L.",
+    "website": "https://www.odoo-community.org",
+    "license": "LGPL-3",
+    "depends": ['product'],
+    "data": [
+        'views/product_supplierinfo_view.xml'
+    ],
+    "installable": True,
+}
+

--- a/product_supplierinfo_editable/models/__init__.py
+++ b/product_supplierinfo_editable/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import product_supplierinfo

--- a/product_supplierinfo_editable/models/product_supplierinfo.py
+++ b/product_supplierinfo_editable/models/product_supplierinfo.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from openerp import api, fields, models
+
+
+class ProductSupplierinfo(models.Model):
+    _inherit = "product.supplierinfo"
+
+    is_editable = fields.Boolean(string='Is editable',
+                                 compute='_compute_is_editable',
+                                 default=True)
+
+    @api.multi
+    @api.depends('state')
+    def _compute_is_editable(self):
+        for rec in self:
+            rec.is_editable = True

--- a/product_supplierinfo_editable/views/product_supplierinfo_view.xml
+++ b/product_supplierinfo_editable/views/product_supplierinfo_view.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="product_supplierinfo_form_view" model="ir.ui.view">
+            <field name="name">product.supplierinfo.form.view</field>
+            <field name="model">product.supplierinfo</field>
+            <field name="inherit_id"
+                   ref="product.product_supplierinfo_form_view"/>
+            <field name="arch" type="xml">
+                <field name="company_id" position="after">
+                    <field name="is_editable" invisible="True"/>
+                </field>
+                <field name="name" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="product_name" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="product_code" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="product_id" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="delay" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="product_tmpl_id" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="min_qty" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="product_uom" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="price" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="currency_id" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="date_start" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="date_end" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+                <field name="company_id" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_editable','=', False)]}</attribute>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
# 
# Product Supplerinfo Editable

This module provides the framework to define if a Supplier Pricelist is
editable. This module used as standalone will not provide any visual effect.
# Configuration

Other modules should implement method `_compute_is_editable` of model
`product.supplierinfo` introduced here to define when is the pricelist not
editable.
