### PR TITLE
[9.0][FIX]purchase_request_to_rfq: Fix default_get on wizard

### DIFF
--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -91,9 +91,8 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         res = super(PurchaseRequestLineMakePurchaseOrder, self).default_get(
             fields)
         request_line_obj = self.env['purchase.request.line']
-        request_line_ids = self.env.context['active_ids'] or []
-        active_model = self.env.context['active_model']
-
+        request_line_ids = self.env.context.get('active_ids', False)
+        active_model = self.env.context.get('active_model', False)
         if not request_line_ids:
             return res
         assert active_model == 'purchase.request.line', \


### PR DESCRIPTION
* Current behavior: in `default_get` method of the wizard converting a purchase request lines to a purchase order (Transient model `purchase.request.line.make.purchase.order`), we read the `active_ids` in the context. If the `active_ids` isn't provided in the context a `KeyError` is raised.
* The fix: To fix this issue i've used the `get()` fonction to retrieve the `active_ids` in the context.
* The expected behavior: With this fix if the `active_ids` isn't provided the method return the `res` of the super method.