### PR TITLE
[ADD] purchase_line_reference: Abstract reference column

### DIFF
--- a/purchase_line_reference/README.rst
+++ b/purchase_line_reference/README.rst
@@ -1,0 +1,52 @@
+.. image:: https://img.shields.io/badge/license-LGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/lgpl.html
+   :alt: License: LGPL-3
+
+=======================
+Purchase Line Reference
+=======================
+
+Adds an abstract reference column to purchase order lines, allowing
+for you to directly reference the record that the line represents.
+
+This is primarily a technical module.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues 
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first, 
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_line_reference/__init__.py
+++ b/purchase_line_reference/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from . import models

--- a/purchase_line_reference/__manifest__.py
+++ b/purchase_line_reference/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+{
+    'name': 'Purchase Line Reference',
+    'summary': 'Adds an abstract reference to purchase order lines.',
+    'version': '10.0.1.0.0',
+    'category': 'Purchase',
+    'website': 'https://laslabs.com/',
+    'author': 'LasLabs, Odoo Community Association (OCA)',
+    'license': 'LGPL-3',
+    'application': False,
+    'installable': True,
+    'depends': [
+        'purchase',
+    ],
+}

--- a/purchase_line_reference/models/__init__.py
+++ b/purchase_line_reference/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from . import purchase_order_line

--- a/purchase_line_reference/models/purchase_order_line.py
+++ b/purchase_line_reference/models/purchase_order_line.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    reference = fields.Reference(
+        selection='_get_references',
+        help='Link to the record that this purchase order line directly '
+             'represents.',
+    )
+
+    @api.model
+    def _get_references(self):
+        all_models = self.env['ir.model'].search([])
+        return [(m.model, m.description) for m in all_models]

--- a/purchase_line_reference/models/purchase_order_line.py
+++ b/purchase_line_reference/models/purchase_order_line.py
@@ -17,4 +17,4 @@ class PurchaseOrderLine(models.Model):
     @api.model
     def _get_references(self):
         all_models = self.env['ir.model'].search([])
-        return [(m.model, m.description) for m in all_models]
+        return [(m.model, m.name) for m in all_models]

--- a/purchase_line_reference/models/purchase_order_line.py
+++ b/purchase_line_reference/models/purchase_order_line.py
@@ -16,5 +16,5 @@ class PurchaseOrderLine(models.Model):
 
     @api.model
     def _get_references(self):
-        all_models = self.env['ir.model'].search([])
-        return [(m.model, m.name) for m in all_models]
+        models = self.env['res.request.link'].search([])
+        return [(model.object, model.name) for model in models]


### PR DESCRIPTION
* New module to add an abstract reference column to `purchase.order.line` allowing for a direct back reference to the record it represents.