### PR TITLE
[9.0][IMP] purchase_request: add cancelled state to lines.

### DIFF
--- a/purchase_request/README.rst
+++ b/purchase_request/README.rst
@@ -14,7 +14,8 @@ The person creating the requisition determines what and how much to order,
 and the requested date.
 
 "Indirectly" means that the purchase request initiated by the application
-automatically, for example, from procurement orders.
+automatically, for example, from procurement orders (the module
+purchase_request_procurement is also needed for this feature).
 
 A purchase request is an instruction to Purchasing to procure a certain
 quantity of materials services, so that they are available at a
@@ -32,7 +33,7 @@ Requests', and also from the 'Purchase' menu.
 
 Users can access to the list of Purchase Requests or Purchase Request Lines.
 
-It is possible to filter requests by it's approval status.
+It is possible to filter requests by its approval status.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/purchase_request/README.rst
+++ b/purchase_request/README.rst
@@ -62,6 +62,7 @@ Contributors
 * Jonathan Nemry <jonathan.nemry@acsone.eu>
 * Aaron Henriquez <ahenriquez@eficent.com>
 * Adrien Peiffer <adrien.peiffer@acsone.eu>
+* Lois Rilo <lois.rilo@eficent.com>
 
 Maintainer
 ----------

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -137,6 +137,7 @@ class PurchaseRequest(models.Model):
     def button_draft(self):
         for rec in self:
             rec.state = 'draft'
+            rec.line_ids.do_uncancel()
         return True
 
     @api.multi
@@ -155,6 +156,7 @@ class PurchaseRequest(models.Model):
     def button_rejected(self):
         for rec in self:
             rec.state = 'rejected'
+            rec.line_ids.do_cancel()
         return True
 
     @api.multi
@@ -162,6 +164,14 @@ class PurchaseRequest(models.Model):
         for rec in self:
             rec.state = 'done'
         return True
+
+    @api.multi
+    def check_auto_reject(self):
+        """When all lines are cancelled the purchase request should be
+        auto-rejected."""
+        for pr in self:
+            if not pr.line_ids.filtered(lambda l: l.cancelled is False):
+                pr.write({'state': 'rejected'})
 
 
 class PurchaseRequestLine(models.Model):
@@ -241,10 +251,11 @@ class PurchaseRequestLine(models.Model):
     supplier_id = fields.Many2one('res.partner',
                                   string='Preferred supplier',
                                   compute="_compute_supplier_id")
-
     procurement_id = fields.Many2one('procurement.order',
                                      'Procurement Order',
                                      readonly=True, copy=False)
+    cancelled = fields.Boolean(
+        string="Cancelled", readonly=True, default=False)
 
     @api.onchange('product_id')
     def onchange_product_id(self):
@@ -257,3 +268,21 @@ class PurchaseRequestLine(models.Model):
             self.product_uom_id = self.product_id.uom_id.id
             self.product_qty = 1.0
             self.name = name
+
+    @api.multi
+    def do_cancel(self):
+        """Actions to perform when cancelling a purchase request line."""
+        self.write({'cancelled': True})
+
+    @api.multi
+    def do_uncancel(self):
+        """Actions to perform when uncancelling a purchase request line."""
+        self.write({'cancelled': False})
+
+    @api.multi
+    def write(self, vals):
+        res = super(PurchaseRequestLine, self).write(vals)
+        if vals.get('cancelled'):
+            requests = self.mapped('request_id')
+            requests.check_auto_reject()
+        return res

--- a/purchase_request/tests/test_purchase_request.py
+++ b/purchase_request/tests/test_purchase_request.py
@@ -12,20 +12,22 @@ class TestPurchaseRequest(common.TransactionCase):
         super(TestPurchaseRequest, self).setUp()
         self.purchase_request = self.env['purchase.request']
         self.purchase_request_line = self.env['purchase.request.line']
-
-    def test_purchase_request_status(self):
         vals = {
             'picking_type_id': self.env.ref('stock.picking_type_in').id,
             'requested_by': SUPERUSER_ID,
         }
-        purchase_request = self.purchase_request.create(vals)
+        self.purchase_request = self.purchase_request.create(vals)
         vals = {
-            'request_id': purchase_request.id,
+            'request_id': self.purchase_request.id,
             'product_id': self.env.ref('product.product_product_13').id,
             'product_uom_id': self.env.ref('product.product_uom_unit').id,
             'product_qty': 5.0,
         }
         self.purchase_request_line.create(vals)
+
+    def test_purchase_request_status(self):
+        """Tests Purchase Request status workflow."""
+        purchase_request = self.purchase_request
         self.assertEqual(
             purchase_request.is_editable, True,
             'Should be editable')
@@ -53,3 +55,25 @@ class TestPurchaseRequest(common.TransactionCase):
             purchase_request.is_editable, False,
             'Should not be editable')
         self.purchase_request_line.unlink()
