### PR TITLE
[9.0] [FIX] purchase_request - Error in definition of group 'Purchase Request User'

### DIFF
--- a/purchase_request/security/purchase_request.xml
+++ b/purchase_request/security/purchase_request.xml
@@ -12,13 +12,14 @@
 
     <record id="group_purchase_request_user" model="res.groups">
         <field name="name">Purchase Request User</field>
-        <field name="users" eval="[(4, ref('base.group_user'))]"/>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="category_id" ref="module_category_purchase_request"/>
     </record>
 
     <record id="group_purchase_request_manager" model="res.groups">
         <field name="name">Purchase Request Manager</field>
         <field name="implied_ids" eval="[(4, ref('purchase_request.group_purchase_request_user'))]"/>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
         <field name="category_id" ref="module_category_purchase_request"/>
     </record>
 


### PR DESCRIPTION
The group "Purchase Request User" was defined incorrectly, using:
`<field name="users" eval="[(4, ref('base.group_user'))]"/>`
instead of:
`<field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>`