### PR TITLE
[9.0][REF]purchase_request: subscribe assigned_to user using a separate method

### DIFF
--- a/purchase_request/__openerp__.py
+++ b/purchase_request/__openerp__.py
@@ -6,7 +6,7 @@
     "name": "Purchase Request",
     "author": "Eficent Business and IT Consulting Services S.L., "
               "Odoo Community Association (OCA)",
-    "version": "9.0.1.0.1",
+    "version": "9.0.1.0.2",
     "summary": "Use this module to have notification of requirements of "
                "materials and/or external services and keep track of such "
                "requirements.",

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -178,7 +178,8 @@ class PurchaseRequest(models.Model):
         for rec in self:
             if not rec.assigned_to:
                 continue
-            rec.message_subscribe_users(user_ids=[rec.assigned_to.id])
+            rec.message_subscribe_users(
+                user_ids=[rec.assigned_to.id], subtype_ids=None)
 
 
 class PurchaseRequestLine(models.Model):

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -122,15 +122,14 @@ class PurchaseRequest(models.Model):
     def create(self, vals):
         request = super(PurchaseRequest, self).create(vals)
         if vals.get('assigned_to'):
-            request.message_subscribe_users(user_ids=[request.assigned_to.id])
+            request._subscribe_assigned_to_user()
         return request
 
     @api.multi
     def write(self, vals):
         res = super(PurchaseRequest, self).write(vals)
-        for request in self:
-            if vals.get('assigned_to'):
-                self.message_subscribe_users(user_ids=[request.assigned_to.id])
+        if vals.get('assigned_to'):
+            self._subscribe_assigned_to_user()
         return res
 
     @api.multi
@@ -172,6 +171,14 @@ class PurchaseRequest(models.Model):
         for pr in self:
             if not pr.line_ids.filtered(lambda l: l.cancelled is False):
                 pr.write({'state': 'rejected'})
+
+    @api.multi
+    def _subscribe_assigned_to_user(self):
+        """If the assigned to user is set on the PR, subscribe him."""
+        for rec in self:
+            if not rec.assigned_to:
+                continue
+            rec.message_subscribe_users(user_ids=[rec.assigned_to.id])
 
 
 class PurchaseRequestLine(models.Model):

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -173,13 +173,13 @@ class PurchaseRequest(models.Model):
                 pr.write({'state': 'rejected'})
 
     @api.multi
-    def _subscribe_assigned_to_user(self):
+    def _subscribe_assigned_to_user(self, subtype_ids=None):
         """If the assigned to user is set on the PR, subscribe him."""
         for rec in self:
             if not rec.assigned_to:
                 continue
             rec.message_subscribe_users(
-                user_ids=[rec.assigned_to.id], subtype_ids=None)
+                user_ids=[rec.assigned_to.id], subtype_ids=subtype_ids)
 
 
 class PurchaseRequestLine(models.Model):


### PR DESCRIPTION
Currently in the purchase request module, when assigning a user to `assigned_to` field, that user will be subscribed automatically to the document. This behavior is done by overriding the `create` and `write` method using `message_subscribe_users()`.
The issue with this implementation is the `assigned_to user`  is subscribed to all the subtypes of the purchase request and it doesn't give us an override point to change that behavior.
As a solution for this issue, I propose to use a separate method to subscribe the` assigned_to`  user called `_subscribe_assigned_to_user` and call that method in the `create` and `write` methods. This way we can easily change the subscription behavior by overriding this new method.