+
+    def test_auto_reject(self):
+        """Tests if a Purchase Request is autorejected when all lines are
+        cancelled."""
+        purchase_request = self.purchase_request
+        # Add a second line to the PR:
+        vals = {
+            'request_id': purchase_request.id,
+            'product_id': self.env.ref('product.product_product_14').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 5.0,
+        }
+        self.purchase_request_line.create(vals)
+        lines = purchase_request.line_ids
+        # Cancel one line:
+        lines[0].do_cancel()
+        self.assertNotEqual(purchase_request.state, 'rejected',
+                            'Purchase Request should not have been rejected.')
+        # Cancel the second one:
+        lines[1].do_cancel()
+        self.assertEqual(purchase_request.state, 'rejected',
+                         'Purchase Request should have been auto-rejected.')

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -82,7 +82,7 @@
                                     <field name="analytic_account_id"
                                            groups="analytic.group_analytic_accounting"/>
                                     <field name="date_required"/>
-                                    <field name="cancelled"/>
+                                    <field name="cancelled" invisible="1"/>
                                     <field name="is_editable" invisible="1"/>
                                 </tree>
                                 <form>
@@ -104,7 +104,6 @@
                                                            groups="product.group_uom"
                                                            class="oe_inline"
                                                            attrs="{'readonly': [('is_editable','=', False)]}"/>
-                                                    <field name="cancelled" invisible="1"/>
                                                 </div>
                                                 <field name="analytic_account_id"
                                                        groups="analytic.group_analytic_accounting"
@@ -112,6 +111,7 @@
                                                        attrs="{'readonly': [('is_editable','=', False)]}"/>
                                                 <field name="date_required"
                                                        attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                                <field name="cancelled"/>
                                                 <field name="procurement_id"/>
                                             </group>
                                         </group>
@@ -252,7 +252,7 @@
                     <field name="analytic_account_id"
                            groups="analytic.group_analytic_accounting"/>
                     <field name="supplier_id"/>
-                    <field name="cancelled"/>
+                    <field name="cancelled" invisible="1"/>
                 </tree>
             </field>
         </record>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -74,7 +74,7 @@
                     <notebook>
                         <page string="Products">
                             <field name="line_ids">
-                                <tree>
+                                <tree decoration-muted="cancelled == True">
                                     <field name="product_id"/>
                                     <field name="name"/>
                                     <field name="product_qty"/>
@@ -82,6 +82,7 @@
                                     <field name="analytic_account_id"
                                            groups="analytic.group_analytic_accounting"/>
                                     <field name="date_required"/>
+                                    <field name="cancelled"/>
                                     <field name="is_editable" invisible="1"/>
                                 </tree>
                                 <form>
@@ -103,6 +104,7 @@
                                                            groups="product.group_uom"
                                                            class="oe_inline"
                                                            attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                                    <field name="cancelled" invisible="1"/>
                                                 </div>
                                                 <field name="analytic_account_id"
                                                        groups="analytic.group_analytic_accounting"
@@ -236,7 +238,8 @@
             <field name="name">purchase.request.line.tree</field>
             <field name="model">purchase.request.line</field>
             <field name="arch" type="xml">
-                <tree string="Purchase Request Lines" create="false">
+                <tree string="Purchase Request Lines" create="false"
+                      decoration-muted="cancelled == True">
                     <field name="request_id"/>
                     <field name="request_state"/>
                     <field name="requested_by"/>
@@ -249,6 +252,7 @@
                     <field name="analytic_account_id"
                            groups="analytic.group_analytic_accounting"/>
                     <field name="supplier_id"/>
+                    <field name="cancelled"/>
                 </tree>
             </field>
         </record>
@@ -302,6 +306,7 @@
                                        attrs="{'readonly': [('is_editable','=', False)]}"/>
                                 <field name="date_required"
                                        attrs="{'readonly': [('is_editable','=', False)]}"/>
+                                <field name="cancelled"/>
                                 <field name="procurement_id"/>
                             </group>
                         </group>
@@ -336,6 +341,7 @@
                     <field name="date_required"/>
                     <field name="analytic_account_id"/>
                     <field name="procurement_id"/>
+                    <field name="cancelled" invisible="1"/>
                     <filter name="request_state_draft" string="Draft"
                             domain="[('request_state','=','draft')]"
                             help="Request is to be approved"/>
@@ -352,6 +358,9 @@
                             help="Assigned to me"/>
                     <filter domain="[('requested_by','=', uid)]"
                             help="My requests"/>
+                    <filter name="uncancelled"
+                            domain="[('cancelled','=', False)]"
+                            string="Uncancelled"/>
                     <group expand="0" string="Group By...">
                         <filter string="Product"
                                 domain="[]" context="{'group_by' : 'product_id'}" />


### PR DESCRIPTION
related to https://github.com/OCA/purchase-workflow/issues/396.

A new state is added to lines to enhance the behavior and flow of purchase_request and its submodules.