### PR TITLE
 [UPT][8.0]Delete the purchase request line if the procurement is cancelled

### DIFF
--- a/purchase_request_procurement/models/procurement.py
+++ b/purchase_request_procurement/models/procurement.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openerp import _, api, fields, models
-from openerp.exceptions import ValidationError
+from openerp.exceptions import Warning as UserError
 
 
 class Procurement(models.Model):
@@ -76,7 +76,7 @@ class Procurement(models.Model):
         result = super(Procurement, self).propagate_cancel(procurement)
         # Remove the reference to the request_id from the procurement order
         request = procurement.request_id
-        procurement.write({'request_id': None})
+        procurement.write({'request_id': False})
         # Search for purchase request lines containing the procurement_id
         request_lines = self.env['purchase.request.line'].\
             search([('procurement_id', '=', procurement.id)])
@@ -84,11 +84,10 @@ class Procurement(models.Model):
         # or reject
         for line in request_lines:
             if line.request_id.state not in ('draft', 'reject'):
-                raise ValidationError(_('Can not cancel this procurement as '
-                                        'the related purchase request is in '
-                                        'progress confirmed already. '
-                                        'Please cancel the purchase request '
-                                        'first.'))
+                raise UserError(_('Can not cancel this procurement as the '
+                                  'related purchase request is in progress '
+                                  'confirmed already. Please cancel the '
+                                  'purchase request first.'))
             else:
                 line.unlink()
         # If the purchase request has not lines, delete it as well

--- a/purchase_request_procurement/models/procurement.py
+++ b/purchase_request_procurement/models/procurement.py
@@ -82,13 +82,15 @@ class Procurement(models.Model):
             search([('procurement_id', '=', procurement.id)])
         # Remove the purchase request lines, if the request is not draft
         # or reject
-        for line in request_lines:
-            if line.request_id.state not in ('draft', 'reject'):
-                raise UserError(_('Can not cancel this procurement as the '
-                                  'related purchase request is in progress '
-                                  'confirmed already. Please cancel the '
-                                  'purchase request first.'))
-            else:
+        approved_lines = request_lines.filtered(
+            lambda r: r.request_state not in ('draft', 'reject'))
+        if approved_lines:
+            raise UserError(_('Can not cancel this procurement as the '
+                              'related purchase request is in progress '
+                              'confirmed already. Please cancel the '
+                              'purchase request first.'))
+        else:
+            for line in request_lines:
                 line.unlink()
         # If the purchase request has not lines, delete it as well
         if len(request.line_ids) == 0:

--- a/purchase_request_procurement/models/procurement.py
+++ b/purchase_request_procurement/models/procurement.py
@@ -84,8 +84,8 @@ class Procurement(models.Model):
         # or reject
         for line in request_lines:
             if line.request_id.state not in ('draft', 'reject'):
