### PR TITLE
[9.0][FIX-MIG][product_by_supplier] Fix Migration

### DIFF
--- a/product_by_supplier/README.rst
+++ b/product_by_supplier/README.rst
@@ -38,6 +38,7 @@ Contributors
 * LIN Yu <lin.yu@elico-corp.com>
 * Yannick Gouin <yannick.gouin@elico-corp.com>
 * Denis Leemann <denis.leemann@camptocamp.com>
+* Iván Todorovich <ivan.todorovich@gmail.com>
 
 Maintainer
 ----------

--- a/product_by_supplier/__openerp__.py
+++ b/product_by_supplier/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     'name': 'Product by supplier info',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.1.0',
     'category': 'purchase',
     'summary': 'Show products grouped by suppliers',
     'author': "Elico Corp, "

--- a/product_by_supplier/views/product_supplierinfo_view.xml
+++ b/product_by_supplier/views/product_supplierinfo_view.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-        <record id="product_template_form_view" model="ir.ui.view">
-            <field name="name">product.template.common.form</field>
-            <field name="model">product.template</field>
-            <field name="inherit_id" ref="product.product_template_form_view"/>
-            <field name="arch" type="xml">
-                <field name="seller_ids" position="attributes">
-                    <attribute name="context">{'from_product_form':True}</attribute>
-                </field>
-            </field>
-        </record>
 
         <record id="view_product_supplierinfo_search" model="ir.ui.view">
             <field name="name">product.supplierinfo.search</field>
@@ -56,11 +46,10 @@
             <field name="inherit_id" ref="product.product_supplierinfo_form_view"/>
             <field name="priority">99</field>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='product_name']" position="before">
-                    <field name="product_tmpl_id" string="Product"
-                    invisible="context.get('from_product_form')"
-                    required="not context.get('from_product_form')"/>
-                </xpath>
+                <field name="product_tmpl_id" position="replace"/>
+                <field name="product_id" position="before">
+                    <field name="product_tmpl_id" required="True" invisible="context.get('default_product_tmpl_id')"/>
+                </field>
             </field>
         </record>
 

--- a/product_by_supplier/views/product_supplierinfo_view.xml
+++ b/product_by_supplier/views/product_supplierinfo_view.xml
@@ -7,9 +7,9 @@
             <field name="arch" type="xml">
                 <search string="Product by Suppliers">
                     <field name="name" string="Supplier"/>
+                    <field name="product_tmpl_id" />
                     <field name="product_code" string="Supplier Product Code"/>
                     <field name="product_name" string="Supplier Product Name"/>
-                    <field name="product_tmpl_id" />
                     <group expand='1' string='Group by...'>
                        <filter string='Product Code' name='supplier_code' icon="terp-stock_symbol-selection"
                             domain="[]" context="{'group_by' : 'product_code'}" />
@@ -29,13 +29,15 @@
             <field name="arch" type="xml">
                 <tree string="Supplier Information" editable="top">
                     <field name="sequence" widget="handle"/>
+                    <field name="name" string="Supplier"/>
+                    <field name="product_tmpl_id" string="Product"/>
                     <field name="product_code" string="Supplier Product Code"/>
                     <field name="product_name" string="Supplier Product Name"/>
-                    <field name="product_tmpl_id" string="Product"/>
-                    <field name="name"/>
                     <field name="delay"/>
                     <field name="min_qty"/>
+                    <field name="price"/>
                     <field name="company_id" groups="base.group_multi_company" widget="selection"/>
+                    <field name="write_date" readonly="1"/>
                 </tree>
             </field>
         </record>
@@ -44,11 +46,12 @@
             <field name="name">product.supplierinfo.form1</field>
             <field name="model">product.supplierinfo</field>
             <field name="inherit_id" ref="product.product_supplierinfo_form_view"/>
+            <field name="mode">primary</field>
             <field name="priority">99</field>
             <field name="arch" type="xml">
                 <field name="product_tmpl_id" position="replace"/>
                 <field name="product_id" position="before">
-                    <field name="product_tmpl_id" required="True" invisible="context.get('default_product_tmpl_id')"/>
+                    <field name="product_tmpl_id" required="True"/>
                 </field>
             </field>
         </record>
@@ -59,9 +62,22 @@
             <field name="type">ir.actions.act_window</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
-            <field name="view_id" ref="view_product_supplierinfo_tree1"/>
-            <field name="search_view_id" ref="view_product_supplierinfo_search"/>
-            <field name="context">{'search_default_supplier':1,'group_by':[]}</field>
+            <field name="context">{'search_default_supplier': True}</field>
+        </record>
+
+        <!-- Custom views for action. Have to do it this way because we need to define both custom tree and form views -->
+        <record id="action_product_supplier_info_tree" model="ir.actions.act_window.view" >
+            <field name="sequence" eval="1" />
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="view_product_supplierinfo_tree1" />
+            <field name="act_window_id" ref="action_product_supplier_info" />
+        </record>
+
+        <record id="action_product_supplier_info_form" model="ir.actions.act_window.view" >
+            <field name="sequence" eval="3" />
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="view_product_supplierinfo_form1" />
+            <field name="act_window_id" ref="action_product_supplier_info" />
         </record>
 
         <menuitem


### PR DESCRIPTION
This PR fixes some issues on 9.0:
- It was not possible to add supplier info from product form, because this module override the `default_product_tmpl_id` context (maybe in 8.0 odoo handled this differently)
- `product_tmpl_id` field was buggy on `supplierinfo.form`, because it was defining it when it was already there.

I suspect that this module had never been properly migrated from 8.0. It just had it's version changed.

---

ping @jjscarafia  