### PR TITLE
[9.0][IMP] purchase_request_to_rfq: cancelating procurements in hands of purchase_request

### DIFF
--- a/purchase_request_to_rfq/README.rst
+++ b/purchase_request_to_rfq/README.rst
@@ -1,22 +1,29 @@
-.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
-    :alt: License LGPL-3
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
+=======================
 Purchase Request to RFQ
 =======================
+
 This module adds the possibility to create or update Requests for
 Quotation (RFQ) from Purchase Request Lines.
 
-
 Usage
 =====
-Go to the Purchase Request Lines from the menu entry 'Purchase Requests',
-and also from the 'Purchase' menu.
 
-Select the lines that you wish to initiate the RFQ for, then go to 'More'
-and press 'Create RFQ'.
+To use this module you need to:
 
-You can choose to select an existing RFQ or create a new one. In the later,
-you have to choose a supplier.
+#. Go to the Purchase Request Lines either from the *Purchase Requests*
+   or *Purchase* menus.
+#. Select the lines that you wish to initiate the RFQ for, then go to *More*
+   and press *Create RFQ*.
+#. In the wizard that raises you can choose to select an existing RFQ or
+   create a new one. In the second case, you additionally have to choose a
+   supplier.
+
+Consolidation logic for RFQ
+---------------------------
 
 In case that you chose to select an existing RFQ, the application will search
 for existing lines matching the request line, and will add the extra
@@ -25,6 +32,19 @@ if it exists for the supplier of that RFQ.
 
 In case that you create a new RFQ, the request lines will also be
 consolidated into as few as possible lines in the RFQ.
+
+Cancel Logic
+------------
+
+Note the following behaviors:
+
+* When you cancel a PO related to a purchase request, only incoming shipments
+  will be cancelled.
+* If you are using this module in conjunction with
+  `purchase_request_procurement` and the purchase request was originated
+  after a chain of moves/procurements, they will be all respected when
+  cancelling a PO. Cancel de purchase request if you want to totally cancel
+  this chain.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
@@ -50,6 +70,7 @@ Contributors
 * Jonathan Nemry <jonathan.nemry@acsone.eu>
 * Aaron Henriquez <ahenriquez@eficent.com>
 * Adrien Peiffer <adrien.peiffer@acsone.eu>
+* Lois Rilo <lois.rilo@eficent.com>
 
 
 Maintainer

--- a/purchase_request_to_rfq/__openerp__.py
+++ b/purchase_request_to_rfq/__openerp__.py
@@ -7,7 +7,9 @@
     "author": "Eficent, "
               "Acsone SA/NV,"
               "Odoo Community Association (OCA)",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
+    "summary": "This module adds the possibility to create or update Requests "
+               "for Quotation (RFQ) from Purchase Request Lines.",
     "website": "http://www.eficent.com/",
     "category": "Purchase Management",
     "depends": [

--- a/purchase_request_to_rfq/models/purchase_order.py
+++ b/purchase_request_to_rfq/models/purchase_order.py
@@ -185,3 +185,22 @@ class PurchaseOrderLine(models.Model):
              )
         message += '</ul>'
         return message
+
+    @api.multi
+    def _po_line_unlink_purchase_request_message_content(self):
+        self.ensure_one()
+        title = _('Line %s of Purchase Order %s was removed') % (
+            self.name, self.order_id.name)
+        message = '<b>%s</b><br/>' % title
+        return message
+
+    @api.multi
+    def unlink(self):
+        for line in self:
+            message = \
+                line._po_line_unlink_purchase_request_message_content()
+            requests = line.purchase_request_lines.mapped('request_id')
+            for req in requests:
+                req.message_post(body=message, subtype='mail.mt_comment')
+
+        return super(PurchaseOrderLine, self).unlink()

--- a/purchase_request_to_rfq/models/purchase_order.py
+++ b/purchase_request_to_rfq/models/purchase_order.py
@@ -2,7 +2,8 @@
 # Copyright 2016 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
-from openerp import _, api, exceptions, fields, models
+from openerp import api, fields, models, _
+from openerp.exceptions import UserError
 
 
 class PurchaseOrder(models.Model):
@@ -63,7 +64,7 @@ class PurchaseOrder(models.Model):
             for line in po.order_line:
                 for request_line in line.purchase_request_lines:
                     if request_line.sudo().purchase_state == 'done':
