### PR TITLE
[8.0][purchase_request][FIX] Description of the purchase request line is not passed to PO line

### DIFF
--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -107,6 +107,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             name=False, price_unit=False, state='draft')['value']
         vals.update({
             'order_id': po.id,
+            'name': item.name,
             'product_id': product.id,
             'account_analytic_id': item.line_id.analytic_account_id.id,
             'taxes_id': [(6, 0, vals.get('taxes_id', []))],
@@ -124,6 +125,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
     def _get_order_line_search_domain(self, order, item):
         vals = self._prepare_purchase_order_line(order, item)
         order_line_data = [('order_id', '=', order.id),
+                           ('name', '=', item.name),
                            ('product_id', '=', item.product_id.id or False),
                            ('product_uom', '=', vals['product_uom']),
                            ('account_analytic_id', '=',


### PR DESCRIPTION
What this PR does: When a po line is to be created, first look for an existing po line that also matches in name. Otherwise create a new line, with name to be the same as the purchase request line.
