### PR TITLE
[11.0][mig] purchase_order_block]

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
 server-tools
+purchase-workflow

--- a/purchase_order_approval_block/README.rst
+++ b/purchase_order_approval_block/README.rst
@@ -1,0 +1,94 @@
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+    :alt: License LGPL-3
+
+=============================
+Purchase Order Approval Block
+=============================
+
+This module allows you to block the approval of an RFQ when an Approval
+Block Reason has been provided. Upon confirmation of an RFQ the orders will be
+waiting for approval by a Manager.
+
+Configuration
+=============
+
+* Go to ‘Purchases / Configuration / Purchase Approval Block Reasons’ and create
+  the blocking reasons as needed, providing a name and a description. A field
+  ‘Active’ allows you to deactivate the reason if you do not plan to use it
+  any more.
+* Assign the security group 'Release blocked RFQ' to users that should be able
+  to release the block. Users in group 'Purchase / Managers' are by default
+  assigned to this group.
+
+Usage
+=====
+
+Set the Purchase Approval Block
+-------------------------------
+
+#. Go to ‘Purchases / Purchase / Requests for Quotation’
+#. Create a new RFQ and indicate the approval block reason (found in the
+   right hand side of the screen, below the order date).
+
+Search existing RFQ
+-------------------
+
+There is a filter ‘Blocked’ to search for orders that are blocked for approval.
+It is also possible to search RFQ’s with a specific block reason.
+
+Confirm the RFQ
+---------------
+
+#. Press the button ‘Confirm’. If there’s an approval block, the order will
+   be set to status 'To Approve'. You will then need to request a Purchase
+   Manager to approve it.
+
+Release the purchase approval block
+-----------------------------------
+
+While the RFQ is in draft, members of security group ‘Release blocked RFQ’,
+can see a button ‘Release Approval Block’. From this point and on, anyone
+seeing that RFQ will be able to validate it.
+
+Notifications to followers
+--------------------------
+
+Followers of the RFQ receive notifications when an approval block has been
+set or released.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Roser Garcia <roser.garcia@eficent.com>
+* Darshan Patel <darshan.patel.serpentcs@gmail.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_order_approval_block/README.rst
+++ b/purchase_order_approval_block/README.rst
@@ -1,5 +1,6 @@
 .. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
-    :alt: License LGPL-3
+   :target: https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License LGPL-3
 
 =============================
 Purchase Order Approval Block
@@ -58,7 +59,7 @@ set or released.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/142/10.0
+   :target: https://runbot.odoo-community.org/runbot/142/11.0
 
 Bug Tracker
 ===========
@@ -70,6 +71,11 @@ help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
 
 Contributors
 ------------

--- a/purchase_order_approval_block/__init__.py
+++ b/purchase_order_approval_block/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import models

--- a/purchase_order_approval_block/__init__.py
+++ b/purchase_order_approval_block/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 Eficent Business and IT Consulting Services S.L.
-# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from . import models
+from . import wizard

--- a/purchase_order_approval_block/__manifest__.py
+++ b/purchase_order_approval_block/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Purchase Order Approval Block",
+    "author": "Eficent, SerpentCS, Odoo Community Association (OCA)",
+    "version": "10.0.1.0.0",
+    "category": "Purchase Management",
+    "website": "https://github.com/OCA/purchase-workflow",
+    "depends": [
+        'purchase',
+    ],
+    "data": [
+        'security/ir.model.access.csv',
+        'security/purchase_order_approval_block_security.xml',
+        'views/purchase_approval_block_reason_view.xml',
+        'views/purchase_order_view.xml',
+    ],
+    "license": 'LGPL-3',
+    "installable": True
+}

