### PR TITLE
[9.0][procurement_service]

### DIFF
--- a/procurement_service/README.rst
+++ b/procurement_service/README.rst
@@ -1,0 +1,59 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================
+Procurement service
+===================
+
+This module allows to generate procurements from confirmed sale orders when the
+product is a service and is assigned the Buy and Make To Order rules.
+The "Routes" field is always displayed on the product form view, regardless of
+product type.
+
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/8.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <ajuaristo@gmail.com>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/procurement_service/__init__.py
+++ b/procurement_service/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Avanzosc(http://www.avanzosc.es)
+# Copyright 2015 Tecnativa (http://www.tecnativa.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/procurement_service/__openerp__.py
+++ b/procurement_service/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Avanzosc(http://www.avanzosc.es)
+# Copyright 2015 Tecnativa (http://www.tecnativa.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Procurement Service",
+    "version": "8.0.1.0.0",
+    "summary": "Allows to generate procurements from confirmed sale orders",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Tecnativa",
+    "website": "http://www.odoomrp.com",
+    "category": "Procurements",
+    "depends": ['product',
+                'sale',
+                'stock',
+                'purchase',
+                ],
+    "data": ['views/product_template_view.xml',
+             ],
+    "installable": True
+}

--- a/procurement_service/i18n/es.po
+++ b/procurement_service/i18n/es.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * procurement_service
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:44+0000\n"
+"PO-Revision-Date: 2015-10-09 10:50+0000\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/oca/odoomrp-wip-8-0/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: procurement_service
+#: model:ir.model,name:procurement_service.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+
+#. module: procurement_service
+#: model:ir.model,name:procurement_service.model_sale_order
+msgid "Sales Order"
+msgstr "Pedidos de venta"
+
+#. module: procurement_service
+#: view:product.template:procurement_service.view_template_property_form_inh_procservice
+msgid "Supply Chain Information"
+msgstr ""

--- a/procurement_service/i18n/pt_BR.po
+++ b/procurement_service/i18n/pt_BR.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * procurement_service
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:44+0000\n"
+"PO-Revision-Date: 2015-10-09 03:36+0000\n"
+"Last-Translator: danimaribeiro <danimaribeiro@gmail.com>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/oca/odoomrp-wip-8-0/language/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: procurement_service
+#: model:ir.model,name:procurement_service.model_procurement_order
+msgid "Procurement"
+msgstr "Aprovisionamento"
+
+#. module: procurement_service
+#: model:ir.model,name:procurement_service.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venda"
+
+#. module: procurement_service
+#: view:product.template:procurement_service.view_template_property_form_inh_procservice
+msgid "Supply Chain Information"
+msgstr ""

--- a/procurement_service/i18n/ro.po
+++ b/procurement_service/i18n/ro.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * procurement_service
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-11-20 18:10+0000\n"
+"PO-Revision-Date: 2015-09-10 16:42+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Romanian (http://www.transifex.com/oca/odoomrp-wip-8-0/language/ro/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#. module: procurement_service
+#: model:ir.model,name:procurement_service.model_procurement_order
+msgid "Procurement"
+msgstr "Aprovizionare"
+
+#. module: procurement_service
+#: model:ir.model,name:procurement_service.model_sale_order
+msgid "Sales Order"
+msgstr "Comandă vânzare"
+
+#. module: procurement_service
+#: view:product.template:procurement_service.view_template_property_form_inh_procservice
+msgid "Supply Chain Information"
+msgstr ""

--- a/procurement_service/i18n/sl.po
+++ b/procurement_service/i18n/sl.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * procurement_service
+# 
+# Translators:
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:44+0000\n"
+"PO-Revision-Date: 2015-09-20 19:01+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
+"Language-Team: Slovenian (http://www.transifex.com/oca/odoomrp-wip-8-0/language/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: procurement_service
+#: model:ir.model,name:procurement_service.model_procurement_order
+msgid "Procurement"
+msgstr "Oskrbovanje"
+
+#. module: procurement_service
+#: model:ir.model,name:procurement_service.model_sale_order
+msgid "Sales Order"
+msgstr "Prodajni nalog"
+
+#. module: procurement_service
+#: view:product.template:procurement_service.view_template_property_form_inh_procservice
+msgid "Supply Chain Information"
+msgstr "Podatki o nabavni verigi"

--- a/procurement_service/models/__init__.py
+++ b/procurement_service/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Avanzosc(http://www.avanzosc.es)
+# Copyright 2015 Tecnativa (http://www.tecnativa.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import procurement_order
+from . import product

--- a/procurement_service/models/procurement_order.py
+++ b/procurement_service/models/procurement_order.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Avanzosc(http://www.avanzosc.es)
+# Copyright 2015 Tecnativa (http://www.tecnativa.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.model
+    def _assign(self, procurement):
+        res = super(ProcurementOrder, self)._assign(procurement)
+        if procurement.product_id.type == 'service':
+            rule_id = self._find_suitable_rule(procurement)
+            if rule_id:
+                procurement.rule_id = rule_id
+            res = bool(rule_id)
+        return res

--- a/procurement_service/models/product.py
+++ b/procurement_service/models/product.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Avanzosc(http://www.avanzosc.es)
+# Copyright 2015 Tecnativa (http://www.tecnativa.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api
+
+
+class Product(models.Model):
+    _inherit = 'product.product'
+
+    @api.multi
+    def need_procurement(self):
+        for product in self:
+            if product.type == 'service':
+                return True
+        return super(Product, self).need_procurement()

--- a/procurement_service/models/sale_order.py
+++ b/procurement_service/models/sale_order.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Avanzosc(http://www.avanzosc.es)
+# Copyright 2015 Tecnativa (http://www.tecnativa.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.one
+    def action_button_confirm(self):
+        procurement_obj = self.env['procurement.order']
+        procurement_group_obj = self.env['procurement.group']
+        res = super(SaleOrder, self).action_button_confirm()
+        for line in self.order_line:
+            valid = self._validate_service_product_for_procurement(
+                line.product_id)
+            if valid:
+                if not self.procurement_group_id:
+                    vals = self._prepare_procurement_group(self)
+                    group = procurement_group_obj.create(vals)
+                    self.write({'procurement_group_id': group.id})
+                vals = self._prepare_order_line_procurement(
+                    self, line, group_id=self.procurement_group_id.id)
+                vals['name'] = self.name + ' - ' + line.product_id.name
+                procurement_obj.create(vals)
+        return res
+
+    def _validate_service_product_for_procurement(self, product):
+        routes = product.route_ids.filtered(
+            lambda r: r.id in (self.env.ref('stock.route_warehouse0_mto').id,
+                               self.env.ref('purchase.route_warehouse0_buy').id
+                               ))
+        return product.type == 'service' and len(routes) == 2

--- a/procurement_service/tests/__init__.py
+++ b/procurement_service/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Avanzosc(http://www.avanzosc.es)
+# Copyright 2015 Tecnativa (http://www.tecnativa.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_procurement_service

--- a/procurement_service/tests/test_procurement_service.py
+++ b/procurement_service/tests/test_procurement_service.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Avanzosc(http://www.avanzosc.es)
+# Copyright 2015 Tecnativa (http://www.tecnativa.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import openerp.tests.common as common
+
+
+class TestProcurementService(common.TransactionCase):
+
+    def setUp(self):
+        super(TestProcurementService, self).setUp()
+        self.product_model = self.env['product.product']
+        self.partner_model = self.env['res.partner']
+        self.sale_model = self.env['sale.order']
+        self.sale_line_model = self.env['sale.order.line']
+        self.procurement_model = self.env['procurement.order']
+        product_vals = {
+            'name': 'Service Generated Procurement',
+            'standard_price': 20.5,
+            'list_price': 30.75,
+            'type': 'service',
+            'route_ids': [(6, 0,
+                           [self.env.ref('stock.route_warehouse0_mto').id,
+                            self.env.ref('purchase.route_warehouse0_buy').id
+                            ])]}
+        self.service_product = self.product_model.create(product_vals)
+        partner_vals = {'name': 'Customer for procurement service',
+                        'customer': True}
+        self.partner = self.partner_model.create(partner_vals)
+        sale_vals = {'partner_id': self.partner.id,
+                     'partner_shipping_id': self.partner.id,
+                     'partner_invoice_id': self.partner.id,
+                     'pricelist_id': self.env.ref('product.list0').id}
+        sale_line_vals = {'product_id': self.service_product.id,
+                          'name': self.service_product.name,
+                          'product_uos_qty': 1,
+                          'product_uom': self.service_product.uom_id.id,
+                          'price_unit': self.service_product.list_price}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+
+    def test_confirm_sale_and_generate_procurement_service(self):
+        self.sale_order.action_button_confirm()
+        for line in self.sale_order.order_line:
+            cond = [('sale_line_id', '=', line.id)]
+            procs = self.procurement_model.search(cond)
+            self.assertEqual(
+                len(procs), 1,
+                "Procurement not generated for the service product type")

--- a/procurement_service/views/product_template_view.xml
+++ b/procurement_service/views/product_template_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_template_property_form_inh_procservice" >
+            <field name="name">view.template.property.form.inh.procservice</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="stock.view_template_property_form"/>
+            <field name="arch" type="xml">
+                <field name="route_ids" position="attributes">
+                    <attribute name="attrs"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Procurement service
===================

This module allows to generate procurements from confirmed sale orders when the
product is a service and is assigned the Buy and Make To Order rules.
The "Routes" field is always displayed on the product form view, regardless of
product type.

