### PR TITLE
[9.0][FIX]purchase_request_to_rfq: Fix invisible domain in PO line tree views

### DIFF
--- a/purchase_request_to_rfq/views/purchase_order_view.xml
+++ b/purchase_request_to_rfq/views/purchase_order_view.xml
@@ -13,7 +13,7 @@
                        position="inside">
                     <field name="purchase_request_lines" invisible="1"/>
                     <button string="Purchase Request lines"
-                        attrs="{'invisible': [('purchase_request_lines', '=', [])]}"
+                        attrs="{'invisible': [('purchase_request_lines', '=', False)]}"
                         name="action_openRequestLineTreeView"
                         type="object"
                         icon="gtk-open"/>
@@ -41,7 +41,7 @@
                 <xpath expr="//tree" position="inside">
                     <field name="purchase_request_lines" invisible="1"/>
                     <button string="Purchase Request lines"
-                        attrs="{'invisible': [('purchase_request_lines', '=', [])]}"
+                        attrs="{'invisible': [('purchase_request_lines', '=', False)]}"
                         name="action_openRequestLineTreeView"
                         type="object"
                         icon="gtk-open"/>


### PR DESCRIPTION
Fix invisible domain in PO line tree views by s/('purchase_request_lines', '=', [])/('purchase_request_lines', '=', False)