--- a/purchase_order_approval_block/__manifest__.py
+++ b/purchase_order_approval_block/__manifest__.py
@@ -1,18 +1,18 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
-# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Purchase Order Approval Block",
-    "author": "Eficent, SerpentCS, Odoo Community Association (OCA)",
-    "version": "10.0.1.0.0",
+    "author": "Eficent, Odoo Community Association (OCA)",
+    "version": "11.0.1.0.0",
     "category": "Purchase Management",
     "website": "https://github.com/OCA/purchase-workflow",
     "depends": [
         'purchase',
+        'purchase_exception',
     ],
     "data": [
+        'data/purchase_exception_data.xml',
         'security/ir.model.access.csv',
         'security/purchase_order_approval_block_security.xml',
         'views/purchase_approval_block_reason_view.xml',

--- a/purchase_order_approval_block/data/purchase_exception_data.xml
+++ b/purchase_order_approval_block/data/purchase_exception_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+        <record id ="po_excep_approval_block" model="exception.rule">
+            <field name="name">Approval Blocked</field>
+            <field name="description">The approval has been blocked,
+                with a Blocking reason.</field>
+            <field name="sequence">100</field>
+            <field name="rule_group">purchase</field>
+            <field name="model">purchase.order</field>
+            <field name="code">if 'approval_block_id' in purchase._fields and purchase.approval_block_id: failed = True</field>
+            <field name="next_state">to approve</field>
+            <field name="active" eval="True"/>
+        </record>
+
+</odoo>

--- a/purchase_order_approval_block/models/__init__.py
+++ b/purchase_order_approval_block/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import purchase_approval_block_reason
+from . import purchase_order

--- a/purchase_order_approval_block/models/__init__.py
+++ b/purchase_order_approval_block/models/__init__.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 Eficent Business and IT Consulting Services S.L.
-# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from . import purchase_approval_block_reason
 from . import purchase_order

--- a/purchase_order_approval_block/models/purchase_approval_block_reason.py
+++ b/purchase_order_approval_block/models/purchase_approval_block_reason.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models
+
+
+class PurchaseApprovalBlockReason(models.Model):
+    _name = 'purchase.approval.block.reason'
+
+    name = fields.Char(required=True)
+    description = fields.Text()
+    active = fields.Boolean(default=True)

--- a/purchase_order_approval_block/models/purchase_approval_block_reason.py
+++ b/purchase_order_approval_block/models/purchase_approval_block_reason.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
-# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
 

--- a/purchase_order_approval_block/models/purchase_order.py
+++ b/purchase_order_approval_block/models/purchase_order.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, fields, models, _
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    approval_block_id = fields.Many2one(
+        comodel_name='purchase.approval.block.reason',
+        string='Approval Block Reason',
+    )
+    approval_blocked = fields.Boolean(
+        'Approval Blocked',
+        compute='_compute_approval_blocked',
+    )
+
+    @api.multi
+    def _compute_approval_blocked(self):
+        for rec in self:
+            if rec.approval_block_id:
+                rec.approval_blocked = True
+
+    @api.model
+    def create(self, vals):
+        po = super(PurchaseOrder, self).create(vals)
+        if 'approval_block_id' in vals and vals['approval_block_id']:
+            po.message_post(body=_('Order \"%s\" blocked with reason'
+                                   ' \"%s\"') % (po.name,
+                                                 po.approval_block_id.name))
+        return po
+
+    @api.multi
+    def write(self, vals):
+        res = super(PurchaseOrder, self).write(vals)
+        for po in self:
+            if 'approval_block_id' in vals and vals['approval_block_id']:
+                po.message_post(
+                    body=_('Order \"%s\" blocked with reason \"%s\"') % (
+                        po.name, po.approval_block_id.name))
+            elif 'approval_block_id' in vals and not vals['approval_block_id']:
+                po.message_post(
+                    body=_('Order \"%s\" approval block released.') % po.name)
+        return res
+
+    @api.multi
+    def button_approve(self, force=False):
+        for rec in self:
+            if rec.approval_block_id:
+                rec.button_release_approval_block()
+        return super(PurchaseOrder, self).button_approve(force=force)
+
+    @api.multi
+    def button_release_approval_block(self):
+        for order in self.with_context(force_po_approval_block_release=True):
+            order.approval_block_id = False
+        return True
+
+    @api.multi
+    def _check_order_release(self):
+        self.ensure_one()
+        if self.approval_block_id:
+            return True
+
+    @api.multi
+    def button_confirm(self):
+        self.filtered(lambda o: o.state in ['draft', 'sent'] and
+                      o.approval_blocked).write({'state': 'to approve'})
+        return super(PurchaseOrder, self).button_confirm()

--- a/purchase_order_approval_block/models/purchase_order.py
+++ b/purchase_order_approval_block/models/purchase_order.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
-# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models, _
 
@@ -55,18 +53,6 @@ class PurchaseOrder(models.Model):
 
     @api.multi
     def button_release_approval_block(self):
-        for order in self.with_context(force_po_approval_block_release=True):
+        for order in self:
             order.approval_block_id = False
         return True
-
-    @api.multi
-    def _check_order_release(self):
-        self.ensure_one()
-        if self.approval_block_id:
-            return True
-
-    @api.multi
-    def button_confirm(self):
-        self.filtered(lambda o: o.state in ['draft', 'sent'] and
-                      o.approval_blocked).write({'state': 'to approve'})
-        return super(PurchaseOrder, self).button_confirm()

--- a/purchase_order_approval_block/security/ir.model.access.csv
+++ b/purchase_order_approval_block/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_purchase_order_approval_block_reason,purchase.order.block.reason,model_purchase_approval_block_reason,purchase.group_purchase_user,1,0,0,0
+access_purchase_order_approval_block_reason_manager,purchase.order.block.reason,model_purchase_approval_block_reason,purchase.group_purchase_manager,1,1,1,1

--- a/purchase_order_approval_block/security/purchase_order_approval_block_security.xml
+++ b/purchase_order_approval_block/security/purchase_order_approval_block_security.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+    <record id="group_rfq_approval_block" model="res.groups">
+        <field name="name">Release RFQ with approval block</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+        <field name="comment">
+            The user will be able to release an RFQ blocked for approval.
+        </field>
+    </record>
+    <record id="purchase.group_purchase_manager" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('group_rfq_approval_block'))]"/>
+    </record>
+</odoo>

