### PR TITLE
[9.0][ADD] purchase_tier_validation

### DIFF
--- a/purchase_tier_validation/README.rst
+++ b/purchase_tier_validation/README.rst
@@ -1,0 +1,84 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+========================
+Purchase Tier Validation
+========================
+
+This module extends the functionality of Purchase Orders to support a tier
+validation process.
+
+Installation
+============
+
+This module depends on ``base_tier_validation``. You can find it at
+`OCA/server-tools <https://github.com/OCA/purchase-workflow>`_
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to *Settings > Technical > Tier Validations > Tier Definition*.
+#. Create as many tiers as you want for Purchase Order model.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Create a Purchase Order triggering at least one "Tier Definition".
+#. Click on *Request Validation* button.
+#. Under the tab *Reviews* have a look to pending reviews and their statuses.
+#. Once all reviews are validated click on *Confirm Order*.
+
+Additional features:
+
+* You can filter the POs requesting your review through the filter *Needs my
+  Review*.
+* User with rights to confirm the PO (validate all tiers that would
+  be generated) can directly do the operation, this is, there is no need for
+  her/him to request a validation.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/server-tools/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
+
+Contributors
+------------
+
+* Lois Rilo <lois.rilo@eficent.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_tier_validation/__init__.py
+++ b/purchase_tier_validation/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/purchase_tier_validation/__openerp__.py
+++ b/purchase_tier_validation/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Purchase Tier Validation",
+    "summary": "Extends the functionality of Purchase Orders to "
+               "support a tier validation process.",
+    "version": "9.0.1.0.0",
+    "category": "Purchases",
+    "website": "https://github.com/OCA/purchase-workflow",
+    "author": "Eficent, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "purchase",
+        "base_tier_validation",
+    ],
+    "data": [
+        "views/purchase_order_view.xml",
+    ],
+}

--- a/purchase_tier_validation/models/__init__.py
+++ b/purchase_tier_validation/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import purchase_order
+from . import tier_definition

--- a/purchase_tier_validation/models/purchase_order.py
+++ b/purchase_tier_validation/models/purchase_order.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openerp import models
+
+
+class PurchaseOrder(models.Model):
+    _name = "purchase.order"
+    _inherit = ['purchase.order', 'tier.validation']
+    _state_from = ['draft', 'sent']
+    _state_to = ['purchase', 'approved']

--- a/purchase_tier_validation/models/tier_definition.py
+++ b/purchase_tier_validation/models/tier_definition.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openerp import api, models
+
+
+class TierDefinition(models.Model):
+    _inherit = "tier.definition"
+
+    @api.model
+    def _get_tier_validation_model_names(self):
+        res = super(TierDefinition, self)._get_tier_validation_model_names()
+        res.append("purchase.order")
+        return res

--- a/purchase_tier_validation/views/purchase_order_view.xml
+++ b/purchase_tier_validation/views/purchase_order_view.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field name="name">purchase.order.form - test</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <button name="button_confirm" position="before">
+                <button name="request_validation"
+                    string="Request Validation"
+                    attrs="{'invisible': [('need_validation', '!=', True)]}"
+                    type="object"
+                    states="draft"/>
+            </button>
+            <header position="after">
+                <field name="need_validation" invisible="1"/>
+                <field name="validated" invisible="1"/>
+                <field name="rejected" invisible="1"/>
+                <div class="alert alert-warning"
+                     attrs="{'invisible': ['|', '|', ('validated', '=', True), ('state', '!=', 'draft'),('rejected', '=', True)]}"
+                     style="margin-bottom:0px;">
+                    <p><i class="fa fa-info-circle"/>This PO needs to be
+                        validated.
+                        <button name="validate_tier"
+                            string="Validate"
+                            attrs="{'invisible': [('review_ids', '=', [])]}"
+                            type="object"
+                            states="draft"
+                            class="oe_inline oe_button btn-success"
+                            icon="fa-thumbs-up"/>
+                        <button name="reject_tier"
+                            string="Reject"
+                            type="object"
+                            states="draft"
+                            class="btn-icon btn-danger"
+                            icon="fa-thumbs-down"/>
+                    </p>
+                </div>
+                <div class="alert alert-success"
+                     attrs="{'invisible': ['|', '|', ('validated', '!=', True), ('state', '!=', 'draft'), ('review_ids', '=', [])]}"
+                     style="margin-bottom:0px;">
+                    <p><i class="fa fa-thumbs-up"/> Operation has been <b>validated</b>!</p>
+                </div>
+                <div class="alert alert-danger"
+                     attrs="{'invisible': ['|', '|', ('rejected', '!=', True), ('state', '!=', 'draft'), ('review_ids', '=', [])]}"
+                     style="margin-bottom:0px;">
+                    <p><i class="fa fa-thumbs-down"/> Operation has been <b>rejected</b>.</p>
+                </div>
+            </header>
+            <notebook position="inside">
+                <page string="Reviews" name="tier_validation">
+                    <field name="review_ids" readonly="1"/>
+                </page>
+            </notebook>
+        </field>
+    </record>
+
+    <record id="view_purchase_order_filter" model="ir.ui.view">
+        <field name="name">purchase.order.select - purchase_tier_validation</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.view_purchase_order_filter"/>
+        <field name="arch" type="xml">
+            <filter name="message_needaction" position="after">
+                <filter name="needs_review" string="Needs my Review"
+                        domain="[('reviewer_ids','in',uid)]"
+                        help="My Purchases to review"/>
+                <filter name="tier_validated" string="Validated"
+                        domain="[('validated', '=', True)]"
+                        help="POs validated and ready to be confirmed"/>
+            </filter>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Purchase Tier Validation
========================
This module extends the functionality of Purchase Orders to support a tier
validation process.

Configuration
=============

To configure this module, you need to:

#. Go to *Settings > Technical > Tier Validations > Tier Definition*.
#. Create as many tiers as you want for Purchase Order model.

Usage
=====

To use this module, you need to:

#. Create a Purchase Order triggering at least one "Tier Definition".
#. Click on *Request Validation* button.
#. Under the tab *Reviews* have a look to pending reviews and their statuses.
#. Once all reviews are validated click on *Confirm Order*.

------

* [x] : Depends on https://github.com/OCA/server-tools/pull/1085