### PR TITLE
[9.0][REF]purchase_request: call get_default name method inside copy

### DIFF
--- a/purchase_request/__openerp__.py
+++ b/purchase_request/__openerp__.py
@@ -6,7 +6,7 @@
     "name": "Purchase Request",
     "author": "Eficent Business and IT Consulting Services S.L., "
               "Odoo Community Association (OCA)",
-    "version": "9.0.1.0.1",
+    "version": "9.0.1.0.2",
     "summary": "Use this module to have notification of requirements of "
                "materials and/or external services and keep track of such "
                "requirements.",

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -123,7 +123,7 @@ class PurchaseRequest(models.Model):
         self.ensure_one()
         default.update({
             'state': 'draft',
-            'name': self.env['ir.sequence'].get('purchase.request'),
+            'name': self._get_default_name(),
         })
         return super(PurchaseRequest, self).copy(default)
 


### PR DESCRIPTION
Call `_get_default_name()` to get new name instead of  calling the sequence directly. This will give an entry point to override the copy method when generating a new name.