--- a/purchase_order_approval_block/security/purchase_order_approval_block_security.xml
+++ b/purchase_order_approval_block/security/purchase_order_approval_block_security.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
-     Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<!--
+     Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+-->
 
 <odoo>
     <record id="group_rfq_approval_block" model="res.groups">

--- a/purchase_order_approval_block/tests/__init__.py
+++ b/purchase_order_approval_block/tests/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import test_purchase_order_approval_block
+from . import test_po_approval_block_reason

--- a/purchase_order_approval_block/tests/__init__.py
+++ b/purchase_order_approval_block/tests/__init__.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 Eficent Business and IT Consulting Services S.L.
-# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from . import test_purchase_order_approval_block
 from . import test_po_approval_block_reason

--- a/purchase_order_approval_block/tests/test_po_approval_block_reason.py
+++ b/purchase_order_approval_block/tests/test_po_approval_block_reason.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo.addons.purchase_order_approval_block.tests.\
+    test_purchase_order_approval_block import TestPurchaseOrderApprovalBlock
+
+
+class TestPoApprovalBlockReason(TestPurchaseOrderApprovalBlock):
+
+    def test_po_approval_block_manual_release(self):
+        """Confirming the Blocked PO"""
+        # The purchase manager unblocks the RFQ with block
+        self.purchase1.sudo(self.user2_id).button_release_approval_block()
+        self.assertEquals(self.purchase1.approval_block_id, self.env[
+            'purchase.approval.block.reason'])
+        # The purchase user validates the RFQ without block
+        self.purchase1.sudo(self.user1_id).button_confirm()
+        # The PO is approved
+        self.assertEquals(self.purchase1.state, 'purchase')
+
+    def test_po_approval_block_to_approve_release(self):
+        # The purchase user validates the RFQ with block, and is now to approve
+        self.purchase1.sudo(self.user2_id).button_confirm()
+        self.assertEquals(self.purchase1.state, 'to approve')
+        self.purchase1.sudo(self.user2_id).button_approve(force=False)
+        self.assertEquals(self.purchase1.state, 'purchase')

--- a/purchase_order_approval_block/tests/test_po_approval_block_reason.py
+++ b/purchase_order_approval_block/tests/test_po_approval_block_reason.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
-# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.addons.purchase_order_approval_block.tests.\
     test_purchase_order_approval_block import TestPurchaseOrderApprovalBlock
@@ -11,18 +9,61 @@ class TestPoApprovalBlockReason(TestPurchaseOrderApprovalBlock):
 
     def test_po_approval_block_manual_release(self):
         """Confirming the Blocked PO"""
+        # Create a PO
+        purchase = self._create_purchase(
+            [(self.product1, 1),
+             (self.product2, 5),
+             (self.product3, 8)])
+
+        purchase.approval_block_id = self.po_approval_block_reason.id
+
+        self.assertEqual(purchase.approval_blocked, True)
         # The purchase manager unblocks the RFQ with block
