### PR TITLE
[10.0][FIX] [product_by_supplier] Fix view for product.supplierinfo for showing Product

### DIFF
--- a/product_by_supplier/views/product_supplierinfo_view.xml
+++ b/product_by_supplier/views/product_supplierinfo_view.xml
@@ -62,10 +62,9 @@
         <field name="inherit_id" ref="product.product_supplierinfo_form_view"/>
         <field name="priority">99</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='product_name']" position="before">
-                <field name="product_tmpl_id" string="Product"
-                invisible="context.get('from_product_form')"
-                required="not context.get('from_product_form')"/>
+            <xpath expr="//field[@name='product_tmpl_id']" position="attributes">
+                <attribute name="invisible">context.get('from_product_form')</attribute>
+                <attribute name="required">not context.get('from_product_form')</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The actual inherited view for product.supplierinfo duplicates the product_tmpl_id field so it is not correctly shown