### PR TITLE
[9.0][FIX][purchase_request_to_rfq] Some improvements

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -30,7 +30,7 @@ class PurchaseRequest(models.Model):
 
     @api.model
     def _get_default_name(self):
-        return self.env['ir.sequence'].get('purchase.request')
+        return self.env['ir.sequence'].next_by_code('purchase.request')
 
     @api.model
     def _default_picking_type(self):
@@ -241,9 +241,9 @@ class PurchaseRequestLine(models.Model):
         if self.product_id:
             name = self.product_id.name
             if self.product_id.code:
-                name = '[%s] %s' % (name, self.product_id.code)
+                name = '[%s] %s' % (self.product_id.code, name)
             if self.product_id.description_purchase:
                 name += '\n' + self.product_id.description_purchase
             self.product_uom_id = self.product_id.uom_id.id
-            self.product_qty = 1
+            self.product_qty = 1.0
             self.name = name

--- a/purchase_request_to_rfq/models/purchase_request.py
+++ b/purchase_request_to_rfq/models/purchase_request.py
@@ -80,50 +80,44 @@ class PurchaseRequestLine(models.Model):
             or False
 
     @api.model
-    def _calc_new_qty_price(self, request_line, po_line=None, cancel=False):
-        uom_obj = self.env['product.uom']
-        qty = uom_obj._compute_qty(request_line.product_uom_id.id,
-                                   request_line.product_qty,
-                                   request_line.product_id.uom_po_id.id)
+    def _get_supplier_min_qty(self, product, partner_id=False):
+        seller_min_qty = 0.0
+        if partner_id:
+            seller = product.seller_ids \
+                .filtered(lambda r: r.name == partner_id) \
+                .sorted(key=lambda r: r.min_qty)
+        else:
+            seller = product.seller_ids.sorted(key=lambda r: r.min_qty)
+        if seller:
+            seller_min_qty = seller[0].min_qty
+        return seller_min_qty
+
+    @api.model
+    def _calc_new_qty(self, request_line, po_line=None, cancel=False,
+                      new_pr_line=False):
+        uom = request_line.product_uom_id
+        qty = uom._compute_qty(
+            request_line.product_id.uom_po_id, request_line.product_qty)
+
         # Make sure we use the minimum quantity of the partner corresponding
         # to the PO. This does not apply in case of dropshipping
         supplierinfo_min_qty = 0.0
         if not po_line.order_id.dest_address_id:
-            if po_line.product_id.seller_ids and \
-                po_line.product_id.seller_ids[0].id == \
-                    po_line.order_id.partner_id.id:
-                supplierinfo_min_qty = po_line.product_id.seller_ids[0].min_qty
-            else:
-                supplierinfo_obj = self.env['product.supplierinfo']
-                supplierinfos = supplierinfo_obj.search(
-                    [('name', '=', po_line.order_id.partner_id.id),
-                     ('product_tmpl_id', '=',
-                      po_line.product_id.product_tmpl_id.id)])
-                if supplierinfos:
-                    supplierinfo_min_qty = supplierinfos[0].min_qty
+            supplierinfo_min_qty = self._get_supplier_min_qty(
+                po_line.product_id, po_line.order_id.partner_id)
 
-        if not supplierinfo_min_qty:
-            qty += po_line.product_qty
-        else:
-            # Recompute quantity by adding existing running procurements.
-            for rl in po_line.purchase_request_lines:
-                qty += uom_obj._compute_qty(rl.product_uom_id.id,
-                                            rl.product_qty,
-                                            rl.product_id.uom_po_id.id)
-            qty = max(qty, supplierinfo_min_qty) if qty > 0.0 else 0.0
+        rl_qty = 0.0
+        # Recompute quantity by adding existing running procurements.
+        for rl in po_line.purchase_request_lines:
+            rl_qty += rl.product_uom_id._compute_qty(
+                rl.product_id.uom_po_id, rl.product_qty)
+        new_qty = 0.0
+        if not new_pr_line:
+            new_qty = qty + po_line.product_qty
 
