### PR TITLE
[10.0] purchase_request_to_rfq: several improvements from v9

### DIFF
--- a/purchase_request_procurement/README.rst
+++ b/purchase_request_procurement/README.rst
@@ -13,7 +13,7 @@ Usage
 =====
 
 * Go to the product form, in tab 'Procurement' and choose 'Purchase Request'.
-  When a procurement order is created and the supply method is 'Make to Order'
+  When a procurement order is created and the supply method is 'Buy'
   the application will now create a Purchase Request.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas

--- a/purchase_request_to_rfq/migrations/9.0.1.0.0/pre-migration.py
+++ b/purchase_request_to_rfq/migrations/9.0.1.0.0/pre-migration.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# © 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+def migrate_status(cr):
+
+    cr.execute("""
+        UPDATE purchase_request_line SET
+        purchase_state = False
+        WHERE purchase_state = 'none'
+    """)
+
+    cr.execute("""
+        UPDATE purchase_request_line SET
+        purchase_state = 'purchase'
+        WHERE purchase_state = 'confirmed'
+    """)
+
+
+def migrate(cr, version):
+    migrate_status(cr)

--- a/purchase_request_to_rfq/models/purchase_request.py
+++ b/purchase_request_to_rfq/models/purchase_request.py
@@ -18,7 +18,7 @@ class PurchaseRequestLine(models.Model):
     @api.depends('purchase_lines')
     def _compute_is_editable(self):
         super(PurchaseRequestLine, self)._compute_is_editable()
-        for rec in self.mapped('purchase_lines'):
+        for rec in self.filtered(lambda p: p.purchase_lines):
             rec.is_editable = False
 
     @api.multi

--- a/purchase_request_to_rfq/models/purchase_request.py
+++ b/purchase_request_to_rfq/models/purchase_request.py
@@ -102,9 +102,9 @@ class PurchaseRequestLine(models.Model):
     @api.model
     def _calc_new_qty(self, request_line, po_line=None, cancel=False,
                       new_pr_line=False):
+        purchase_uom = po_line.product_uom or request_line.product_id.uom_po_id
         uom = request_line.product_uom_id
-        qty = uom._compute_quantity(request_line.product_qty,
-                                    request_line.product_id.uom_po_id)
+        qty = uom._compute_quantity(request_line.product_qty, purchase_uom)
         # Make sure we use the minimum quantity of the partner corresponding
         # to the PO. This does not apply in case of dropshipping
         supplierinfo_min_qty = 0.0
@@ -115,8 +115,8 @@ class PurchaseRequestLine(models.Model):
         rl_qty = 0.0
         # Recompute quantity by adding existing running procurements.
         for rl in po_line.purchase_request_lines:
-            rl_qty += rl.product_uom_id._compute_qty(
-                rl.product_id.uom_po_id, rl.product_qty)
+            rl_qty += rl.product_uom_id._compute_quantity(
+                rl.product_qty, purchase_uom)
         new_qty = 0.0
         if not new_pr_line:
             new_qty = qty + po_line.product_qty

--- a/purchase_request_to_rfq/models/purchase_request.py
+++ b/purchase_request_to_rfq/models/purchase_request.py
@@ -18,7 +18,7 @@ class PurchaseRequestLine(models.Model):
     @api.depends('purchase_lines')
     def _compute_is_editable(self):
         super(PurchaseRequestLine, self)._compute_is_editable()
-        for rec in self.filtered(lambda p: p in self and p.purchase_lines):
+        for rec in self.mapped('purchase_lines'):
             rec.is_editable = False
 
     @api.multi

--- a/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
@@ -166,3 +166,59 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
                           'Should be a quantity of 2')
         self.assertEquals(purchase_request_line2.purchased_qty, 1.0,
                           'Should be a quantity of 1')
