### PR TITLE
[FIX] purchase_discount: Handle case where taxes rounding is global

### DIFF
--- a/purchase_discount/README.rst
+++ b/purchase_discount/README.rst
@@ -21,7 +21,12 @@ Usage
 Known issues / Roadmap
 ======================
 
-With this module, the *price_unit* field of purchase order line stores the gross price instead of the net price, which is a change in the meaning of this field. So this module breaks all the other modules that use the *price_unit* field with it's native meaning.
+* With this module, the *price_unit* field of purchase order line stores the
+  gross price instead of the net price, which is a change in the meaning of
+  this field. So this module breaks all the other modules that use the
+  *price_unit* field with it's native meaning.
+* Inheritability can't be respected when you have taxes rounding method =
+  globally.
 
 Bug Tracker
 ===========

--- a/purchase_discount/tests/test_purchase_discount.py
+++ b/purchase_discount/tests/test_purchase_discount.py
@@ -11,6 +11,8 @@ class TestPurchaseOrder(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super(TestPurchaseOrder, cls).setUpClass()
+        cls.company = cls.env.user.company_id
+        cls.company.tax_calculation_rounding_method = 'round_per_line'
         cls.product_1 = cls.env['product.product'].create({
             'name': 'Test product 1',
         })
@@ -87,3 +89,10 @@ class TestPurchaseOrder(common.SavepointCase):
         ])
         self.assertEqual(rec.price_total, 5)
         self.assertEqual(rec.discount, 50)
+
+
+class TestPurchaseOrderRoundGlobally(TestPurchaseOrder):
+    @classmethod
+    def setUpClass(cls):
+        super(TestPurchaseOrderRoundGlobally, cls).setUpClass()
+        cls.company.tax_calculation_rounding_method = 'round_globally'


### PR DESCRIPTION
In the case that taxes rounding is set to globally, Odoo requires again the line price unit, and currently ORM mixes values, so the only way to get a proper value is to overwrite that part, losing inheritability.

cc @Tecnativa