-                        raise exceptions.Warning(
+                        raise UserError(
                             _('Purchase Request %s has already '
                               'been completed') % request_line.request_id.name)
         return True
@@ -74,6 +75,72 @@ class PurchaseOrder(models.Model):
         res = super(PurchaseOrder, self).button_confirm()
         self._purchase_request_confirm_message()
         return res
+
+    @api.multi
+    def button_cancel(self):
+        """Filters the Purchase Orders (POs):
+        * POs with purchase request(s) related go to
+        cancel_po_from_request method.
+        * POs with no purchase request related are returned to super.
+        """
+        po_from_request = self.filtered(
+            lambda po: po.mapped('order_line.purchase_request_lines'))
+        remaining_po = self.filtered(
+            lambda po: not po.mapped('order_line.purchase_request_lines'))
+        po_from_request.cancel_po_from_request()
+        return super(PurchaseOrder, remaining_po).button_cancel()
+
+    @api.multi
+    def cancel_po_from_request(self):
+        """Filter PO lines of PO that are related to some purchase request
+        (PR).
+        * Lines which have no relation to PRs are processed with a copy of
+        standard code.
+        * Lines with relation to PRs aren't processed. The purpose of this is
+        to leave on hands of the purchase requests the task of cancelling
+        procurements which originated them."""
+        for order in self:
+            for pick in order.picking_ids:
+                if pick.state == 'done':
+                    raise UserError(_(
+                        'Unable to cancel purchase order %s as some '
+                        'receptions have already been done.') % order.name)
+            for inv in order.invoice_ids:
+                if inv and inv.state not in ('cancel', 'draft'):
+                    raise UserError(_(
+                        "Unable to cancel this purchase order. You must "
+                        "first cancel related vendor bills."))
+            for pick in order.picking_ids.filtered(
+                    lambda r: r.state != 'cancel'):
+                pick.action_cancel()
+            # Post a msg in purchase requests:
+            # TODO: msg to PR
+            request_po_lines = order.order_line.filtered(
+                lambda pol: pol.purchase_request_lines)
+            for line in request_po_lines:
+                message = \
+                    line._po_line_purchase_request_cancel_message_content()
+                requests = line.purchase_request_lines.mapped('request_id')
+                for req in requests:
+                    req.message_post(body=message, subtype='mail.mt_comment')
+            # Search for lines not created from a Purchase request and end
+            # the process
+            no_request_po_lines = order.order_line.filtered(
+                lambda pol: not pol.purchase_request_lines)
+            # TODO: remove PO from procurement ?!
+            if not self.env.context.get('cancel_procurement'):
+                procurements = no_request_po_lines.mapped('procurement_ids')
+                procurements.filtered(lambda r: r.state not in (
+                    'cancel', 'exception') and r.rule_id.propagate).write(
+                    {'state': 'cancel'})
+                procurements.filtered(lambda r: r.state not in (
+                    'cancel', 'exception') and not r.rule_id.propagate).write(
+                    {'state': 'exception'})
+                moves = procurements.filtered(
+                    lambda r: r.rule_id.propagate).mapped('move_dest_id')
+                moves.filtered(
+                    lambda r: r.state != 'cancel').action_cancel()
+        self.write({'state': 'cancel'})
 
 
 class PurchaseOrderLine(models.Model):
@@ -103,3 +170,20 @@ class PurchaseOrderLine(models.Model):
                 'view_type': 'form',
                 'view_mode': 'tree,form',
                 'domain': domain}
+
+    @api.multi
+    def _po_line_purchase_request_cancel_message_content(self):
+        self.ensure_one()
+        title = _('Purchase Order %s cancelled') % self.order_id.name
+        message = '<b>%s</b><br/>' % title
+        message += _('The following requested item from this Purchase Request '
+                     'is affected:')
+        message += '<ul>'
+        message += _(
+            '<li><b>%s</b>: Quantity %s %s</li>'
+        ) % (self.product_id.name,
+             self.product_qty,
+             self.product_uom.name,
+             )
+        message += '</ul>'
+        return message

--- a/purchase_request_to_rfq/models/purchase_order.py
+++ b/purchase_request_to_rfq/models/purchase_order.py
@@ -114,7 +114,6 @@ class PurchaseOrder(models.Model):
                     lambda r: r.state != 'cancel'):
                 pick.action_cancel()
             # Post a msg in purchase requests:
-            # TODO: msg to PR
             request_po_lines = order.order_line.filtered(
                 lambda pol: pol.purchase_request_lines)
             for line in request_po_lines:

--- a/purchase_request_to_rfq/models/purchase_request.py
+++ b/purchase_request_to_rfq/models/purchase_request.py
@@ -11,7 +11,6 @@ from openerp import _, api, exceptions, fields, models
 
 
 class PurchaseRequestLine(models.Model):
-
     _inherit = "purchase.request.line"
 
     @api.multi

--- a/purchase_request_to_rfq/models/stock.py
+++ b/purchase_request_to_rfq/models/stock.py
@@ -9,9 +9,8 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     @api.model
-    def _purchase_request_picking_confirm_message_content(self, picking,
-                                                          request,
-                                                          request_dict):
+    def _purchase_request_picking_confirm_message_content(
+            self, picking, request, request_dict):
         if not request_dict:
             request_dict = {}
         title = _('Receipt confirmation %s for your Request %s') % (


### PR DESCRIPTION
The aim of this PR is to modify the cancellation of purchase orders (POs) to not propagate the cancel signal to related procurements and the chain of moves if the origin of a PO line is a purchase request. 

This scenario only applies if you have also `purchase_request_procurement`installed. To complete the cancellation as it is done by default the user has to also cancel the purchase request with the fixes proposed in https://github.com/OCA/purchase-workflow/pull/398