### PR TITLE
[IMP] Disallow to request an approval for empty purchase requests

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -2,7 +2,8 @@
 # Copyright 2016 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 import odoo.addons.decimal_precision as dp
 
 _STATES = [
@@ -103,10 +104,27 @@ class PurchaseRequest(models.Model):
     is_editable = fields.Boolean(string="Is editable",
                                  compute="_compute_is_editable",
                                  readonly=True)
-
+    to_approve_allowed = fields.Boolean(
+        compute='_compute_to_approve_allowed')
     picking_type_id = fields.Many2one('stock.picking.type',
                                       'Picking Type', required=True,
                                       default=_default_picking_type)
+
+    @api.multi
+    @api.depends(
+        'state',
+        'line_ids.product_qty',
+        'line_ids.cancelled',
+    )
+    def _compute_to_approve_allowed(self):
+        for rec in self:
+            rec.to_approve_allowed = (
+                rec.state == 'draft' and
+                any([
+                    not line.cancelled and line.product_qty
+                    for line in rec.line_ids
+                ])
+            )
 
     @api.multi
     def copy(self, default=None):
@@ -140,6 +158,7 @@ class PurchaseRequest(models.Model):
 
     @api.multi
     def button_to_approve(self):
+        self.to_approve_allowed_check()
         return self.write({'state': 'to_approve'})
 
     @api.multi
@@ -162,6 +181,14 @@ class PurchaseRequest(models.Model):
         for pr in self:
             if not pr.line_ids.filtered(lambda l: l.cancelled is False):
                 pr.write({'state': 'rejected'})
+
+    @api.multi
+    def to_approve_allowed_check(self):
+        for rec in self:
+            if not rec.to_approve_allowed:
+                raise UserError(
+                    _("You can't request an approval for a purchase request "
+                      "which is empty. (%s)") % rec.name)
 
 
 class PurchaseRequestLine(models.Model):

--- a/purchase_request/tests/test_purchase_request.py
+++ b/purchase_request/tests/test_purchase_request.py
@@ -2,6 +2,7 @@
 # Copyright 2016 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
+from odoo.exceptions import UserError
 from odoo.tests import common
 from odoo.tools import SUPERUSER_ID
 
@@ -10,20 +11,20 @@ class TestPurchaseRequest(common.TransactionCase):
 
     def setUp(self):
         super(TestPurchaseRequest, self).setUp()
-        self.purchase_request = self.env['purchase.request']
-        self.purchase_request_line = self.env['purchase.request.line']
+        self.purchase_request_obj = self.env['purchase.request']
+        self.purchase_request_line_obj = self.env['purchase.request.line']
         vals = {
             'picking_type_id': self.env.ref('stock.picking_type_in').id,
             'requested_by': SUPERUSER_ID,
         }
-        self.purchase_request = self.purchase_request.create(vals)
+        self.purchase_request = self.purchase_request_obj.create(vals)
         vals = {
             'request_id': self.purchase_request.id,
             'product_id': self.env.ref('product.product_product_13').id,
             'product_uom_id': self.env.ref('product.product_uom_unit').id,
             'product_qty': 5.0,
         }
-        self.purchase_request_line.create(vals)
+        self.purchase_request_line_obj.create(vals)
 
     def test_purchase_request_status(self):
         """Tests Purchase Request status workflow."""
@@ -54,7 +55,6 @@ class TestPurchaseRequest(common.TransactionCase):
         self.assertEqual(
             purchase_request.is_editable, False,
             'Should not be editable')
-        self.purchase_request_line.unlink()
 
     def test_auto_reject(self):
         """Tests if a Purchase Request is autorejected when all lines are
@@ -67,7 +67,7 @@ class TestPurchaseRequest(common.TransactionCase):
             'product_uom_id': self.env.ref('product.product_uom_unit').id,
             'product_qty': 5.0,
         }
-        self.purchase_request_line.create(vals)
+        self.purchase_request_line_obj.create(vals)
         lines = purchase_request.line_ids
         # Cancel one line:
         lines[0].do_cancel()
@@ -77,3 +77,48 @@ class TestPurchaseRequest(common.TransactionCase):
         lines[1].do_cancel()
         self.assertEqual(purchase_request.state, 'rejected',
                          'Purchase Request should have been auto-rejected.')
+
+    def test_pr_line_to_approve_allowed(self):
+        request = self.purchase_request
+        self.assertTrue(request.to_approve_allowed)
+
+        pr_lines = self.purchase_request.line_ids
+        pr_lines.write({'product_qty': 0})
+        self.assertFalse(request.to_approve_allowed)
+
+        pr_lines.write({'product_qty': 5})
+        self.assertTrue(request.to_approve_allowed)
+
+        pr_lines.do_cancel()
+        self.assertFalse(request.to_approve_allowed)
+
+        # Request has been automatically rejected
+        request.button_draft()
+        new_line = self.purchase_request_line_obj.create({
+            'product_id': self.env.ref(
+                'product.product_product_16').id,
+            'product_uom_id': self.env.ref(
+                'product.product_uom_unit').id,
+            'product_qty': 0.0,
+            'request_id': request.id,
+        })
+        pr_lines.do_cancel()
+        self.assertFalse(request.to_approve_allowed)
+
+        new_line.write({'product_qty': 1})
+        self.assertTrue(request.to_approve_allowed)
+
+        request.line_ids.unlink()
+        self.assertFalse(request.to_approve_allowed)
+
+    def test_empty_purchase_request(self):
+        pr = self.purchase_request
+        pr_lines = pr.line_ids
+        pr_lines.write({'product_qty': 0})
+
+        with self.assertRaises(UserError):
+            self.purchase_request.button_to_approve()
+
+        pr_lines.write({'product_qty': 4})
+        pr.button_to_approve()
+        self.assertEqual(pr.state, 'to_approve')


### PR DESCRIPTION
At the moment, we can request an approval for a purchase requests which has no lines or without any quantity. This makes no sense. This PR fixes this behavior.