### PR TITLE
[8.0] FIX default sequence

### DIFF
--- a/purchase_order_reorder_lines/models/purchase.py
+++ b/purchase_order_reorder_lines/models/purchase.py
@@ -29,7 +29,8 @@ class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
     _order = 'order_id desc, sequence, id'
 
-    sequence = fields.Integer(help="Gives the sequence of this line when "
+    sequence = fields.Integer(default=0,
+                              help="Gives the sequence of this line when "
                                    "displaying the purchase order.")
 
 

--- a/purchase_order_reorder_lines/models/purchase.py
+++ b/purchase_order_reorder_lines/models/purchase.py
@@ -29,7 +29,7 @@ class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
     _order = 'order_id desc, sequence, id'
 
-    sequence = fields.Integer(default=0,
+    sequence = fields.Integer(default=10,
                               help="Gives the sequence of this line when "
                                    "displaying the purchase order.")
 


### PR DESCRIPTION
Without defaul parameter if you create a purchase order with one line, the sequence of this order line is 0 on odoo, but is null on database, and ordering lines null is after all integer.

To reproduce error:
- Create sale order, with one line and save.
- Edit and create new line, and save.
  then new line has first on list, and the first line created allways be the last.

With this default=0 it fix this bug
