### PR TITLE
[10.0][IMP][purchase_request_to_procurement]: Auto-fill the location and warehouse with the picking type…

### DIFF
--- a/purchase_request_to_procurement/tests/test_purchase_request_to_procurement.py
+++ b/purchase_request_to_procurement/tests/test_purchase_request_to_procurement.py
@@ -32,10 +32,13 @@ class TestPurchaseRequestToProcurement(TransactionCase):
             p_order.name,
             purchase_request.name,
             'Should have the same name')
-        self.assertFalse(
-            p_order.location_id, 'Should not have location')
-        self.assertFalse(
-            p_order.warehouse_id, 'Should not have warehouse')
+        self.assertTrue(
+            p_order.location_id, 'Procurements must be created with a '
+                                 'location always. Even if not explicitly '
+                                 'defined.')
+        self.assertTrue(
+            p_order.warehouse_id, 'Procurements must be created with a '
+                                  'warehouse always.')
         vals = {
             'location_id': self.env['stock.location'].search([], limit=1).id,
             'warehouse_id': self.env['stock.warehouse'].search([], limit=1).id,

--- a/purchase_request_to_procurement/tests/test_purchase_request_to_procurement.py
+++ b/purchase_request_to_procurement/tests/test_purchase_request_to_procurement.py
@@ -86,3 +86,14 @@ class TestPurchaseRequestToProcurement(TransactionCase):
             line.procurement_id.id,
             procurement_ids[0],
             'Should be the same procurement order id')
+
+    def test_view_methods(self):
+        """Tests the methods to handle views."""
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request = self.purchase_request.create(vals)
+        purchase_request.onchange_picking_type_id()
+        self.assertTrue(purchase_request.warehouse_id)
+        self.assertTrue(purchase_request.location_id)

--- a/purchase_request_to_procurement/views/purchase_request.xml
+++ b/purchase_request_to_procurement/views/purchase_request.xml
@@ -2,7 +2,6 @@
 <!-- Copyright 2017 ACSONE SA/NV
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-<data>
 
     <!-- Purchase Request -->
 
@@ -73,5 +72,4 @@
         </field>
     </record>
 
-</data>
 </odoo>


### PR DESCRIPTION
… info and if not defined use them to create the procurement.

This PR includes a renamed cherry pick of ec19708c26ae3f7005047b944d9e386c2d95bca9:

 * Do not copy the procurement_id when duplicating purchase requests.
 * Modify the onchange method to use the picking type to fill the warehouse and location of the purchase request as picking type is a required field.
 * Ensure that no procurement without location and/or warehouse is created. 
 * Fix tests accordingly. 