-        price = po_line.price_unit
-        if qty != po_line.product_qty:
-            pricelist_obj = self.pool['product.pricelist']
-            pricelist_id = po_line.order_id.partner_id.\
-                property_product_pricelist.id
-            price = pricelist_obj.price_get(
-                self.env.cr, self.env.uid, [pricelist_id],
-                request_line.product_id.id, qty,
-                po_line.order_id.partner_id.id,
-                {'uom': request_line.product_id.uom_po_id.id})[pricelist_id]
+        qty = max(rl_qty, supplierinfo_min_qty, new_qty)
 
-        return qty, price
+        return qty
 
     @api.multi
     def unlink(self):

--- a/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
@@ -72,3 +72,98 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
 
         # Test also for onchanges on non created lines
         self.purchase_request_line.new({}).is_editable
+
+    def test_purchase_request_to_purchase_rfq_minimum_order_qty(self):
+
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request.id,
+            'product_id': self.env.ref('product.product_product_8').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line = self.purchase_request_line.create(vals)
+        vals = {
+            'supplier_id': self.env.ref('base.res_partner_1').id,
+        }
+        purchase_request.button_approved()
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line.id],
+            active_id=purchase_request_line.id,).create(vals)
+        wiz_id.make_purchase_order()
+        self.assertTrue(
+            len(purchase_request_line.purchase_lines),
+            'Should have a purchase line')
+        self.assertEquals(
+            purchase_request_line.purchase_lines.product_id.id,
+            purchase_request_line.product_id.id,
+            'Should have same product')
+        self.assertEquals(
+            purchase_request_line.purchase_lines.state,
+            purchase_request_line.purchase_state,
+            'Should have same state')
+        self.assertEquals(
+            purchase_request_line.purchase_lines.product_qty,
+            5,
+            'The PO line should have the minimum order quantity.')
+        self.assertEquals(
+            purchase_request_line,
+            purchase_request_line.purchase_lines.purchase_request_lines,
+            'The PO should cross-reference to the purchase request.')
+
+    def test_purchase_request_to_purchase_rfq_multiple_PO(self):
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request1 = self.purchase_request.create(vals)
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request2 = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request1.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line1 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line2 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line3 = self.purchase_request_line.create(vals)
+        vals = {
+            'supplier_id': self.env.ref('base.res_partner_1').id,
+        }
+        purchase_request1.button_approved()
+        purchase_request2.button_approved()
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line1.id, purchase_request_line2.id,
+                        purchase_request_line3.id]).create(vals)
+        for item in wiz_id.item_ids:
+            if item.line_id.id == purchase_request_line2.id:
+                item.keep_description = True
+            if item.line_id.id == purchase_request_line3.id:
+                item.onchange_product_id()
+        wiz_id.make_purchase_order()
+        self.assertEquals(purchase_request_line1.purchased_qty, 2.0,
+                          'Should be a quantity of 2')
+        self.assertEquals(purchase_request_line2.purchased_qty, 1.0,
+                          'Should be a quantity of 1')

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -34,6 +34,7 @@
                                   <field name="product_qty"/>
                                   <field name="product_uom_id"
                                          groups="product.group_uom"/>
+                                  <field name="keep_description"/>
                               </tree>
                          </field>
                      </group>


### PR DESCRIPTION
Superseeds https://github.com/OCA/purchase-workflow/pull/346.

At this moment, this PR solves/fixes the following issues:
- Taxes and prices not determined in the PO line
- Wrong PO lines when creating a RFQ with several purchase request lines of same product
- <code>.get()</code> from ir.sequence model is deprecated in the new API

At this moment, this PR has this features:
- Adds .keep_description
- Adds backport of v10 improvements like onchange method
- Adds several tests