### PR TITLE
[10.0][MIG] purchase_request_to_rfq_order_approved

### DIFF
--- a/purchase_request_to_rfq_order_approved/README.rst
+++ b/purchase_request_to_rfq_order_approved/README.rst
@@ -13,7 +13,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/repo/github-com-oca-purchase-workflow-142
+   :target: https://runbot.odoo-community.org/runbot/142/9.0
 
 
 Bug Tracker
@@ -31,7 +31,7 @@ Credits
 Contributors
 ------------
 
-Gisela Mora gisela.mora@eficent.com
+Gisela Mora <gisela.mora@eficent.com>
 Eficent. http://www.eficent.com/
 
 

--- a/purchase_request_to_rfq_order_approved/README.rst
+++ b/purchase_request_to_rfq_order_approved/README.rst
@@ -1,6 +1,8 @@
-.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
-    :alt: License LGPL-3
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
+======================================
 Purchase Request to RFQ Order Approved
 ======================================
 
@@ -13,7 +15,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/142/9.0
+   :target: https://runbot.odoo-community.org/runbot/142/10.0
 
 
 Bug Tracker
@@ -24,15 +26,14 @@ Bugs are tracked on `GitHub Issues
 check there if your issue has already been reported. If you spotted it first,
 help us smashing it by providing a detailed and welcomed feedback.
 
-
 Credits
 =======
 
 Contributors
 ------------
 
-Gisela Mora <gisela.mora@eficent.com>
-Eficent. http://www.eficent.com/
+* Gisela Mora <gisela.mora@eficent.com>
+* Lois Rilo <lois.rilo@eficent.com>
 
 
 Maintainer

--- a/purchase_request_to_rfq_order_approved/README.rst
+++ b/purchase_request_to_rfq_order_approved/README.rst
@@ -1,0 +1,51 @@
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+    :alt: License LGPL-3
+
+Purchase Request to RFQ Order Approved
+======================================
+
+This module computes the new PO state 'Approved' related to a Purchase
+Request Line to display it in the Purchase Request Line tree view and adds a
+'Purchase Approved' filter.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/repo/github-com-oca-purchase-workflow-142
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+Gisela Mora gisela.mora@eficent.com
+Eficent. http://www.eficent.com/
+
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/purchase_request_to_rfq_order_approved/__init__.py
+++ b/purchase_request_to_rfq_order_approved/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+from . import models

--- a/purchase_request_to_rfq_order_approved/__init__.py
+++ b/purchase_request_to_rfq_order_approved/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
 from . import models

--- a/purchase_request_to_rfq_order_approved/__init__.py
+++ b/purchase_request_to_rfq_order_approved/__init__.py
@@ -3,3 +3,4 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
 from . import models
+from .init_hook import post_init_hook

--- a/purchase_request_to_rfq_order_approved/__manifest__.py
+++ b/purchase_request_to_rfq_order_approved/__manifest__.py
@@ -6,14 +6,15 @@
     "name": "Purchase Request to RFQ Order Approved",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
-    "version": "9.0.1.0.0",
+    "version": "10.0.1.0.0",
     "website": "http://www.eficent.com/",
     "category": "Purchase Management",
     "depends": [
         "purchase_request_to_rfq",
-        "purchase_order_approved"],
+        "purchase_order_approved",
+    ],
     "data": [
-        "views/purchase_request_view.xml"
+        "views/purchase_request_view.xml",
     ],
     "license": 'LGPL-3',
     "installable": True,

--- a/purchase_request_to_rfq_order_approved/__openerp__.py
+++ b/purchase_request_to_rfq_order_approved/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+{
+    "name": "Purchase Request to RFQ Order Approved",
+    "author": "Eficent, "
+              "Odoo Community Association (OCA)",
+    "version": "9.0.1.0.0",
+    "website": "http://www.eficent.com/",
+    "category": "Purchase Management",
+    "depends": [
+        "purchase_request_to_rfq",
+        "purchase_order_approved"],
+    "data": [
+        "views/purchase_request_view.xml"
+    ],
+    "license": 'LGPL-3',
+    "installable": True,
+    "auto_install": True,
+}

--- a/purchase_request_to_rfq_order_approved/__openerp__.py
+++ b/purchase_request_to_rfq_order_approved/__openerp__.py
@@ -17,5 +17,6 @@
     ],
     "license": 'LGPL-3',
     "installable": True,
+    "post_init_hook": 'post_init_hook',
     "auto_install": True,
 }

--- a/purchase_request_to_rfq_order_approved/i18n/es.po
+++ b/purchase_request_to_rfq_order_approved/i18n/es.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_request_to_rfq_order_approved
+# 
+# Translators:
+# Pedro M. Baeza <pedro.baeza@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-13 03:10+0000\n"
+"PO-Revision-Date: 2017-06-13 03:10+0000\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>, 2017\n"
+"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: purchase_request_to_rfq_order_approved
+#: model:ir.ui.view,arch_db:purchase_request_to_rfq_order_approved.purchase_request_line_search
+msgid "At least a Purchase Order has been approved"
+msgstr ""
+
+#. module: purchase_request_to_rfq_order_approved
+#: model:ir.ui.view,arch_db:purchase_request_to_rfq_order_approved.purchase_request_line_search
+msgid "Purchase Approved"
+msgstr ""
+
+#. module: purchase_request_to_rfq_order_approved
+#: model:ir.model,name:purchase_request_to_rfq_order_approved.model_purchase_request_line
+msgid "Purchase Request Line"
+msgstr "Línea de petición de compra"

--- a/purchase_request_to_rfq_order_approved/i18n/fr.po
+++ b/purchase_request_to_rfq_order_approved/i18n/fr.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_request_to_rfq_order_approved
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-13 03:10+0000\n"
+"PO-Revision-Date: 2017-06-13 03:10+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: purchase_request_to_rfq_order_approved
+#: model:ir.ui.view,arch_db:purchase_request_to_rfq_order_approved.purchase_request_line_search
+msgid "At least a Purchase Order has been approved"
+msgstr ""
+
+#. module: purchase_request_to_rfq_order_approved
+#: model:ir.ui.view,arch_db:purchase_request_to_rfq_order_approved.purchase_request_line_search
+msgid "Purchase Approved"
+msgstr ""
+
+#. module: purchase_request_to_rfq_order_approved
+#: model:ir.model,name:purchase_request_to_rfq_order_approved.model_purchase_request_line
+msgid "Purchase Request Line"
+msgstr "Ligne de demande d'achat"

--- a/purchase_request_to_rfq_order_approved/i18n/sl.po
+++ b/purchase_request_to_rfq_order_approved/i18n/sl.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_request_to_rfq_order_approved
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-13 03:10+0000\n"
+"PO-Revision-Date: 2017-06-13 03:10+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: purchase_request_to_rfq_order_approved
+#: model:ir.ui.view,arch_db:purchase_request_to_rfq_order_approved.purchase_request_line_search
+msgid "At least a Purchase Order has been approved"
+msgstr ""
+
+#. module: purchase_request_to_rfq_order_approved
+#: model:ir.ui.view,arch_db:purchase_request_to_rfq_order_approved.purchase_request_line_search
+msgid "Purchase Approved"
+msgstr ""
+
+#. module: purchase_request_to_rfq_order_approved
+#: model:ir.model,name:purchase_request_to_rfq_order_approved.model_purchase_request_line
+msgid "Purchase Request Line"
+msgstr "Postavka zahteve po nabavi"

--- a/purchase_request_to_rfq_order_approved/init_hook.py
+++ b/purchase_request_to_rfq_order_approved/init_hook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 David Dufresne <david.dufresne@savoirfairelinux.com>
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging

--- a/purchase_request_to_rfq_order_approved/init_hook.py
+++ b/purchase_request_to_rfq_order_approved/init_hook.py
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 
 def post_init_hook(cr, registry):
     """
-    The objective of this hook is to update the field purchase_state in 
+    The objective of this hook is to update the field purchase_state in
     existing purchase request lines
     """
-    update_field_purchase_state(cr )
+    update_field_purchase_state(cr)
 
 
 def update_field_purchase_state(cr):

--- a/purchase_request_to_rfq_order_approved/init_hook.py
+++ b/purchase_request_to_rfq_order_approved/init_hook.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# © 2016 David Dufresne <david.dufresne@savoirfairelinux.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def post_init_hook(cr):
+    """
+    The objective of this hook is to update the field purchase_state in 
+    existing purchase request lines
+    """
+    update_field_purchase_state(cr)
+
+
+def update_field_purchase_state(cr):
+
+    logger.info('Updating field purchase_state on purchase_request_line')
+
+    cr.execute(
+        """
+        UPDATE purchase_request_line prl
+        SET purchase_state = 'approved'
+        FROM purchase_request_purchase_order_line_rel AS prpol
+        JOIN purchase_order_line AS pol
+        ON pol.id = prpol.purchase_order_line_id
+        JOIN purchase_order AS po
+        ON po.id = pol.order_id
+        WHERE prpol.purchase_request_line_id = prl.id
+        AND po.state = 'approved'
+        """
+    )

--- a/purchase_request_to_rfq_order_approved/init_hook.py
+++ b/purchase_request_to_rfq_order_approved/init_hook.py
@@ -8,12 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def post_init_hook(cr):
+def post_init_hook(cr, registry):
     """
     The objective of this hook is to update the field purchase_state in 
     existing purchase request lines
     """
-    update_field_purchase_state(cr)
+    update_field_purchase_state(cr )
 
 
 def update_field_purchase_state(cr):

--- a/purchase_request_to_rfq_order_approved/models/__init__.py
+++ b/purchase_request_to_rfq_order_approved/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+from . import purchase_request

--- a/purchase_request_to_rfq_order_approved/models/__init__.py
+++ b/purchase_request_to_rfq_order_approved/models/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
 from . import purchase_request

--- a/purchase_request_to_rfq_order_approved/models/purchase_request.py
+++ b/purchase_request_to_rfq_order_approved/models/purchase_request.py
@@ -2,7 +2,7 @@
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
-from openerp import api, models
+from odoo import api, models
 
 
 class PurchaseRequestLine(models.Model):

--- a/purchase_request_to_rfq_order_approved/models/purchase_request.py
+++ b/purchase_request_to_rfq_order_approved/models/purchase_request.py
@@ -2,7 +2,7 @@
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
-from openerp import api, fields, models
+from openerp import api, models
 
 
 class PurchaseRequestLine(models.Model):
@@ -15,6 +15,7 @@ class PurchaseRequestLine(models.Model):
         for rec in self:
             if rec.purchase_lines:
                 if any([po_line.state == 'approved' for po_line in
-                        rec.purchase_lines]) and not any([po_line.state in ['purchase', 'done']
-                                                          for po_line in rec.purchase_lines]):
+                        rec.purchase_lines]) and not any(
+                    [po_line.state in ['purchase', 'done'] for po_line in
+                     rec.purchase_lines]):
                     rec.purchase_state = 'approved'

--- a/purchase_request_to_rfq_order_approved/models/purchase_request.py
+++ b/purchase_request_to_rfq_order_approved/models/purchase_request.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+from openerp import models, api
+
+
+class PurchaseRequestLine(models.Model):
+    _inherit = "purchase.request.line"
+
+    @api.multi
+    @api.depends('purchase_lines.state', 'purchase_lines.order_id.state')
+    def _compute_purchase_state(self):
+        temp_purchase_state = \
+            super(PurchaseRequestLine, self)._compute_purchase_state()
+        for rec in self:
+            temp_purchase_state = False
+            if rec.purchase_lines:
+                if any([po_line.state == 'approved' for po_line in
+                        rec.purchase_lines]):
+                    temp_purchase_state = 'approved'
+            rec.purchase_state = temp_purchase_state

--- a/purchase_request_to_rfq_order_approved/models/purchase_request.py
+++ b/purchase_request_to_rfq_order_approved/models/purchase_request.py
@@ -9,14 +9,11 @@ class PurchaseRequestLine(models.Model):
     _inherit = "purchase.request.line"
 
     @api.multi
-    @api.depends('purchase_lines.state', 'purchase_lines.order_id.state')
+    @api.depends('purchase_lines', 'purchase_lines.order_id.state')
     def _compute_purchase_state(self):
-        temp_purchase_state = \
-            super(PurchaseRequestLine, self)._compute_purchase_state()
+        super(PurchaseRequestLine, self)._compute_purchase_state()
         for rec in self:
-            temp_purchase_state = False
             if rec.purchase_lines:
-                if any([po_line.state == 'approved' for po_line in
+                if any([po_line.order_id.state == 'approved' for po_line in
                         rec.purchase_lines]):
-                    temp_purchase_state = 'approved'
-            rec.purchase_state = temp_purchase_state
+                    rec.purchase_state = 'approved'

--- a/purchase_request_to_rfq_order_approved/models/purchase_request.py
+++ b/purchase_request_to_rfq_order_approved/models/purchase_request.py
@@ -2,7 +2,7 @@
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
-from openerp import models, api
+from openerp import api, fields, models
 
 
 class PurchaseRequestLine(models.Model):
@@ -14,6 +14,7 @@ class PurchaseRequestLine(models.Model):
         super(PurchaseRequestLine, self)._compute_purchase_state()
         for rec in self:
             if rec.purchase_lines:
-                if any([po_line.order_id.state == 'approved' for po_line in
-                        rec.purchase_lines]):
+                if any([po_line.state == 'approved' for po_line in
+                        rec.purchase_lines]) and not any([po_line.state in ['purchase', 'done']
+                                                          for po_line in rec.purchase_lines]):
                     rec.purchase_state = 'approved'

--- a/purchase_request_to_rfq_order_approved/tests/__init__.py
+++ b/purchase_request_to_rfq_order_approved/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+from . import test_purchase_request_to_rfq_order_approved

--- a/purchase_request_to_rfq_order_approved/tests/__init__.py
+++ b/purchase_request_to_rfq_order_approved/tests/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
 from . import test_purchase_request_to_rfq_order_approved

--- a/purchase_request_to_rfq_order_approved/tests/test_purchase_request_to_rfq_order_approved.py
+++ b/purchase_request_to_rfq_order_approved/tests/test_purchase_request_to_rfq_order_approved.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+
+from openerp.tests import common
+from openerp.tools import SUPERUSER_ID
+
+
+class TestPurchaseRequestToRfqOrderApproved(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseRequestToRfqOrderApproved, self).setUp()
+        self.purchase_request = self.env['purchase.request']
+        self.purchase_request_line = self.env['purchase.request.line']
+        self.wiz =\
+            self.env['purchase.request.line.make.purchase.order']
+        self.purchase_order = self.env['purchase.order']
+
+    def test_purchase_request_to_purchase_rfq_multiple_PO(self):
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request1 = self.purchase_request.create(vals)
+        purchase_request1.company_id.purchase_approve_active = True
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+        }
+        purchase_request2 = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request1.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 2.0,
+        }
+        purchase_request_line1 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line2 = self.purchase_request_line.create(vals)
+        vals = {
+            'request_id': purchase_request2.id,
+            'product_id': self.env.ref('product.product_product_6').id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 1.0,
+        }
+        purchase_request_line3 = self.purchase_request_line.create(vals)
+        vals = {
+            'supplier_id': self.env.ref('base.res_partner_1').id,
+        }
+        purchase_request1.button_approved()
+        purchase_request2.button_approved()
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line1.id, purchase_request_line2.id,
+                        purchase_request_line3.id]).create(vals)
+        for item in wiz_id.item_ids:
+            if item.line_id.id == purchase_request_line1.id:
+                item.product_qty = 1
+            if item.line_id.id == purchase_request_line2.id:
+                item.keep_description = True
+            if item.line_id.id == purchase_request_line3.id:
+                item.onchange_product_id()
+        wiz_id.make_purchase_order()
+        purchase = purchase_request_line1.purchase_lines[0].order_id
+        purchase.button_confirm()
+
+        self.assertEquals(purchase_request_line1.purchase_state, 'approved',
+                          'Status of the request line should be approved')
+
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line1.id]).create(vals)
+        for item in wiz_id.item_ids:
+            if item.line_id.id == purchase_request_line1.id:
+                item.product_qty = 1
+        wiz_id.make_purchase_order()
+        purchase = purchase_request_line1.purchase_lines[0].order_id
+        purchase.button_confirm()
+        self.assertEquals(purchase_request_line1.purchase_state, 'approved',
+                          'Status of the request line should be approved')
+        purchase.button_release()
+        self.assertEquals(purchase_request_line1.purchase_state, 'purchase',
+                          'Status of the request line should be purchase')

--- a/purchase_request_to_rfq_order_approved/tests/test_purchase_request_to_rfq_order_approved.py
+++ b/purchase_request_to_rfq_order_approved/tests/test_purchase_request_to_rfq_order_approved.py
@@ -2,8 +2,8 @@
 # Copyright 2016 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
 
-from openerp.tests import common
-from openerp.tools import SUPERUSER_ID
+from odoo.tests import common
+from odoo.tools import SUPERUSER_ID
 
 
 class TestPurchaseRequestToRfqOrderApproved(common.TransactionCase):

--- a/purchase_request_to_rfq_order_approved/views/purchase_request_view.xml
+++ b/purchase_request_to_rfq_order_approved/views/purchase_request_view.xml
@@ -11,7 +11,7 @@
                 <filter name="purchase_state_approved"
                         string="Purchase Approved"
                         domain="[('purchase_state','=', 'approved')]"
-                        help="At least a PO has been approved"/>
+                        help="At least a Purchase Order has been approved"/>
             </filter>
         </field>
     </record>

--- a/purchase_request_to_rfq_order_approved/views/purchase_request_view.xml
+++ b/purchase_request_to_rfq_order_approved/views/purchase_request_view.xml
@@ -5,14 +5,14 @@
     <record id="purchase_request_line_search" model="ir.ui.view">
         <field name="name">purchase.request.line.search</field>
         <field name="model">purchase.request.line</field>
-        <field name="inherit_id" ref="purchase_request.purchase_request_line_search"/>
+        <field name="inherit_id" ref="purchase_request_to_rfq.purchase_request_line_search"/>
         <field name="arch" type="xml">
-            <field name="date_required" position="after">
-            <filter name="purchase_state_approved"
-                    string="Purchase Approved"
-                    domain="[('purchase_state','=', 'approved')]"
-                    help="At least a PO has been approved"/>
-            </field>
+            <filter name="purchase_state_draft" position="after">
+                <filter name="purchase_state_approved"
+                        string="Purchase Approved"
+                        domain="[('purchase_state','=', 'approved')]"
+                        help="At least a PO has been approved"/>
+            </filter>
         </field>
     </record>
 </openerp>

--- a/purchase_request_to_rfq_order_approved/views/purchase_request_view.xml
+++ b/purchase_request_to_rfq_order_approved/views/purchase_request_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
+<openerp>
+    <record id="purchase_request_line_search" model="ir.ui.view">
+        <field name="name">purchase.request.line.search</field>
+        <field name="model">purchase.request.line</field>
+        <field name="inherit_id" ref="purchase_request.purchase_request_line_search"/>
+        <field name="arch" type="xml">
+            <field name="date_required" position="after">
+            <filter name="purchase_state_approved"
+                    string="Purchase Approved"
+                    domain="[('purchase_state','=', 'approved')]"
+                    help="At least a PO has been approved"/>
+            </field>
+        </field>
+    </record>
+</openerp>

--- a/purchase_request_to_rfq_order_approved/views/purchase_request_view.xml
+++ b/purchase_request_to_rfq_order_approved/views/purchase_request_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
-<openerp>
+<odoo>
     <record id="purchase_request_line_search" model="ir.ui.view">
         <field name="name">purchase.request.line.search</field>
         <field name="model">purchase.request.line</field>
@@ -15,4 +15,4 @@
             </filter>
         </field>
     </record>
-</openerp>
+</odoo>


### PR DESCRIPTION
Migration to v10.

Depends on:

* [x] : https://github.com/OCA/purchase-workflow/pull/492

Purchase Request to RFQ Order Approved
=================================

This module computes the new PO state 'Approved' related to a Purchase
Request Line to display it in the Purchase Request Line tree view and adds a
'Purchase Approved' filter.