-        self.purchase1.sudo(self.user2_id).button_release_approval_block()
-        self.assertEquals(self.purchase1.approval_block_id, self.env[
+        purchase.sudo(self.user2_id).button_release_approval_block()
+        self.assertEqual(purchase.approval_block_id, self.env[
             'purchase.approval.block.reason'])
         # The purchase user validates the RFQ without block
-        self.purchase1.sudo(self.user1_id).button_confirm()
+        purchase.sudo(self.user1_id).button_confirm()
         # The PO is approved
-        self.assertEquals(self.purchase1.state, 'purchase')
+        self.assertEqual(purchase.state, 'purchase')
 
-    def test_po_approval_block_to_approve_release(self):
+    def test_po_approval_block_to_approve_release_01(self):
+        # Create a PO
+        purchase = self._create_purchase(
+            [(self.product1, 1),
+             (self.product2, 5),
+             (self.product3, 8)])
+
+        purchase.approval_block_id = self.po_approval_block_reason.id
         # The purchase user validates the RFQ with block, and is now to approve
-        self.purchase1.sudo(self.user2_id).button_confirm()
-        self.assertEquals(self.purchase1.state, 'to approve')
-        self.purchase1.sudo(self.user2_id).button_approve(force=False)
-        self.assertEquals(self.purchase1.state, 'purchase')
+        purchase.sudo(self.user2_id).button_confirm()
+        self.assertEquals(purchase.state, 'to approve')
+
+        # Simulation the opening of the wizard purchase_exception_confirm and
+        # set ignore_exception to True
+        po_except_confirm = \
+            self.env['purchase.exception.confirm'].with_context(
+                {
+                    'active_id': purchase.id,
+                    'active_ids': [purchase.id],
+                    'active_model': purchase._name
+                }).create({'ignore': True})
+        po_except_confirm.action_confirm()
+
+        self.assertEqual(purchase.state, 'purchase')
+
+    def test_po_approval_block_to_approve_release_02(self):
+        # Create a PO
+        purchase = self._create_purchase(
+            [(self.product1, 1),
+             (self.product2, 5),
+             (self.product3, 8)])
+
+        purchase.approval_block_id = self.po_approval_block_reason.id
+        # The purchase user validates the RFQ with block, and is now to approve
+        purchase.sudo(self.user2_id).button_confirm()
+        self.assertEquals(purchase.state, 'to approve')
+
+        purchase.sudo(self.user2_id).button_approve()
+
+        self.assertEqual(purchase.state, 'purchase')

--- a/purchase_order_approval_block/tests/test_purchase_order_approval_block.py
+++ b/purchase_order_approval_block/tests/test_purchase_order_approval_block.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+import time
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tests.common import TransactionCase
+
+
+class TestPurchaseOrderApprovalBlock(TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseOrderApprovalBlock, self).setUp()
+        self.users_obj = self.env['res.users']
+        self.po_obj = self.env['purchase.order']
+        self.po_block_obj = self.env['purchase.approval.block.reason']
+        # company
+        self.company1 = self.env.ref('base.main_company')
+        # groups
+        self.group_purchase_user = self.env.ref('purchase.group_purchase_user')
+        self.group_purchase_manager = self.env.ref(
+            'purchase.group_purchase_manager')
+        # Partner
+        self.partner1 = self.env.ref('base.res_partner_1')
+        # Products
+        self.product1 = self.env.ref('product.product_product_7')
+        self.product2 = self.env.ref('product.product_product_9')
+        self.product3 = self.env.ref('product.product_product_11')
+        # Create users
+        self.user1_id = self._create_user('user_1',
+                                          [self.group_purchase_user],
+                                          self.company1)
+        self.user2_id = self._create_user('user_2',
+                                          [self.group_purchase_manager],
+                                          self.company1)
+        # Create a PO Block Reason
+        self._create_block_reason()
+        # Create a PO
+        self.purchase1 = self._create_purchase(
+            [(self.product1, 1),
+             (self.product2, 5),
+             (self.product3, 8)])
+
+    def _create_block_reason(self):
+        self.po_approval_block_reason = self.po_block_obj.create({
+            'name': 'Needs Permission',
+            'description': 'Permission to validate',
+            })
+
+    def _create_user(self, login, groups, company):
+        """ Create a user."""
+        group_ids = [group.id for group in groups]
+        user =\
+            self.users_obj.with_context({'no_reset_password': True}).\
+            create({
+                'name': 'Purchase User',
+                'login': login,
+                'password': 'test',
+                'email': 'test@yourcompany.com',
+                'company_id': company.id,
+                'company_ids': [(4, company.id)],
+                'groups_id': [(6, 0, group_ids)]
+            })
+        return user.id
+
+    def _create_purchase(self, line_products):
+        """ Create a purchase order.
+        ``line_products`` is a list of tuple [(product, qty)]
+        """
+        lines = []
+        for product, qty in line_products:
+            line_values = {
+                'name': product.name,
+                'product_id': product.id,
+                'product_qty': qty,
+                'product_uom': product.uom_id.id,
+                'price_unit': 100,
+                'date_planned': time.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+            }
+            lines.append((0, 0, line_values))
+        purchase = self.po_obj.create({
+            'partner_id': self.partner1.id,
+            'approval_block_id': self.po_approval_block_reason.id,
+            'order_line': lines,
+            'company_id': self.company1.id,
+        })
+        return purchase

--- a/purchase_order_approval_block/tests/test_purchase_order_approval_block.py
+++ b/purchase_order_approval_block/tests/test_purchase_order_approval_block.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
-# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import time
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
@@ -36,11 +34,6 @@ class TestPurchaseOrderApprovalBlock(TransactionCase):
                                           self.company1)
         # Create a PO Block Reason
         self._create_block_reason()
-        # Create a PO
-        self.purchase1 = self._create_purchase(
-            [(self.product1, 1),
-             (self.product2, 5),
-             (self.product3, 8)])
 
     def _create_block_reason(self):
         self.po_approval_block_reason = self.po_block_obj.create({
@@ -81,7 +74,6 @@ class TestPurchaseOrderApprovalBlock(TransactionCase):
             lines.append((0, 0, line_values))
         purchase = self.po_obj.create({
             'partner_id': self.partner1.id,
-            'approval_block_id': self.po_approval_block_reason.id,
             'order_line': lines,
             'company_id': self.company1.id,
         })

--- a/purchase_order_approval_block/views/purchase_approval_block_reason_view.xml
+++ b/purchase_order_approval_block/views/purchase_approval_block_reason_view.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+
+<odoo>
+    <record id="purchase_approval_block_reason_tree_view" model="ir.ui.view">
+        <field name="name">purchase.approval.block.reason.tree</field>
+        <field name="model">purchase.approval.block.reason</field>
+        <field name="arch" type="xml">
+            <tree string="Purchase Order Approval Block Reason">
+                <field name="name"/>
+                <field name="description"/>
+            </tree>
+        </field>
+    </record>
+    <record id="purchase_approval_block_reason_form_view" model="ir.ui.view">
+        <field name="name">purchase.approval.block.reason.form</field>
+        <field name="model">purchase.approval.block.reason</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="active_button_box">
+                        <button name="toggle_active" type="object"
+                                class="oe_stat_button" icon="fa-archive">
+                            <field name="active" widget="boolean_button"
+                                options='{"terminology": "archive"}'/>
+                        </button>
+                    </div>
+                    <group name="top" colspan="2" col="2">
+                        <field name="name"/>
+                        <field name="description"/>
+                    </group>
+                </sheet>
+
+            </form>
+        </field>
+    </record>
+    <act_window id="action_purchase_approval_block_reason"
+                name="Purchase Approval Block Reason"
+                res_model="purchase.approval.block.reason"
+                view_mode="tree,form"/>
+
+    <menuitem id="menu_purchase_approval_block_reason"
+              name="Purchase Approval Block Reason"
+              parent="purchase.menu_purchase_config"
+              action="action_purchase_approval_block_reason"/>
+</odoo>

--- a/purchase_order_approval_block/views/purchase_approval_block_reason_view.xml
+++ b/purchase_order_approval_block/views/purchase_approval_block_reason_view.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
-     Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+<!--
+     Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+-->
 
 <odoo>
     <record id="purchase_approval_block_reason_tree_view" model="ir.ui.view">
         <field name="name">purchase.approval.block.reason.tree</field>
         <field name="model">purchase.approval.block.reason</field>
         <field name="arch" type="xml">
-            <tree string="Purchase Order Approval Block Reason">
+            <tree string="Purchase Order Approval Block Reasons">
                 <field name="name"/>
                 <field name="description"/>
             </tree>
@@ -38,12 +39,12 @@
         </field>
     </record>
     <act_window id="action_purchase_approval_block_reason"
-                name="Purchase Approval Block Reason"
+                name="Purchase Approval Block Reasons"
                 res_model="purchase.approval.block.reason"
                 view_mode="tree,form"/>
 
     <menuitem id="menu_purchase_approval_block_reason"
-              name="Purchase Approval Block Reason"
+              name="Purchase Approval Block Reasons"
               parent="purchase.menu_purchase_config"
               action="action_purchase_approval_block_reason"/>
 </odoo>

--- a/purchase_order_approval_block/views/purchase_order_view.xml
+++ b/purchase_order_approval_block/views/purchase_order_view.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+
+<odoo>
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field name="name">purchase.order.form.block.reason</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <button name="button_draft" position="attributes">
+                <attribute name="states">cancel,to approve</attribute>
+            </button>
+            <field name="date_order" position="after">
+                <field name="approval_block_id"
+                       attrs="{'readonly': ['|',('approval_blocked','=', True), ('state', 'not in', 'draft')]}"/>
+                <field name="approval_blocked" invisible="True"/>
+            </field>
+            <xpath expr="//header/button[@name='button_confirm']"
+                   position="before">
+                <button name="button_release_approval_block"
+                        string="Release Approval Block"
+                        type="object" class="btn-primary"
+                        groups="purchase_order_approval_block.group_rfq_approval_block"
+                        attrs="{'invisible': ['|',('approval_block_id', '=', False),
+                        ('state', 'not in', ['draft', 'sent'])]}"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_purchase_order_filter" model="ir.ui.view">
+        <field name="name">request.quotation.select.block.reason</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.view_purchase_order_filter"/>
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="approval_block_id"/>
+            </field>
+            <filter name="approved" position="after">
+                <filter string="Blocked for Approval" name="blocked_po"
+                        domain="[('approval_block_id', '!=', False)]"/>
+            </filter>
+        </field>
+    </record>
+</odoo>

--- a/purchase_order_approval_block/views/purchase_order_view.xml
+++ b/purchase_order_approval_block/views/purchase_order_view.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
-     Copyright 2017 Serpent Consulting Services Pvt. Ltd.
-     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+<!--
+     Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+-->
 
 <odoo>
     <record id="purchase_order_form" model="ir.ui.view">

--- a/purchase_order_approval_block/wizard/__init__.py
+++ b/purchase_order_approval_block/wizard/__init__.py
@@ -1,0 +1,2 @@
+
+from . import purchase_exception_confirm

--- a/purchase_order_approval_block/wizard/purchase_exception_confirm.py
+++ b/purchase_order_approval_block/wizard/purchase_exception_confirm.py
@@ -1,0 +1,15 @@
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class PurchaseExceptionConfirm(models.TransientModel):
+    _inherit = 'purchase.exception.confirm'
+
+    @api.multi
+    def action_confirm(self):
+        self.ensure_one()
+        if self.ignore and self.related_model_id.approval_block_id:
+            self.related_model_id.button_release_approval_block()
+        return super(PurchaseExceptionConfirm, self).action_confirm()


### PR DESCRIPTION
Replaces https://github.com/OCA/purchase-workflow/pull/476
Depends on the following PR's:
- [x] base_exception https://github.com/OCA/server-tools/pull/1025
- [x] purchase_exception https://github.com/OCA/purchase-workflow/pull/467

Purchase Order Approval Block
=============================

This module allows you to block the approval of an RFQ when an Approval
Block Reason has been provided. Upon confirmation of an RFQ the orders will be
waiting for approval by a Manager.

Configuration
=============

* Go to ‘Purchases / Configuration / Purchase Approval Block Reasons’ and create
  the blocking reasons as needed, providing a name and a description. A field
  ‘Active’ allows you to deactivate the reason if you do not plan to use it
  any more.
* Assign the security group 'Release blocked RFQ' to users that should be able
  to release the block. Users in group 'Purchase / Managers' are by default
  assigned to this group.

Usage
=====

Set the Purchase Approval Block
-------------------------------

#. Go to ‘Purchases / Purchase / Requests for Quotation’
#. Create a new RFQ and indicate the approval block reason (found in the
   right hand side of the screen, below the order date).

Search existing RFQ
-------------------

There is a filter ‘Blocked’ to search for orders that are blocked for approval.
It is also possible to search RFQ’s with a specific block reason.

Confirm the RFQ
---------------

#. Press the button ‘Confirm’. If there’s an approval block, the order will
   be set to status 'To Approve'. You will then need to request a Purchase
   Manager to approve it.

Release the purchase approval block
-----------------------------------

While the RFQ is in draft, members of security group ‘Release blocked RFQ’,
can see a button ‘Release Approval Block’. From this point and on, anyone
seeing that RFQ will be able to validate it.

Notifications to followers
--------------------------

Followers of the RFQ receive notifications when an approval block has been
set or released.
  