+
+    def test_purchase_request_to_purchase_rfq_multiple_PO_purchaseUoM(self):
+        product = self.env.ref('product.product_product_6')
+        product.uom_po_id = self.env.ref('product.product_uom_dozen')
+
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request1 = self.purchase_request.create(vals)
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request2 = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request1.id,
+            'product_id': product.id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 12.0,
+        }
+        purchase_request_line1 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': product.id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 12.0,
+        }
+        purchase_request_line2 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 12.0,
+        }
+        purchase_request_line3 = self.purchase_request_line.create(vals)
+        vals = {
+            'supplier_id': self.env.ref('base.res_partner_1').id,
+        }
+        purchase_request1.button_approved()
+        purchase_request2.button_approved()
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line1.id, purchase_request_line2.id,
+                        purchase_request_line3.id]).create(vals)
+        for item in wiz_id.item_ids:
+            if item.line_id.id == purchase_request_line2.id:
+                item.keep_description = True
+            if item.line_id.id == purchase_request_line3.id:
+                item.onchange_product_id()
+        wiz_id.make_purchase_order()
+        po_line = purchase_request_line1.purchase_lines[0]
+        self.assertEquals(po_line.product_qty, 2.0, 'Quantity should be 2')
+        self.assertEquals(po_line.product_uom,
+                          self.env.ref('product.product_uom_dozen'),
+                          'The purchase UoM should be Dozen(s).')

--- a/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request_to_rfq/tests/test_purchase_request_to_rfq.py
@@ -72,3 +72,97 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
 
         # Test also for onchanges on non created lines
         self.purchase_request_line.new({}).is_editable
+
+    def test_purchase_request_to_purchase_rfq_minimum_order_qty(self):
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request.id,
+            'product_id': self.env.ref('product.product_product_8').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line = self.purchase_request_line.create(vals)
+        vals = {
+            'supplier_id': self.env.ref('base.res_partner_1').id,
+        }
+        purchase_request.button_approved()
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line.id],
+            active_id=purchase_request_line.id, ).create(vals)
+        wiz_id.make_purchase_order()
+        self.assertTrue(
+            len(purchase_request_line.purchase_lines),
+            'Should have a purchase line')
+        self.assertEquals(
+            purchase_request_line.purchase_lines.product_id.id,
+            purchase_request_line.product_id.id,
+            'Should have same product')
+        self.assertEquals(
+            purchase_request_line.purchase_lines.state,
+            purchase_request_line.purchase_state,
+            'Should have same state')
+        self.assertEquals(
+            purchase_request_line.purchase_lines.product_qty,
+            5,
+            'The PO line should have the minimum order quantity.')
+        self.assertEquals(
+            purchase_request_line,
+            purchase_request_line.purchase_lines.purchase_request_lines,
+            'The PO should cross-reference to the purchase request.')
+
+    def test_purchase_request_to_purchase_rfq_multiple_po(self):
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request1 = self.purchase_request.create(vals)
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request2 = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request1.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line1 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line2 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line3 = self.purchase_request_line.create(vals)
+        vals = {
+            'supplier_id': self.env.ref('base.res_partner_1').id,
+        }
+        purchase_request1.button_approved()
+        purchase_request2.button_approved()
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line1.id, purchase_request_line2.id,
+                        purchase_request_line3.id]).create(vals)
+        for item in wiz_id.item_ids:
+            if item.line_id.id == purchase_request_line2.id:
+                item.keep_description = True
+            if item.line_id.id == purchase_request_line3.id:
+                item.onchange_product_id()
+        wiz_id.make_purchase_order()
+        self.assertEquals(purchase_request_line1.purchased_qty, 2.0,
+                          'Should be a quantity of 2')
+        self.assertEquals(purchase_request_line2.purchased_qty, 1.0,
+                          'Should be a quantity of 1')

--- a/purchase_request_to_rfq/views/purchase_request_view.xml
+++ b/purchase_request_to_rfq/views/purchase_request_view.xml
@@ -57,13 +57,94 @@
                             <field name="purchased_qty"/>
                             <field name="purchase_state"/>
                         </group>
-                        <group>
-                            <group>
-                                <field name="purchase_lines" nolabel="1"/>
-                            </group>
-                        </group>
+                        <field name="purchase_lines" mode="tree"
+                               attrs="{'readonly': [('purchase_state', 'in', ('cancel'))]}"
+                               domain="[('product_id', '=', product_id)]"
+                               context="{'form_view_ref' : 'purchase_request_to_rfq.purchase_order_line_form2_sub',
+                                         'tree_view_ref' : 'purchase_request_to_rfq.purchase_order_line_tree_sub',
+                                         'search_view_ref' : 'purchase_request_to_rfq.purchase_order_line_search_sub'}"/>
                     </page>
                 </notebook>
