### PR TITLE
[ADD] purchase_triple_discount: New module

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,5 +1,6 @@
 # list the OCA project dependencies, one per line
 # add a github url if you need a forked version
+account-invoicing
 server-tools
 stock-logistics-workflow
 sale-workflow

--- a/purchase_triple_discount/README.rst
+++ b/purchase_triple_discount/README.rst
@@ -1,0 +1,71 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+========================
+Purchase Triple Discount
+========================
+
+This module allows to have three successive discounts on every purchase order
+line.
+
+Usage
+=====
+
+Create a new purchase order and add discounts in any of the three discount
+fields given. They go in order of precedence so discount 2 will be calculated
+over discount 1 and discount 3 over the result of discount 2. For example,
+let's divide by two on every discount:
+
+Unit price: 600.00 ->
+
+  - Disc. 1 = 50% -> Amount = 300.00
+  - Disc. 2 = 50% -> Amount = 150.00
+  - Disc. 3 = 50% -> Amount = 75.00
+
+You can also use negative values to charge instead of discount:
+
+Unit price: 600.00 ->
+
+  - Disc. 1 = 50% -> Amount = 300.00
+  - Disc. 2 = -5% -> Amount = 315.00
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* David Vidal <david.vidal@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_triple_discount/__init__.py
+++ b/purchase_triple_discount/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/purchase_triple_discount/__manifest__.py
+++ b/purchase_triple_discount/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Account Invoice Triple Discount',
+    'version': '10.0.1.0.0',
+    'category': 'Purchase Management',
+    'author': 'Tecnativa, '
+              'Odoo Community Association (OCA)',
+    'website': 'https://tecnativa.com',
+    'license': 'AGPL-3',
+    'summary': 'Manage triple discount on purchase order lines',
+    'depends': [
+        'purchase_discount',
+        'account_invoice_triple_discount',
+    ],
+    'data': [
+        'views/purchase_view.xml',
+    ],
+    'installable': True,
+}

--- a/purchase_triple_discount/models/__init__.py
+++ b/purchase_triple_discount/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import account_invoice
+from . import purchase_order

--- a/purchase_triple_discount/models/account_invoice.py
+++ b/purchase_triple_discount/models/account_invoice.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    def _prepare_invoice_line_from_po_line(self, line):
+        vals = super(AccountInvoice,
+                     self)._prepare_invoice_line_from_po_line(line)
+        vals['discount2'] = line.discount2
+        vals['discount3'] = line.discount3
+        return vals

--- a/purchase_triple_discount/models/purchase_order.py
+++ b/purchase_triple_discount/models/purchase_order.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+from odoo.addons import decimal_precision as dp
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    @api.depends('discount2', 'discount3')
+    def _compute_amount(self):
+        super(PurchaseOrderLine, self)._compute_amount()
+
+    discount2 = fields.Float(
+        'Disc. 2 (%)',
+        digits=dp.get_precision('Discount'),
+        default=0.0,
+    )
+
+    discount3 = fields.Float(
+        'Disc. 3 (%)',
+        digits=dp.get_precision('Discount'),
+        default=0.0,
+    )
+
+    _sql_constraints = [
+        ('discount2_limit', 'CHECK (discount2 <= 100.0)',
+         'Discount 2 must be lower than 100%.'),
+        ('discount3_limit', 'CHECK (discount3 <= 100.0)',
+         'Discount 3 must be lower than 100%.'),
+    ]
+
+    def _get_discounted_price_unit(self):
+        price_unit = super(
+            PurchaseOrderLine, self)._get_discounted_price_unit()
+        if self.discount2:
+            price_unit *= (1 - self.discount2 / 100.0)
+        if self.discount3:
+            price_unit *= (1 - self.discount3 / 100.0)
+        return price_unit

--- a/purchase_triple_discount/tests/__init__.py
+++ b/purchase_triple_discount/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_purchase_discount

