### PR TITLE
[10.0] Add_purchase_company_currency

### DIFF
--- a/purchase_company_currency/README.rst
+++ b/purchase_company_currency/README.rst
@@ -1,0 +1,55 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+==================================
+Purchase Order in company currency
+==================================
+
+This module adds functional fields to show Purchase Order in the company currency:
+amount total.
+
+1. For tree view, when you have PO in multiple currencies, Odoo sums them
+regardless the different currencies. This modules removes this useless sum and
+add a column & sum in the company's currency.
+
+2. The field is also shown in form view after the total.
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/92/10.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Denis Leemann <denis.leemann@camptocamp.com>
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_company_currency/__init__.py
+++ b/purchase_company_currency/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/purchase_company_currency/__manifest__.py
+++ b/purchase_company_currency/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': "Company currency in purchase orders",
+    'version': "10.0.1.0.0",
+    'author': "Camptocamp, "
+              "Odoo Community Association (OCA) ",
+    'website': "https://odoo-community.org/",
+    'category': "Purchase",
+    'license': "AGPL-3",
+    'depends': ["purchase"],
+    'data': [
+        "views/purchase_order_view.xml"
+    ],
+    'installable': True,
+}

--- a/purchase_company_currency/models/__init__.py
+++ b/purchase_company_currency/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import purchase_order

--- a/purchase_company_currency/models/purchase_order.py
+++ b/purchase_company_currency/models/purchase_order.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    company_currency_id = fields.Many2one(
+        'res.currency',
+        related='company_id.currency_id',
+        string="Company Currency",
+        readonly=True
+    )
+    amount_total_curr = fields.Monetary(
+        string="Total Amount",
+        readonly=True,
+        help='Sale Order Amount in the company Currency',
+        compute="_compute_amount_company",
+        currency_id='company_currency_id',
+    )
+
+    @api.multi
+    @api.depends('amount_total')
+    def _compute_amount_company(self):
+        for po in self:
+            if po.state in ('purchase', 'done'):
+                po_date = po.confirmation_date
+            else:
+                po_date = po.date_order
+            po.amount_total_curr = po.currency_id.with_context(
+                date=po_date).compute(
+                po.amount_total, po.company_id.currency_id)

--- a/purchase_company_currency/views/purchase_order_view.xml
+++ b/purchase_company_currency/views/purchase_order_view.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+  <!-- Purchase Order total in company currency -->
+  <record id="purchase_order_tree" model="ir.ui.view">
+    <field name="name">purchase.order.tree</field>
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase.purchase_order_tree" />
+    <field name="arch" type="xml">
+
+      <!-- Remove sums where field is in multiple currencies -->
+      <field name="amount_untaxed" position="attributes">
+        <attribute name="sum" />
+      </field>
+      <field name="amount_total" position="attributes">
+        <attribute name="sum" />
+      </field>
+      <!--  Sum in company currency -->
+      <field name="amount_total" position="after">
+        <field name='company_currency_id' invisible="True"/>
+        <field
+          name="amount_total_curr"
+          sum="Total"
+          string="Total (Company Currency)"
+          widget="monetary"
+          options="{'currency_field': 'company_currency_id'}" />
+      </field>
+
+    </field>
+  </record>
+    <!-- Purchase Order total in company currency -->
+  <record id="purchase_order_form" model="ir.ui.view">
+    <field name="name">purchase.order.form</field>
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase.purchase_order_form" />
+    <field name="arch" type="xml">
+      <!--  Sum in company currency -->
+      <field name="amount_total" position="after">
+        <field name='company_currency_id' invisible="True"/>
+        <field
+          name="amount_total_curr"
+          sum="Total"
+          string="Total (Company Currency)"
+          widget="monetary"
+          options="{'currency_field': 'company_currency_id'}" />
+      </field>
+
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
This module adds functional fields to show Purchase Order in the company currency:
amount total.

1. For tree view, when you have SO in multiple currencies, Odoo sums them
regardless the different currencies. This modules removes this useless sum and
add a column & sum in the company's currency.
2. The field is also shown in form view after the total.
