### PR TITLE
[9.0][IMP][purchase_discount] Make stock move cost be aware of discount

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -30,3 +30,9 @@ class PurchaseOrderLine(models.Model):
         ('discount_limit', 'CHECK (discount <= 100.0)',
          'Discount must be lower than 100%.'),
     ]
+
+    @api.multi
+    def _get_stock_move_price_unit(self):
+        price_unit = super(PurchaseOrderLine,
+                           self)._get_stock_move_price_unit()
+        return price_unit * (1 - (self.discount / 100))


### PR DESCRIPTION
This functionality is implemented in 8.0 but not in subsequent versions. It makes the stock moves created from purchase receptions reflect the line discount in its cost.