### PR TITLE
[9.0][FIX][purchase_location_by_line] Pickings to include the correct destination location

### DIFF
--- a/purchase_location_by_line/__openerp__.py
+++ b/purchase_location_by_line/__openerp__.py
@@ -21,5 +21,4 @@
         "views/purchase_view.xml"
     ],
     'installable': True,
-    'active': False,
 }

--- a/purchase_location_by_line/models/__init__.py
+++ b/purchase_location_by_line/models/__init__.py
@@ -4,3 +4,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import purchase
+from . import stock_picking

--- a/purchase_location_by_line/models/purchase.py
+++ b/purchase_location_by_line/models/purchase.py
@@ -40,8 +40,8 @@ class PurchaseOrderLine(models.Model):
     @api.multi
     def _create_stock_moves(self, picking):
         res = super(PurchaseOrderLine, self)._create_stock_moves(picking)
-        for move, line in zip(res, self):
-            if line.order_id.picking_type_id.code == \
-                    'internal' and line.location_dest_id:
-                move.write({'location_dest_id': line.location_dest_id.id})
+        for line in self:
+            if line.location_dest_id:
+                line.move_ids.write(
+                    {'location_dest_id': line.location_dest_id.id})
         return res

--- a/purchase_location_by_line/models/stock_picking.py
+++ b/purchase_location_by_line/models/stock_picking.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+#   (<http://www.eficent.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, models
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.multi
+    def _update_picking_from_group_key(self, key):
+        """The picking is updated with data from the grouping key.
+        This method is designed for extensibility, so that other modules
+        can store more data based on new keys."""
+        super(StockPicking, self)._update_picking_from_group_key(key)
+        for rec in self:
+            for key_element in key:
+                if ('location_dest_id' in key_element.keys() and
+                        key_element['location_dest_id']):
+                    rec.location_dest_id = key_element['location_dest_id']
+        return False


### PR DESCRIPTION
This PR fixes the process that creates pickings from Purchase Orders, so that the destination location of the picking equals to the destination location of the PO Line.