-                raise ValidationError(_('Can not cancel this procurement as the'
-                                        ' related purchase request is in '
+                raise ValidationError(_('Can not cancel this procurement as '
+                                        'the related purchase request is in '
                                         'progress confirmed already. '
                                         'Please cancel the purchase request '
                                         'first.'))

--- a/purchase_request_procurement/models/procurement.py
+++ b/purchase_request_procurement/models/procurement.py
@@ -6,6 +6,7 @@
 from openerp import _, api, fields, models
 from openerp.exceptions import ValidationError
 
+
 class Procurement(models.Model):
     _inherit = 'procurement.order'
 
@@ -70,7 +71,6 @@ class Procurement(models.Model):
             return True
         return super(Procurement, self)._run(procurement)
 
-
     @api.model
     def propagate_cancel(self, procurement):
         result = super(Procurement, self).propagate_cancel(procurement)
@@ -79,18 +79,19 @@ class Procurement(models.Model):
         procurement.write({'request_id': None})
         # Search for purchase request lines containing the procurement_id
         request_lines = self.env['purchase.request.line'].\
-            search([('procurement_id','=',procurement.id)])
+            search([('procurement_id', '=', procurement.id)])
         # Remove the purchase request lines, if the request is not draft
         # or reject
         for line in request_lines:
-            if line.request_id.state not in ('draft','reject'):
-                raise ValidationError(_('Can not cancel this procurement as'
-                                ' the related purchase request is in progress'
-                                ' confirmed already.  Please cancel the'
-                                ' purchase request first.'))
+            if line.request_id.state not in ('draft', 'reject'):
+                raise ValidationError(_('Can not cancel this procurement as the'
+                                        ' related purchase request is in '
+                                        'progress confirmed already. '
+                                        'Please cancel the purchase request '
+                                        'first.'))
             else:
                 line.unlink()
         # If the purchase request has not lines, delete it as well
-        if len (request.line_ids) == 0:
+        if len(request.line_ids) == 0:
             request.unlink()
         return result

--- a/purchase_request_procurement/tests/__init__.py
+++ b/purchase_request_procurement/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_purchase_request_procurement

--- a/purchase_request_procurement/tests/test_purchase_request_procurement.py
+++ b/purchase_request_procurement/tests/test_purchase_request_procurement.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests import common
+from openerp import fields
+from openerp.exceptions import ValidationError
+
+class TestPurchaseRequestProcurement(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseRequestProcurement, self).setUp()
+        self.purchase_request_ = self.env['purchase.request']
+        self.purchase_request_line = self.env['purchase.request.line']
+        self.product_1 = self.env.ref('product.product_product_16')
+        self.product_1.purchase_request = True
+        self.product_2 = self.env.ref('product.product_product_13')
+
+    def create_purchase_request(self, name):
+        values = {'company_id': self.env.ref('base.main_company').id,
+                  'date_planned': fields.Datetime.now(),
+                  'name': name,
+                  'product_id': self.product_1.id,
+                  'product_qty': 4,
+                  'product_uom': self.product_1.uom_id.id,
+                  'warehouse_id': self.env.ref('stock.warehouse0').id,
+                  'location_id': self.env.ref('stock.stock_location_stock').id,
+                  'route_ids':
+                      [(
+                       4, self.env.ref('purchase.route_warehouse0_buy').id, 0)],
+                  }
+
+        return self.env['procurement.order'].create(values)
+
+    def test_1_purchase_request_in_progress(self):
+
+        proc = self.create_purchase_request('SOME/TEST/0001')
+        proc.check()
+        proc.run()
+        request = proc.request_id
+        request.button_approved()
+        with self.assertRaises(ValidationError):
+            proc.cancel()
+
+    def test_2_purchase_request_remove_lines(self):
+        proc = self.create_purchase_request('SOME/TEST/0002')
+        proc.check()
+        proc.run()
+        request = proc.request_id
+        self.assertEqual(len(request.line_ids),1)
+        proc.cancel()
+        request = proc.request_id
+        self.assertEqual(len(request),0)
+
+    def test_3_purchase_request_keep_manual(self):
+        proc = self.create_purchase_request('SOME/TEST/0003')
+        proc.check()
+        proc.run()
+        request = proc.request_id
+        #create line
+        vals = {
+            'request_id': request.id,
+            'product_id': self.product_2.id,
+            'product_uom_id': self.product_2.uom_id.id,
+            'product_qty': 5.0,
+        }
+        self.purchase_request_line.create(vals)
+        self.assertEqual(len(request.line_ids), 2)
+        proc.cancel()
+        self.assertEqual(len(request.line_ids), 1)
+

--- a/purchase_request_procurement/tests/test_purchase_request_procurement.py
+++ b/purchase_request_procurement/tests/test_purchase_request_procurement.py
@@ -2,12 +2,12 @@
 # Copyright 2016 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp.tests import common
+from openerp.tests.common import TransactionCase
 from openerp import fields
-from openerp.exceptions import ValidationError
+from openerp.exceptions import Warning as UserError
 
 
-class TestPurchaseRequestProcurement(common.TransactionCase):
+class TestPurchaseRequestProcurement(TransactionCase):
 
     def setUp(self):
         super(TestPurchaseRequestProcurement, self).setUp()
@@ -41,7 +41,7 @@ class TestPurchaseRequestProcurement(common.TransactionCase):
         proc.run()
         request = proc.request_id
         request.button_approved()
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(UserError):
             proc.cancel()
 
     def test_2_purchase_request_remove_lines(self):

--- a/purchase_request_procurement/tests/test_purchase_request_procurement.py
+++ b/purchase_request_procurement/tests/test_purchase_request_procurement.py
@@ -6,6 +6,7 @@ from openerp.tests import common
 from openerp import fields
 from openerp.exceptions import ValidationError
 
+
 class TestPurchaseRequestProcurement(common.TransactionCase):
 
     def setUp(self):
@@ -27,7 +28,8 @@ class TestPurchaseRequestProcurement(common.TransactionCase):
                   'location_id': self.env.ref('stock.stock_location_stock').id,
                   'route_ids':
                       [(
-                       4, self.env.ref('purchase.route_warehouse0_buy').id, 0)],
+                       4, self.env.ref('purchase.route_warehouse0_buy').id,
+                       0)],
                   }
 
         return self.env['procurement.order'].create(values)
@@ -47,17 +49,17 @@ class TestPurchaseRequestProcurement(common.TransactionCase):
         proc.check()
         proc.run()
         request = proc.request_id
-        self.assertEqual(len(request.line_ids),1)
+        self.assertEqual(len(request.line_ids), 1)
         proc.cancel()
         request = proc.request_id
-        self.assertEqual(len(request),0)
+        self.assertEqual(len(request), 0)
 
     def test_3_purchase_request_keep_manual(self):
         proc = self.create_purchase_request('SOME/TEST/0003')
         proc.check()
         proc.run()
         request = proc.request_id
-        #create line
+        # create line
         vals = {
             'request_id': request.id,
             'product_id': self.product_2.id,
@@ -68,4 +70,3 @@ class TestPurchaseRequestProcurement(common.TransactionCase):
         self.assertEqual(len(request.line_ids), 2)
         proc.cancel()
         self.assertEqual(len(request.line_ids), 1)
-


### PR DESCRIPTION
When the procurement creates a purchase request and later the procurement it is cancelled, the corresponding purchase request line is removed. If the Purchase request has not lines anymore it is also deleted.

This is done only if the purchase request is in state draft or rejected.
