### PR TITLE
[9.0][FIX][purchase_delivery_split_date]Datetime issue.

### DIFF
--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -3,6 +3,9 @@
 # © 2016 Eficent Business and IT Consulting Services, S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from datetime import datetime
+from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT
+
 import logging
 from itertools import groupby
 from openerp import models, api
@@ -20,7 +23,9 @@ class PurchaseOrderLine(models.Model):
         dictionary element with the field that you want to group by. This
         method is designed for extensibility, so that other modules can add
         additional keys or replace them by others."""
-        key = ({'date_planned': line.date_planned},)
+        date = datetime.strptime(
+            line.date_planned, DEFAULT_SERVER_DATETIME_FORMAT)
+        key = ({'date_planned': date.date()},)
         return key
 
     @api.model


### PR DESCRIPTION
As found by @gmeficent in https://github.com/OCA/purchase-workflow/pull/313 in v9 the <code>date_planned</code> is now datetime field so the module <code>purchase_delivery_split_date</code> was not working as in v8. This PR fix this issue.