### PR TITLE
[9.0][FIX] Purchase order type menu child of purchase configuration menu

### DIFF
--- a/purchase_order_type/__openerp__.py
+++ b/purchase_order_type/__openerp__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Purchase Order Type",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.1.0",
     "category": "Purchase Management",
     "website": "http://www.camptocamp.com",
     "author": "Camptocamp,"

--- a/purchase_order_type/views/view_purchase_order_type.xml
+++ b/purchase_order_type/views/view_purchase_order_type.xml
@@ -36,8 +36,8 @@
     </record>
 
     <menuitem id="menu_purchase_order_type"
-      parent="purchase.menu_purchase_general_settings"
-      sequence="40"
+      parent="purchase.menu_purchase_config"
+      sequence="10"
       action="action_purchase_order_type_view"/>
 
 </odoo>


### PR DESCRIPTION
Purchase order type menu is child of purchase / configuration / configuration and makes configuration  un clickeable on enterprise interface. We change it to be a child of purchase / configuration menu

Before this PR:
![seleccion_034](https://cloud.githubusercontent.com/assets/3016656/21654688/6c61bfea-d295-11e6-9297-637baedfba46.png)


After this PR:
![seleccion_033](https://cloud.githubusercontent.com/assets/3016656/21654690/727c20dc-d295-11e6-9156-fbb7864a2dd0.png)

