### PR TITLE
[9.0][IMP] purchase_request: add migration script

### DIFF
--- a/purchase_request/__openerp__.py
+++ b/purchase_request/__openerp__.py
@@ -6,7 +6,10 @@
     "name": "Purchase Request",
     "author": "Eficent Business and IT Consulting Services S.L., "
               "Odoo Community Association (OCA)",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
+    "summary": "Use this module to have notification of requirements of "
+               "materials and/or external services and keep track of such "
+               "requirements.",
     "category": "Purchase Management",
     "depends": [
         "purchase",

--- a/purchase_request/migrations/9.0.1.0.1/post-migration.py
+++ b/purchase_request/migrations/9.0.1.0.1/post-migration.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def update_rejected_requests(cr):
+    logger.info('Updating purchase request lines that need to be cancelled.')
+    cr.execute("""
+        UPDATE purchase_request_line prl
+        SET cancelled = true
+        FROM purchase_request pr
+        WHERE pr.state = 'rejected' AND prl.request_id = pr.id
+    """)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    update_rejected_requests(cr)


### PR DESCRIPTION
Adds a post-migration script to set to cancelled all old purchase request lines belonging to a purchase request in state 'rejected'.

Improves https://github.com/OCA/purchase-workflow/pull/412