### PR TITLE
[9.0] [purchase_request_to_rfq] - Fix in create RFQ

### DIFF
--- a/purchase_request_to_rfq/models/purchase_request.py
+++ b/purchase_request_to_rfq/models/purchase_request.py
@@ -80,7 +80,8 @@ class PurchaseRequestLine(models.Model):
             or False
 
     @api.model
-    def _calc_new_qty_price(self, request_line, po_line=None, cancel=False):
+    def _calc_new_qty_price(self, request_line, po_line=None, cancel=False,
+                            new_pr_line=False):
         uom_obj = self.env['product.uom']
         qty = uom_obj._compute_qty(request_line.product_uom_id.id,
                                    request_line.product_qty,
@@ -102,15 +103,16 @@ class PurchaseRequestLine(models.Model):
                 if supplierinfos:
                     supplierinfo_min_qty = supplierinfos[0].min_qty
 
-        if not supplierinfo_min_qty:
-            qty += po_line.product_qty
-        else:
-            # Recompute quantity by adding existing running procurements.
-            for rl in po_line.purchase_request_lines:
-                qty += uom_obj._compute_qty(rl.product_uom_id.id,
-                                            rl.product_qty,
-                                            rl.product_id.uom_po_id.id)
-            qty = max(qty, supplierinfo_min_qty) if qty > 0.0 else 0.0
+        rl_qty = 0.0
+        # Recompute quantity by adding existing running procurements.
+        for rl in po_line.purchase_request_lines:
+            rl_qty += uom_obj._compute_qty(rl.product_uom_id.id,
+                                           rl.product_qty,
+                                           rl.product_id.uom_po_id.id)
+        new_qty = 0.0
+        if not new_pr_line:
+            new_qty = qty + po_line.product_qty
+        qty = max(rl_qty, supplierinfo_min_qty, new_qty)
 
         price = po_line.price_unit
         if qty != po_line.product_qty:

--- a/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
@@ -72,3 +72,45 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
 
         # Test also for onchanges on non created lines
         self.purchase_request_line.new({}).is_editable
+
+    def test_purchase_request_to_purchase_rfq_minimum_order_qty(self):
+
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request.id,
+            'product_id': self.env.ref('product.product_product_8').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line = self.purchase_request_line.create(vals)
+        vals = {
+            'supplier_id': self.env.ref('base.res_partner_12').id,
+        }
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line.id],
+            active_id=purchase_request_line.id,).create(vals)
+        wiz_id.make_purchase_order()
+        self.assertTrue(
+            len(purchase_request_line.purchase_lines),
+            'Should have a purchase line')
+        self.assertEquals(
+            purchase_request_line.purchase_lines.product_id.id,
+            purchase_request_line.product_id.id,
+            'Should have same product')
+        self.assertEquals(
+            purchase_request_line.purchase_lines.state,
+            purchase_request_line.purchase_state,
+            'Should have same state')
+        self.assertEquals(
+            purchase_request_line.purchase_lines.product_qty,
+            5,
+            'The PO line should have the minimum order quantity.')
+        self.assertEquals(
+            purchase_request_line,
+            purchase_request_line.purchase_lines.purchase_request_lines,
+            'The PO should cross-reference to the purchase request.')

--- a/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
@@ -88,8 +88,9 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
         }
         purchase_request_line = self.purchase_request_line.create(vals)
         vals = {
-            'supplier_id': self.env.ref('base.res_partner_12').id,
+            'supplier_id': self.env.ref('base.res_partner_1').id,
         }
+        purchase_request.button_approved()
         wiz_id = self.wiz.with_context(
             active_model="purchase.request.line",
             active_ids=[purchase_request_line.id],

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -228,7 +228,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                 if new_qty > po_line.product_qty:
                     po_line.product_qty = new_qty
                     po_line.price_unit = new_price
-                    po_line.purchase_request_lines = [(4, line.id)]
+                po_line.purchase_request_lines = [(4, line.id)]
             else:
                 po_line_data = self._prepare_purchase_order_line(purchase,
                                                                  item)

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -223,16 +223,17 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             available_po_lines = po_line_obj.search(domain)
             if available_po_lines:
                 po_line = available_po_lines[0]
-                new_qty, new_price = pr_line_obj._calc_new_qty_price(
-                    line, po_line=po_line)
-                if new_qty > po_line.product_qty:
-                    po_line.product_qty = new_qty
-                    po_line.price_unit = new_price
                 po_line.purchase_request_lines = [(4, line.id)]
             else:
                 po_line_data = self._prepare_purchase_order_line(purchase,
                                                                  item)
-                po_line_obj.create(po_line_data)
+                po_line = po_line_obj.create(po_line_data)
+            new_qty, new_price = pr_line_obj._calc_new_qty_price(
+                line, po_line=po_line,
+                new_pr_line=len(available_po_lines) >= 1)
+            po_line.product_qty = new_qty
+            po_line.price_unit = new_price
+
             res.append(purchase.id)
 
         return {


### PR DESCRIPTION
Port of https://github.com/OCA/purchase-workflow/pull/247 to 9.0

- When the RFQ was created from a purchase request line,
if the product has a minimum defined in the product.supplierinfo,
a RFQ line was created with quantity ordered = minimum.
If a second request line was later added, and the sum of
the request lines was < RFQ line quantity, no link was
established between the RFQ line and the new request line.
- Tests are added to include the scenario of creating an
RFQ for a purchase request that contains a product that has minimums.