### PR TITLE
8.0 Add module purchase_commercial_partner

### DIFF
--- a/purchase_commercial_partner/README.rst
+++ b/purchase_commercial_partner/README.rst
@@ -1,0 +1,55 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===========================
+Purchase Commercial Partner
+===========================
+
+This module adds a related stored field *Commercial Supplier* on purchase orders. It is similar to the native field *Commercial Partner* on invoices. This module is the twin brother of the OCA module *sale_commercial_partner* located in the `sale-workflow project <https://github.com/OCA/sale-workflow/>`_.
+
+Usage
+=====
+
+In the search view of RFQ/purchase orders, you can group by *Commercial Supplier*.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/8.0
+
+Known issues / Roadmap
+======================
+
+Add commercial_partner_id in purchase.report. This is not easy because the
+SQL view which is the basis of purchase.report cannot be inherited.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_commercial_partner/__init__.py
+++ b/purchase_commercial_partner/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/purchase_commercial_partner/__openerp__.py
+++ b/purchase_commercial_partner/__openerp__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Purchase Commercial Partner',
+    'version': '8.0.1.0.0',
+    'category': 'Purchase Management',
+    'license': 'AGPL-3',
+    'summary': "Add stored related field 'Commercial Supplier' on POs",
+    'author': 'Akretion,Odoo Community Association (OCA)',
+    'website': 'http://www.akretion.com',
+    'depends': ['purchase'],
+    'data': [
+        'views/purchase.xml',
+    ],
+    'installable': True,
+}

--- a/purchase_commercial_partner/models/__init__.py
+++ b/purchase_commercial_partner/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import purchase

--- a/purchase_commercial_partner/models/purchase.py
+++ b/purchase_commercial_partner/models/purchase.py
@@ -10,4 +10,4 @@ class PurchaseOrder(models.Model):
 
     commercial_partner_id = fields.Many2one(
         'res.partner', related='partner_id.commercial_partner_id', store=True,
-        string='Commercial Supplier')
+        index=True, string='Commercial Supplier')

--- a/purchase_commercial_partner/models/purchase.py
+++ b/purchase_commercial_partner/models/purchase.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    commercial_partner_id = fields.Many2one(
+        'res.partner', related='partner_id.commercial_partner_id', store=True,
+        string='Commercial Supplier')

--- a/purchase_commercial_partner/views/purchase.xml
+++ b/purchase_commercial_partner/views/purchase.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<openerp>
+<data>
+
+
+<record id="purchase_order_form" model="ir.ui.view">
+    <field name="name">commercial.partner.purchase.order.form</field>
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase.purchase_order_form"/>
+    <field name="arch" type="xml">
+        <field name="partner_id" position="before">
+            <field name="commercial_partner_id" invisible="1"/>
+        </field>
+    </field>
+</record>
+
+<record id="view_request_for_quotation_filter" model="ir.ui.view">
+    <field name="name">commercial.partner.rfq.purchase.order.search</field>
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase.view_request_for_quotation_filter"/>
+    <field name="arch" type="xml">
+        <filter context="{'group_by':'partner_id'}" position="before">
+            <filter name="commercial_partner_groupby"
+                string="Commercial Supplier"
+                context="{'group_by': 'commercial_partner_id'}"/>
+        </filter>
+    </field>
+</record>
+
+<record id="view_purchase_order_filter" model="ir.ui.view">
+    <field name="name">commercial.partner.purchase.order.search</field>
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase.view_purchase_order_filter"/>
+    <field name="arch" type="xml">
+        <filter context="{'group_by':'partner_id'}" position="before">
+            <filter name="commercial_partner_groupby"
+                string="Commercial Supplier"
+                context="{'group_by': 'commercial_partner_id'}"/>
+        </filter>
+    </field>
+</record>
+
+
+</data>
+</openerp>


### PR DESCRIPTION
This module purchase_commercial_partner is the twin brother of the module sale_commercial_partner which is available in this PR: https://github.com/OCA/sale-workflow/pull/332
