### PR TITLE
[9.0][ADD] product_supplier_code_purchase

### DIFF
--- a/product_supplier_code_purchase/README.rst
+++ b/product_supplier_code_purchase/README.rst
@@ -1,0 +1,60 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============================
+Product Supplier Code Purchase
+==============================
+
+This module adds to the purchase order line the supplier code defined in the
+product.
+
+Usage
+=====
+
+To use this module:
+
+#. Go to 'Purchase' and open a Purchase Order.
+#. If the vendor has defined some code for any purchase order line they will be
+   displayed in the line under the column 'Product Supplier Code'.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Jordi Ballester <jordi.ballester@eficent.com>
+* Lois Rilo Antelo <lois.rilo@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/product_supplier_code_purchase/__init__.py
+++ b/product_supplier_code_purchase/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services, S.L.
+#           (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/product_supplier_code_purchase/__openerp__.py
+++ b/product_supplier_code_purchase/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services, S.L.
+#           (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Product Supplier Code in Purchase",
+    "summary": "This module adds to the purchase order line the supplier "
+               "code defined in the product.",
+    "version": "9.0.1.0.0",
+    "author": "Eficent, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/sale-workflow",
+    "category": "Purchase Management",
+    "depends": ["purchase"],
+    "license": "AGPL-3",
+    "data": [
+        "views/purchase_order_view.xml",
+    ],
+    'installable': True,
+}

--- a/product_supplier_code_purchase/models/__init__.py
+++ b/product_supplier_code_purchase/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services, S.L.
+#           (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import purchase_order

--- a/product_supplier_code_purchase/models/purchase_order.py
+++ b/product_supplier_code_purchase/models/purchase_order.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services, S.L.
+#           (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    @api.multi
+    def _compute_product_supplier_code(self):
+        product_supplierinfo_obj = self.env['product.supplierinfo']
+        for line in self:
+            partner = line.order_id.partner_id
+            product = line.product_id
+            if product and partner:
+                supplier_info = product_supplierinfo_obj.search([
+                    '|', ('product_tmpl_id', '=', product.product_tmpl_id.id),
+                    ('product_id', '=', product.id),
+                    ('name', '=', partner.id)], limit=1)
+                if supplier_info:
+                    code = supplier_info.product_code or ''
+                    line.product_supplier_code = code
+        return True
+
+    product_supplier_code = fields.Char(string='Product Supplier Code',
+                                        compute=_compute_product_supplier_code)

--- a/product_supplier_code_purchase/views/purchase_order_view.xml
+++ b/product_supplier_code_purchase/views/purchase_order_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field name="name">purchase.order.form</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath
+                    expr="//field[@name='order_line']//tree//field[@name='product_id']"
+                   position="after">
+                <field name="product_supplier_code"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="purchase_order_line_tree" model="ir.ui.view">
+        <field name="name">purchase.order.line.tree</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="product_supplier_code"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Product Supplier Code Purchase
==============================

This module adds to the purchase order line the supplier code defined in the
product.

Usage
=====

To use this module:

#. Go to 'Purchase' and open a Purchase Order.
#. If the vendor has defined some code for any purchase order line they will be
   displayed in the line under the column 'Product Supplier Code'.