+            </field>
+        </record>
+
+        <record id="purchase_order_line_form2_sub" model="ir.ui.view">
+            <field name="name">purchase.order.line.form2</field>
+            <field name="model">purchase.order.line</field>
+            <field name="arch" type="xml">
+                <form string="Purchase Order Lines" create="false" readonly="1">
+                    <sheet>
+                        <label for="order_id" readonly="1" class="oe_edit_only"/>
+                        <h1>
+                            <field name="order_id" readonly="1" class="oe_inline"/>
+                            <label string="," readonly="1" attrs="{'invisible':[('date_order','=',False)]}"/>
+                            <field name="date_order" readonly="1" class="oe_inline"/>
+                        </h1>
+                        <label for="partner_id" readonly="1" class="oe_edit_only"/>
+                        <h2><field name="partner_id" readonly="1"/></h2>
+                        <group>
+                            <group>
+                                <field name="product_id" readonly="1"/>
+                                <label for="product_qty" readonly="1"/>
+                                <div>
+                                    <field name="product_qty" readonly="1" class="oe_inline"/>
+                                    <field name="product_uom" readonly="1" groups="product.group_uom" class="oe_inline"/>
+                                </div>
+                                <field name="price_unit" widget="monetary" readonly="1"/>
+                            </group>
+                            <group>
+                                <field name="taxes_id" widget="many2many_tags"
+                                    domain="[('type_tax_use', '=', 'purchase')]" readonly="1"/>
+                                <field name="date_planned" widget="date" readonly="1"/>
+                                <field name="company_id" readonly="1" groups="base.group_multi_company" options="{'no_create': True}"/>
+                                <field name="account_analytic_id" readonly="1" colspan="4" groups="purchase.group_analytic_accounting"/>
+                            </group>
+                        </group>
+                        <field name="name" readonly="1"/>
+                        <separator string="Manual Invoices"/>
+                        <field name="invoice_lines" readonly="1"/>
+                        <separator string="Stock Moves"/>
+                        <field name="move_ids" readonly="1"/>
+                        <separator string="Purchase Request Lines"/>
+                        <field name="purchase_request_lines" readonly="1"/>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="purchase_order_line_tree_sub" model="ir.ui.view">
+            <field name="name">purchase.order.line.tree</field>
+            <field name="model">purchase.order.line</field>
+            <field name="arch" type="xml">
+                <tree string="Purchase Order Lines" create="true">
+                    <field name="order_id"/>
+                    <field name="name"/>
+                    <field name="partner_id" string="Vendor"/>
+                    <field name="product_id"/>
+                    <field name="price_unit"/>
+                    <field name="product_qty"/>
+                    <field name="product_uom" groups="product.group_uom"/>
+                    <field name="price_subtotal" widget="monetary"/>
+                    <field name="date_planned"  widget="date"/>
+                    <field name="purchase_request_lines" invisible="1"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="purchase_order_line_search_sub" model="ir.ui.view">
+            <field name="name">purchase.order.line.search</field>
+            <field name="model">purchase.order.line</field>
+            <field name="arch" type="xml">
+                <search string="Search Purchase Order Line" create="false">
+                    <field name="order_id"/>
+                    <field name="product_id"/>
+                    <field name="partner_id" string="Vendor" filter_domain="[('partner_id', 'child_of', self)]"/>
+                    <filter name="hide_cancelled" string="Hide cancelled lines" domain="[('state', '!=', 'cancel')]"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Order Reference" domain="[]" context="{'group_by': 'order_id'}"/>
+                        <filter name="groupby_supplier" string="Vendor" domain="[]" context="{'group_by': 'partner_id'}"/>
+                    </group>
+                </search>
             </field>
         </record>
 

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -216,7 +216,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             # po line
             domain = self._get_order_line_search_domain(purchase, item)
             available_po_lines = po_line_obj.search(domain)
-            if available_po_lines:
+            if available_po_lines and not item.keep_description:
                 po_line = available_po_lines[0]
                 new_qty = pr_line_obj._calc_new_qty(line, po_line=po_line)
                 if new_qty > po_line.product_qty:
@@ -228,6 +228,8 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             else:
                 po_line_data = self._prepare_purchase_order_line(purchase,
                                                                  item)
+                if item.keep_description:
+                    po_line_data['name'] = item.name
                 po_line_obj.create(po_line_data)
             res.append(purchase.id)
 
@@ -264,13 +266,29 @@ class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):
     product_qty = fields.Float(string='Quantity to purchase',
                                digits=dp.get_precision('Product UoS'))
     product_uom_id = fields.Many2one('product.uom', string='UoM')
+    keep_description = fields.Boolean(string='Copy descriptions to new PO.',
+                                      help='Set true if you want to keep the '
+                                           'descriptions provided in the '
+                                           'wizard in the new PO.',
+                                      default=False)
 
