### PR TITLE
[9.0] [purchase_request] Remove uom from onchange method.

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -236,7 +236,7 @@ class PurchaseRequestLine(models.Model):
                                      'Procurement Order',
                                      readonly=True)
 
-    @api.onchange('product_id', 'product_uom_id')
+    @api.onchange('product_id')
     def onchange_product_id(self):
         if self.product_id:
             name = self.product_id.name


### PR DESCRIPTION
[FIXED] When using the multiple units option for purchase request the units of measure resets when changing from the purchase request line form.