### PR TITLE
[IMP] purchase_discount: fix stock get_price_unit

### DIFF
--- a/purchase_discount/README.rst
+++ b/purchase_discount/README.rst
@@ -48,7 +48,7 @@ Contributors
 
 * OpenERP S.A.
 * Ignacio Ibeas <ignacio@acysos.com>
-* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
 
 Icon

--- a/purchase_discount/__openerp__.py
+++ b/purchase_discount/__openerp__.py
@@ -10,7 +10,7 @@
               "Tecnativa, "
               "ACSONE SA/NV,"
               "Odoo Community Association (OCA)",
-    "version": "9.0.1.0.1",
+    "version": "9.0.1.1.0",
     "category": "Purchase Management",
     "depends": [
         "stock",

--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -28,3 +28,17 @@ class PurchaseOrderLine(models.Model):
         ('discount_limit', 'CHECK (discount <= 100.0)',
          'Discount must be lower than 100%.'),
     ]
+
+    @api.multi
+    def _get_stock_move_price_unit(self):
+        """Get correct price with discount replacing current price_unit
+        value before calling super and restoring it later for assuring
+        maximum inheritability.
+        """
+        if self.discount:
+            price_unit = self.price_unit
+            self.price_unit *= (100 - self.discount) / 100
+        price = super(PurchaseOrderLine, self)._get_stock_move_price_unit()
+        if self.discount:
+            self.price_unit = price_unit
+        return price

--- a/purchase_discount/tests/test_purchase_discount.py
+++ b/purchase_discount/tests/test_purchase_discount.py
@@ -6,42 +6,61 @@ import openerp.tests.common as common
 from openerp import fields
 
 
-class TestPurchaseOrder(common.TransactionCase):
-
-    def setUp(self):
-        super(TestPurchaseOrder, self).setUp()
-        self.product_1 = self.env.ref('product.product_product_4')
-        self.product_2 = self.env.ref('product.product_product_5b')
-        po_model = self.env['purchase.order.line']
-        self.purchase_order = self.env['purchase.order'].create(
-            {'partner_id': self.env.ref('base.res_partner_3').id})
-        self.po_line_1 = po_model.create(
-            {'order_id': self.purchase_order.id,
-             'product_id': self.product_1.id,
-             'date_planned': fields.Datetime.now(),
-             'name': 'Test',
-             'product_qty': 1.0,
-             'product_uom': self.product_1.uom_id.id,
-             'discount': 50.0,
-             'price_unit': 10.0})
-        self.tax = self.env['account.tax'].create(
-            {'name': 'Sample tax 15%',
-             'amount_type': 'percent',
-             'type_tax_use': 'purchase',
-             'amount': 15.0})
-        self.po_line_2 = po_model.create(
-            {'order_id': self.purchase_order.id,
-             'product_id': self.product_2.id,
-             'date_planned': fields.Datetime.now(),
-             'name': 'Test',
-             'product_qty': 10.0,
-             'product_uom': self.product_2.uom_id.id,
-             'discount': 30,
-             'taxes_id': [(6, 0, [self.tax.id])],
-             'price_unit': 230.0})
+class TestPurchaseOrder(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestPurchaseOrder, cls).setUpClass()
+        cls.product_1 = cls.env['product.product'].create({
+            'name': 'Test product 1',
+            'type': 'product',
+        })
+        cls.product_2 = cls.env['product.product'].create({
+            'name': 'Test product 2',
+            'type': 'product',
+        })
+        po_model = cls.env['purchase.order.line']
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'Test supplier',
+            'supplier': True,
+        })
+        cls.purchase_order = cls.env['purchase.order'].create({
+            'partner_id': cls.partner.id,
+        })
+        cls.po_line_1 = po_model.create({
+            'order_id': cls.purchase_order.id,
+            'product_id': cls.product_1.id,
+            'date_planned': fields.Datetime.now(),
+            'name': 'Test',
+            'product_qty': 1.0,
+            'product_uom': cls.product_1.uom_id.id,
+            'discount': 50.0,
+            'price_unit': 10.0,
+        })
+        cls.tax = cls.env['account.tax'].create({
+            'name': 'Sample tax 15%',
+            'amount_type': 'percent',
+            'type_tax_use': 'purchase',
+            'amount': 15.0,
+        })
+        cls.po_line_2 = po_model.create({
+            'order_id': cls.purchase_order.id,
+            'product_id': cls.product_2.id,
+            'date_planned': fields.Datetime.now(),
+            'name': 'Test',
+            'product_qty': 10.0,
+            'product_uom': cls.product_2.uom_id.id,
+            'discount': 30,
+            'taxes_id': [(6, 0, cls.tax.ids)],
+            'price_unit': 230.0,
+        })
 
     def test_purchase_order_vals(self):
         self.assertEqual(self.po_line_1.price_subtotal, 5.0)
         self.assertEqual(self.po_line_2.price_subtotal, 1610.0)
         self.assertEqual(self.purchase_order.amount_untaxed, 1615.0)
         self.assertEqual(self.purchase_order.amount_tax, 241.5)
+
+    def test_move_price_unit(self):
+        self.purchase_order.button_confirm()
+        self.assertEqual(self.po_line_1.move_ids[0].price_unit, 5.0)
+        self.assertEqual(self.po_line_2.move_ids[0].price_unit, 161.0)


### PR DESCRIPTION
There's the concept of unit price in stock moves that it's used for stock valuation, and this one doesn't have the correct price when using discounts before this commit.

cc @Tecnativa