### PR TITLE
[9.0][FIX] SERIUS ERROR with purchase order line subtotal with purchase_discount

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -17,9 +17,7 @@ class PurchaseOrderLine(models.Model):
             if line.discount:
                 prices[line.id] = line.price_unit
                 line.price_unit *= (1 - line.discount / 100.0)
-        super(PurchaseOrderLine, self)._compute_amount()
-        # restore prices
-        for line in self:
+            super(PurchaseOrderLine, line)._compute_amount()
             if line.discount:
                 line.price_unit = prices[line.id]
 


### PR DESCRIPTION
### Steps to reproduce in oca runbot:
Note: this happens with any products or vendor, I mention specific ones to make it easier to reproduce the error.
1. Go to Purchases / Requests for quotations
2. Create a new one, choose partner "ASUSTEK"
3. Add one line, choose product "Ice Cream" set unit price "100" discount "50%"
4. Create another line with same values
5. Before saving pay attention to lines subtotal (50 on each) and order total (100)
6. Save the order

### Error
One line subtotal is replaced for 100 and order subtotal is 150. (Check image attached). Amounts of the order are wrong and have inconsistency.

### Solution
I can not understand yet why this happens, but the solved solution fix it, and as far as I can see it don't have an impact on performance because when saving the order each line is saved separately.
Screenshot on runbot before this pr
![seleccion_047](https://cloud.githubusercontent.com/assets/3016656/22308650/945223b8-e326-11e6-9185-3fe66f55fcdc.png)

Screenshot on runbot of this pr
![seleccion_048](https://cloud.githubusercontent.com/assets/3016656/22309624/cd045f42-e32a-11e6-8501-3cdc48e7b3ae.png)

