### PR TITLE
[9.0][FIX][purchase_request_to_rfq] purchased quantity to use the PO UoM

### DIFF
--- a/purchase_request_to_rfq/models/purchase_request.py
+++ b/purchase_request_to_rfq/models/purchase_request.py
@@ -95,10 +95,10 @@ class PurchaseRequestLine(models.Model):
     @api.model
     def _calc_new_qty(self, request_line, po_line=None, cancel=False,
                       new_pr_line=False):
-        uom = request_line.product_uom_id
-        qty = uom._compute_qty(
-            request_line.product_id.uom_po_id, request_line.product_qty)
-
+        purchase_uom = po_line.product_uom or request_line.product_id.uom_po_id
+        qty = purchase_uom._compute_qty(
+            request_line.product_uom_id.id, request_line.product_qty,
+            purchase_uom.id)
         # Make sure we use the minimum quantity of the partner corresponding
         # to the PO. This does not apply in case of dropshipping
         supplierinfo_min_qty = 0.0
@@ -109,8 +109,8 @@ class PurchaseRequestLine(models.Model):
         rl_qty = 0.0
         # Recompute quantity by adding existing running procurements.
         for rl in po_line.purchase_request_lines:
-            rl_qty += rl.product_uom_id._compute_qty(
-                rl.product_id.uom_po_id, rl.product_qty)
+            rl_qty += purchase_uom._compute_qty(
+                rl.product_uom_id.id, rl.product_qty, purchase_uom.id)
         new_qty = 0.0
         if not new_pr_line:
             new_qty = qty + po_line.product_qty

--- a/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
@@ -167,3 +167,59 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
                           'Should be a quantity of 2')
         self.assertEquals(purchase_request_line2.purchased_qty, 1.0,
                           'Should be a quantity of 1')
+
+    def test_purchase_request_to_purchase_rfq_multiple_PO_purchaseUoM(self):
+        product = self.env.ref('product.product_product_6')
+        product.uom_po_id = self.env.ref('product.product_uom_dozen')
+
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request1 = self.purchase_request.create(vals)
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request2 = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request1.id,
+            'product_id': product.id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 12.0,
+        }
+        purchase_request_line1 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': product.id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 12.0,
+        }
+        purchase_request_line2 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 12.0,
+        }
+        purchase_request_line3 = self.purchase_request_line.create(vals)
+        vals = {
+            'supplier_id': self.env.ref('base.res_partner_1').id,
+        }
+        purchase_request1.button_approved()
+        purchase_request2.button_approved()
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line1.id, purchase_request_line2.id,
+                        purchase_request_line3.id]).create(vals)
+        for item in wiz_id.item_ids:
+            if item.line_id.id == purchase_request_line2.id:
+                item.keep_description = True
+            if item.line_id.id == purchase_request_line3.id:
+                item.onchange_product_id()
+        wiz_id.make_purchase_order()
+        po_line = purchase_request_line1.purchase_lines[0]
+        self.assertEquals(po_line.product_qty, 2.0, 'Quantity should be 2')
+        self.assertEquals(po_line.product_uom,
+                          self.env.ref('product.product_uom_dozen'),
+                          'The purchase UoM should be Dozen(s).')


### PR DESCRIPTION
We have identified that in the cases where you wanted to purchase from a purchase request, where the product had a purchase uom different from the base UoM, the quantity that was transferred to the PO was the original from the purchase request, but the unit was the purchase UoM.

E.g. your purchase request is un Unit(s)
The product has Purchase UoM Dozen(s)

your purchase request is 12 unit(s). Your po is created with 12 Dozen(s)

What is expected:
your purchase request is 12 unit(s). Your po is created with 1 Dozen(s)

The PR contains an additional test case that covers this scenario.