-    @api.onchange('product_id', 'product_uom_id')
+    @api.onchange('product_id')
     def onchange_product_id(self):
         if self.product_id:
             name = self.product_id.name
-            if self.product_id.code:
-                name = '[%s] %s' % (name, self.product_id.code)
+            code = self.product_id.code
+            sup_info_id = self.env['product.supplierinfo'].search([
+                '|', ('product_id', '=', self.product_id.id),
+                ('product_tmpl_id', '=', self.product_id.product_tmpl_id.id),
+                ('name', '=', self.wiz_id.supplier_id.id)])
+            if sup_info_id:
+                p_code = sup_info_id[0].product_code
+                p_name = sup_info_id[0].product_name
+                name = '[%s] %s' % (p_code if p_code else code,
+                                    p_name if p_name else name)
+            else:
+                if code:
+                    name = '[%s] %s' % (code, name)
             if self.product_id.description_purchase:
                 name += '\n' + self.product_id.description_purchase
             self.product_uom_id = self.product_id.uom_id.id

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -112,13 +112,9 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             raise exceptions.Warning(
                 _('Enter a supplier.'))
         supplier = self.supplier_id
-        supplier_pricelist = supplier.property_product_pricelist  \
-            or False
         data = {
             'origin': '',
             'partner_id': self.supplier_id.id,
-            'pricelist_id': supplier_pricelist.id,
-            'location_id': location.id,
             'fiscal_position_id': supplier.property_account_position_id and
             supplier.property_account_position_id.id or False,
             'picking_type_id': picking_type.id,
@@ -283,9 +279,11 @@ class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):
     product_id = fields.Many2one('product.product', string='Product')
     name = fields.Char(string='Description', required=True)
     product_qty = fields.Float(string='Quantity to purchase',
-                               digits=dp.get_precision('Product UoS'))
-    product_uom_id = fields.Many2one('product.uom', string='UoM')
-    keep_description = fields.Boolean(string='Copy descriptions to new PO.',
+                               digits=dp.get_precision('Product UoS'),
+                               readonly=True)
+    product_uom_id = fields.Many2one('product.uom', string='UoM',
+                                     readonly=True)
+    keep_description = fields.Boolean(string='Copy descriptions to new PO',
                                       help='Set true if you want to keep the '
                                            'descriptions provided in the '
                                            'wizard in the new PO.',

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -232,7 +232,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             res.append(purchase.id)
 
         return {
-            'domain': "[('id','in', ["+','.join(map(str, res))+"])]",
+            'domain': [('id', 'in', res)],
             'name': _('RFQ'),
             'view_type': 'form',
             'view_mode': 'tree,form',

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -87,9 +87,8 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         res = super(PurchaseRequestLineMakePurchaseOrder, self).default_get(
             fields)
         request_line_obj = self.env['purchase.request.line']
-        request_line_ids = self.env.context['active_ids'] or []
-        active_model = self.env.context['active_model']
-
+        request_line_ids = self.env.context.get('active_ids', False)
+        active_model = self.env.context.get('active_model', False)
         if not request_line_ids:
             return res
         assert active_model == 'purchase.request.line', \

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -34,6 +34,7 @@
                                   <field name="product_qty"/>
                                   <field name="product_uom_id"
                                          groups="product.group_uom"/>
+                                  <field name="keep_description"/>
                               </tree>
                          </field>
                      </group>


### PR DESCRIPTION
Continue with the work started in https://github.com/OCA/purchase-workflow/pull/287 making several proposed improvements and porting changes made in v9 of the module.

* [x] : Changes proposed by @sylvain-garancher in https://github.com/OCA/purchase-workflow/pull/287.
* [x] : Cherry-pick 93d284bad472623ffdd3aa34bb0482ee8711e7bb
* [x] : Fixes done in https://github.com/OCA/purchase-workflow/pull/350 (merged)
* [x] : Fix done in https://github.com/OCA/purchase-workflow/pull/371 (merged)(cherry-pick 1458c34aa31dd810fbcf4306c1e86ead4f5ccd22)
* [x] : Fix proposed in https://github.com/OCA/purchase-workflow/pull/375 (merged)
* [x] : Changes proposed in https://github.com/OCA/purchase-workflow/pull/395 (merged)
* [x] : Add changes from https://github.com/OCA/purchase-workflow/pull/340 (merged)
* [x] : Add https://github.com/OCA/purchase-workflow/pull/399 (merged)