--- a/purchase_triple_discount/tests/test_purchase_discount.py
+++ b/purchase_triple_discount/tests/test_purchase_discount.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestPurchaseOrder(common.SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestPurchaseOrder, cls).setUpClass()
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'Mr. Odoo',
+        })
+        cls.product1 = cls.env['product.product'].create({
+            'name': 'Test Product 1',
+            'purchase_method': 'purchase',
+        })
+        cls.product2 = cls.env['product.product'].create({
+            'name': 'Test Product 2',
+            'purchase_method': 'purchase',
+        })
+        cls.tax = cls.env['account.tax'].create({
+            'name': 'TAX 15%',
+            'amount_type': 'percent',
+            'type_tax_use': 'purchase',
+            'amount': 15.0,
+        })
+        cls.order = cls.env['purchase.order'].create({
+            'partner_id': cls.partner.id
+        })
+        po_line = cls.env['purchase.order.line']
+        cls.po_line1 = po_line.create({
+            'order_id': cls.order.id,
+            'product_id': cls.product1.id,
+            'date_planned': '2018-01-19 00:00:00',
+            'name': 'Line 1',
+            'product_qty': 1.0,
+            'product_uom': cls.product1.uom_id.id,
+            'taxes_id': [(6, 0, [cls.tax.id])],
+            'price_unit': 600.0,
+        })
+        cls.po_line2 = po_line.create({
+            'order_id': cls.order.id,
+            'product_id': cls.product2.id,
+            'date_planned': '2018-01-19 00:00:00',
+            'name': 'Line 2',
+            'product_qty': 10.0,
+            'product_uom': cls.product2.uom_id.id,
+            'taxes_id': [(6, 0, [cls.tax.id])],
+            'price_unit': 60.0,
+        })
+
+    def test_01_purchase_order_classic_discount(self):
+        """ Tests with single discount """
+        self.po_line1.discount = 50.0
+        self.po_line2.discount = 75.0
+        self.assertEqual(self.po_line1.price_subtotal, 300.0)
+        self.assertEqual(self.po_line2.price_subtotal, 150.0)
+        self.assertEqual(self.order.amount_untaxed, 450.0)
+        self.assertEqual(self.order.amount_tax, 67.5)
+        # Mix taxed and untaxed:
+        self.po_line1.taxes_id = False
+        self.assertEqual(self.order.amount_tax, 22.5)
+
+    def test_02_purchase_order_simple_triple_discount(self):
+        """ Tests on a single line """
+        self.po_line2.unlink()
+        # Divide by two on every discount:
+        self.po_line1.discount = 50.0
+        self.po_line1.discount2 = 50.0
+        self.po_line1.discount3 = 50.0
+        self.assertEqual(self.po_line1.price_subtotal, 75.0)
+        self.assertEqual(self.order.amount_untaxed, 75.0)
+        self.assertEqual(self.order.amount_tax, 11.25)
+        # Unset first discount:
+        self.po_line1.discount = 0.0
+        self.assertEqual(self.po_line1.price_subtotal, 150.0)
+        self.assertEqual(self.order.amount_untaxed, 150.0)
+        self.assertEqual(self.order.amount_tax, 22.5)
+        # Set a charge instead:
+        self.po_line1.discount2 = -50.0
+        self.assertEqual(self.po_line1.price_subtotal, 450.0)
+        self.assertEqual(self.order.amount_untaxed, 450.0)
+        self.assertEqual(self.order.amount_tax, 67.5)
+
+    def test_03_purchase_order_complex_triple_discount(self):
+        """ Tests on multiple lines """
+        self.po_line1.discount = 50.0
+        self.po_line1.discount2 = 50.0
+        self.po_line1.discount3 = 50.0
+        self.assertEqual(self.po_line1.price_subtotal, 75.0)
+        self.assertEqual(self.order.amount_untaxed, 675.0)
+        self.assertEqual(self.order.amount_tax, 101.25)
+        self.po_line2.discount3 = 50.0
+        self.assertEqual(self.po_line2.price_subtotal, 300.0)
+        self.assertEqual(self.order.amount_untaxed, 375.0)
+        self.assertEqual(self.order.amount_tax, 56.25)
+
+    def test_04_purchase_order_triple_discount_invoicing(self):
+        """ When a confirmed order is invoiced, the resultant invoice
+            should inherit the discounts """
+        self.po_line1.discount = 50.0
+        self.po_line1.discount2 = 50.0
+        self.po_line1.discount3 = 50.0
+        self.po_line2.discount3 = 50.0
+        self.order.button_confirm()
+        self.invoice = self.env['account.invoice'].create({
+            'partner_id': self.partner.id,
+            'purchase_id': self.order.id,
+            'account_id': self.partner.property_account_payable_id.id,
+            'type': 'in_invoice',
+        })
+        self.invoice.purchase_order_change()
+        self.invoice._onchange_invoice_line_ids()
+        self.assertEqual(self.po_line1.discount,
+                         self.invoice.invoice_line_ids[0].discount)
+        self.assertEqual(self.po_line1.discount2,
+                         self.invoice.invoice_line_ids[0].discount2)
+        self.assertEqual(self.po_line1.discount3,
+                         self.invoice.invoice_line_ids[0].discount3)
+        self.assertEqual(self.po_line2.discount3,
+                         self.invoice.invoice_line_ids[1].discount3)
+        self.assertEqual(self.order.amount_total, self.invoice.amount_total)

--- a/purchase_triple_discount/views/purchase_view.xml
+++ b/purchase_triple_discount/views/purchase_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="purchase_order_triple_discount_form_view" model="ir.ui.view">
+        <field name="name">purchase.order.triple.discount.form</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']//tree//field[@name='discount']"
+                   position="after">
+                <field name="discount2"/>
+                <field name="discount3"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//field[@name='discount']"
+                   position="after">
+                <field name="discount2"/>
+                <field name="discount3"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Depends on:

- [x] account_invoice_triple_discount: https://github.com/OCA/account-invoicing/pull/294
- [x] purchase_discount: https://github.com/OCA/purchase-workflow/pull/316

Purchase Triple Discount
========================

This module allows to have three successive discounts on every purchase order line.

Usage
=====

Create a new purchase order and add discounts in any of the three discount fields given. They go in order of precedence so discount 2 will be calculated over discount 1 and discount 3 over the result of discount 2. For example, let's divide by two on every discount:

Unit price: 600.00 ->

  - Disc. 1 = 50% -> Amount = 300.00
  - Disc. 2 = 50% -> Amount = 150.00
  - Disc. 3 = 50% -> Amount = 75.00

You can also use negative values to charge instead of discount:

Unit price: 600.00 ->

  - Disc. 1 = 50% -> Amount = 300.00
  - Disc. 2 = -5% -> Amount = 315.00

cc @Tecnativa