### PR TITLE
[9.0][FIX][purchase_open_qty] fixing methods

### DIFF
--- a/purchase_open_qty/__openerp__.py
+++ b/purchase_open_qty/__openerp__.py
@@ -7,7 +7,7 @@
     "name": "Purchase Open Qty",
     "summary": "Allows to identify the purchase orders that have quantities "
                "pending to invoice or to receive.",
-    "version": "9.0.1.0.1",
+    "version": "9.0.1.0.2",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",

--- a/purchase_open_qty/init_hook.py
+++ b/purchase_open_qty/init_hook.py
@@ -53,7 +53,7 @@ def store_field_qty_to_receive_and_invoice(cr):
         SET qty_to_invoice = pol.qty_received - pol.qty_invoiced
         FROM product_product p
         JOIN product_template t ON p.product_tmpl_id = t.id
-        WHERE t.purchase_method = 'receive'
+        WHERE t.purchase_method = 'receive' AND pol.product_id = p.id
         """
     )
     cr.execute(
@@ -62,7 +62,7 @@ def store_field_qty_to_receive_and_invoice(cr):
         SET qty_to_invoice = pol.product_qty - pol.qty_invoiced
         FROM product_product p
         JOIN product_template t ON p.product_tmpl_id = t.id
-        WHERE t.purchase_method != 'receive'
+        WHERE t.purchase_method != 'receive' AND pol.product_id = p.id
         """
     )
     cr.execute(

--- a/purchase_open_qty/migrations/9.0.1.0.2/pre-migration.py
+++ b/purchase_open_qty/migrations/9.0.1.0.2/pre-migration.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# © 2017 Eficent Business and IT Consulting Services, S.L.
+#   (<http://www.eficent.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.addons.purchase_open_qty.init_hook import \
+    store_field_qty_to_receive_and_invoice
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    store_field_qty_to_receive_and_invoice(cr)

--- a/purchase_open_qty/tests/test_purchase_open_qty.py
+++ b/purchase_open_qty/tests/test_purchase_open_qty.py
@@ -31,6 +31,7 @@ class TestPurchaseOpenQty(TransactionCase):
         pr_dict = {
             'name': 'Product Test',
             'uom_id': uom_id,
+            'purchase_method': 'purchase',
         }
         self.product = prod_model.sudo().create(pr_dict)
         ac_dict = {


### PR DESCRIPTION
This PR fixes:
- method `qty_to_invoice` for cases which the purchase_method is 'receive'.
- method `qty_received` is changed to `qty_to_receive`, and calculated directly from the stock_moves associated.
- added migration script for the changes produced in the init_hook