### PR TITLE
8.0 backport purchase triple discount

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -4,3 +4,4 @@ server-tools
 stock-logistics-workflow
 sale-workflow
 product-variant
+account-invoicing

--- a/purchase_supplier_rounding_method/tests/test_purchase_supplier_rounding_method.py
+++ b/purchase_supplier_rounding_method/tests/test_purchase_supplier_rounding_method.py
@@ -10,10 +10,23 @@ class TestPurchaseSupplierRoundingMethod(common.TransactionCase):
 
     def setUp(self):
         super(TestPurchaseSupplierRoundingMethod, self).setUp()
+        self.module_obj = self.env['ir.module.module']
 
     def test_1_account_invoice_rounding_method(self):
         """Test 'Normal' and 'Round Net Price' supplier rounding method
-        on a Suupplier Invoice"""
+        on a Supplier Invoice"""
+        # Because of incompatibility between this module and the
+        # module account_invoice_triple_discount, this test is realized
+        # only if the other module is not installed.
+        # This test is called after, in the glue module
+        # purchase_supplier_rounding_method_triple_discount
+        # that fixes the incompatibility
+        if not self.module_obj.search([
+                ('name', '=', 'account_invoice_triple_discount'),
+                ('state', '=', 'installed')]):
+            self._test_1_account_invoice_rounding_method()
+
+    def _test_1_account_invoice_rounding_method(self):
         # Set a Net price to 0.6667
         line = self.browse_ref(
             'purchase_supplier_rounding_method.invoice_1_line_a')

--- a/purchase_supplier_rounding_method_triple_discount/README.rst
+++ b/purchase_supplier_rounding_method_triple_discount/README.rst
@@ -1,0 +1,52 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================================================
+Purchase Supplier Rounding Method - Triple Discount
+===================================================
+
+This module is a glue module to make compatible the modules
+```purchase_supplier_rounding_method``` and
+```account_invoice_triple_discount``` and is automatically installed if both
+modules are installed.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Known issues / Roadmap
+======================
+
+* For inheritance reasons, the following function will be overwritten,
+  removing the call of super.
+
+1. ```purchase.order.line```: ```_calc_line_base_price()```
+2. ```account.nvoice.line```: ```_compute_price()```
+
+Credits
+=======
+
+Contributors
+------------
+
+* Sylvain LE GAL <https://twitter.com/legalsylvain>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_supplier_rounding_method_triple_discount/__init__.py
+++ b/purchase_supplier_rounding_method_triple_discount/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/purchase_supplier_rounding_method_triple_discount/__openerp__.py
+++ b/purchase_supplier_rounding_method_triple_discount/__openerp__.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+# Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Supplier Rounding Method - Triple Discount - Glue Module',
+    'version': '8.0.1.0.0',
+    'category': 'Purchase Management',
+    'author': 'GRAP,Odoo Community Association (OCA)',
+    'website': 'http://www.grap.coop',
+    'license': 'AGPL-3',
+    'depends': [
+        'purchase_supplier_rounding_method',
+        'account_invoice_triple_discount',
+    ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/purchase_supplier_rounding_method_triple_discount/models/__init__.py
+++ b/purchase_supplier_rounding_method_triple_discount/models/__init__.py
@@ -1,0 +1,3 @@
+# coding: utf-8
+from . import account_invoice_line
+from . import purchase_order_line

--- a/purchase_supplier_rounding_method_triple_discount/models/account_invoice_line.py
+++ b/purchase_supplier_rounding_method_triple_discount/models/account_invoice_line.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+from openerp import api, models
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = 'account.invoice.line'
+
+    @api.one
+    def _compute_price(self):
+        invoice = self.invoice_id
+        price = self.price_unit *\
+            (1 - (self.discount or 0.0) / 100.0) *\
+            (1 - (self.discount2 or 0.0) / 100.0) *\
+            (1 - (self.discount3 or 0.0) / 100.0)
+
+        if invoice and invoice.type in ['in_invoice', 'in_refund'] and\
+                invoice.partner_id.supplier_rounding_method\
+                == 'round_net_price':
+            price = round(
+                self.price_unit * (1 - (self.discount or 0.0) / 100.0),
+                self.env['decimal.precision'].precision_get('Account'))
+
+        taxes = self.invoice_line_tax_id.compute_all(
+            price, self.quantity, product=self.product_id,
+            partner=self.invoice_id.partner_id)
+        self.price_subtotal = taxes['total']
+        if invoice:
+            self.price_subtotal = invoice.currency_id.round(
+                self.price_subtotal)

--- a/purchase_supplier_rounding_method_triple_discount/models/purchase_order_line.py
+++ b/purchase_supplier_rounding_method_triple_discount/models/purchase_order_line.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    @api.model
+    def _calc_line_base_price(self, line):
+        """Overwrite Section to avoid bug in the order of inheritance
+            of this function.
+        """
+        res = line.price_unit *\
+            (1 - line.discount / 100.0) *\
+            (1 - line.discount2 / 100.0) *\
+            (1 - line.discount3 / 100.0)
+        if line.partner_id.supplier_rounding_method == 'round_net_price':
+            res = round(
+                res, self.env['decimal.precision'].precision_get('Account'))
+        return res

--- a/purchase_supplier_rounding_method_triple_discount/tests/__init__.py
+++ b/purchase_supplier_rounding_method_triple_discount/tests/__init__.py
@@ -1,0 +1,3 @@
+# coding: utf-8
+
+from . import test_module

--- a/purchase_supplier_rounding_method_triple_discount/tests/test_module.py
+++ b/purchase_supplier_rounding_method_triple_discount/tests/test_module.py
@@ -1,0 +1,22 @@
+# coding: utf-8
+# Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.addons.purchase_supplier_rounding_method.tests.\
+    test_purchase_supplier_rounding_method import\
+    TestPurchaseSupplierRoundingMethod as TestRoundingMethod
+
+
+class TestModule(TestRoundingMethod):
+
+    def setUp(self):
+        super(TestModule, self).setUp()
+
+    def test_1_account_invoice_rounding_method(self):
+        """Test 'Normal' and 'Round Net Price' supplier rounding method
+        on a Supplier Invoice"""
+        self._test_1_account_invoice_rounding_method()
+
+    def test_2_purchase_order_rounding_method(self):
+        super(TestModule, self).test_2_purchase_order_rounding_method()

--- a/purchase_triple_discount/README.rst
+++ b/purchase_triple_discount/README.rst
@@ -42,6 +42,11 @@ Bugs are tracked on `GitHub Issues
 check there if your issue has already been reported. If you spotted it first,
 help us smash it by providing detailed and welcomed feedback.
 
+Known issues / Roadmap
+======================
+
+* Include second and third discount in purchase order report.
+
 Credits
 =======
 

--- a/purchase_triple_discount/README.rst
+++ b/purchase_triple_discount/README.rst
@@ -1,0 +1,71 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+========================
+Purchase Triple Discount
+========================
+
+This module allows to have three successive discounts on every purchase order
+line.
+
+Usage
+=====
+
+Create a new purchase order and add discounts in any of the three discount
+fields given. They go in order of precedence so discount 2 will be calculated
+over discount 1 and discount 3 over the result of discount 2. For example,
+let's divide by two on every discount:
+
+Unit price: 600.00 ->
+
+  - Disc. 1 = 50% -> Amount = 300.00
+  - Disc. 2 = 50% -> Amount = 150.00
+  - Disc. 3 = 50% -> Amount = 75.00
+
+You can also use negative values to charge instead of discount:
+
+Unit price: 600.00 ->
+
+  - Disc. 1 = 50% -> Amount = 300.00
+  - Disc. 2 = -5% -> Amount = 315.00
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* David Vidal <david.vidal@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_triple_discount/__init__.py
+++ b/purchase_triple_discount/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/purchase_triple_discount/__manifest__.py
+++ b/purchase_triple_discount/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Account Invoice Triple Discount',
+    'version': '10.0.1.0.0',
+    'category': 'Purchase Management',
+    'author': 'Tecnativa, '
+              'Odoo Community Association (OCA)',
+    'website': 'https://tecnativa.com',
+    'license': 'AGPL-3',
+    'summary': 'Manage triple discount on purchase order lines',
+    'depends': [
+        'purchase_discount',
+        'account_invoice_triple_discount',
+    ],
+    'data': [
+        'views/purchase_view.xml',
+    ],
+    'installable': True,
+}

--- a/purchase_triple_discount/__manifest__.py
+++ b/purchase_triple_discount/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Account Invoice Triple Discount',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Purchase Management',
     'author': 'Tecnativa, '
               'Odoo Community Association (OCA)',

--- a/purchase_triple_discount/__openerp__.py
+++ b/purchase_triple_discount/__openerp__.py
@@ -2,10 +2,11 @@
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
-    'name': 'Account Invoice Triple Discount',
-    'version': '10.0.1.1.0',
+    'name': 'Purchase Order Triple Discount',
+    'version': '8.0.1.0.0',
     'category': 'Purchase Management',
     'author': 'Tecnativa, '
+              'GRAP, '
               'Odoo Community Association (OCA)',
     'website': 'https://tecnativa.com',
     'license': 'AGPL-3',
@@ -16,6 +17,9 @@
     ],
     'data': [
         'views/purchase_view.xml',
+    ],
+    'demo': [
+        'demo/purchase_order.xml',
     ],
     'installable': True,
 }

--- a/purchase_triple_discount/demo/purchase_order.xml
+++ b/purchase_triple_discount/demo/purchase_order.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<openerp><data>
+
+    <record id="order" model="purchase.order">
+        <field name="name">Purchase Order</field>
+        <field name="partner_id" ref="base.res_partner_1"/>
+        <field name="location_id" ref="stock.stock_location_stock"/>
+        <field name="pricelist_id" ref="purchase.list0"/>
+    </record>
+
+    <record id="order_line1" model="purchase.order.line">
+        <field name="name">Line 1</field>
+        <field name="order_id" ref="order"/>
+        <field name="product_qty">1.0</field>
+        <field name="product_id" ref="product.product_product_7"/>
+        <field name="product_uom" ref="product.product_uom_unit"/>
+        <field name="taxes_id" eval="[(6, 0, [ref('account_invoice_triple_discount.tax')])]"/>
+        <field name="price_unit">600</field>
+        <field name="date_planned">2018-01-19</field>
+    </record>
+
+    <record id="order_line2" model="purchase.order.line">
+        <field name="name">Line 2</field>
+        <field name="order_id" ref="order"/>
+        <field name="product_qty">10.0</field>
+        <field name="product_id" ref="product.product_product_28"/>
+        <field name="product_uom" ref="product.product_uom_unit"/>
+        <field name="taxes_id" eval="[(6, 0, [ref('account_invoice_triple_discount.tax')])]"/>
+        <field name="price_unit">60</field>
+        <field name="date_planned">2018-01-19</field>
+    </record>
+
+</data></openerp>

--- a/purchase_triple_discount/i18n/de.po
+++ b/purchase_triple_discount/i18n/de.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Bestellposition"

--- a/purchase_triple_discount/i18n/es.po
+++ b/purchase_triple_discount/i18n/es.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Línea orden de compra"

--- a/purchase_triple_discount/i18n/es_MX.po
+++ b/purchase_triple_discount/i18n/es_MX.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/es_MX/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_MX\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Línea de orden de compra"

--- a/purchase_triple_discount/i18n/es_PE.po
+++ b/purchase_triple_discount/i18n/es_PE.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# Henry Garcia <henry@yaroslab.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: Henry Garcia <henry@yaroslab.com>, 2017\n"
+"Language-Team: Spanish (Peru) (https://www.transifex.com/oca/teams/23907/es_PE/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_PE\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Linea de orden de compra"

--- a/purchase_triple_discount/i18n/fi.po
+++ b/purchase_triple_discount/i18n/fi.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fi\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Ostotilausrivi"

--- a/purchase_triple_discount/i18n/fr.po
+++ b/purchase_triple_discount/i18n/fr.po
@@ -1,0 +1,50 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Quentin THEURET <odoo@kerpeo.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-25 08:26+0000\n"
+"PO-Revision-Date: 2017-11-25 08:26+0000\n"
+"Last-Translator: Quentin THEURET <odoo@kerpeo.com>, 2017\n"
+"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr "Rem. 2 (%)"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr "Rem. 3 (%)"
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr "La remise 2 doit être inférieure à 100%."
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr "La remise 3 doit être inférieure à 100%."
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr "Facture"
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Ligne de commande d'achat"

--- a/purchase_triple_discount/i18n/fr.po
+++ b/purchase_triple_discount/i18n/fr.po
@@ -7,25 +7,24 @@
 # Quentin THEURET <odoo@kerpeo.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-25 08:26+0000\n"
-"PO-Revision-Date: 2017-11-25 08:26+0000\n"
-"Last-Translator: Quentin THEURET <odoo@kerpeo.com>, 2017\n"
-"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"POT-Creation-Date: 2018-03-02 20:55+0000\n"
+"PO-Revision-Date: 2018-03-02 20:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: purchase_triple_discount
-#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+#: field:purchase.order.line,discount2:0
 msgid "Disc. 2 (%)"
 msgstr "Rem. 2 (%)"
 
 #. module: purchase_triple_discount
-#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+#: field:purchase.order.line,discount3:0
 msgid "Disc. 3 (%)"
 msgstr "Rem. 3 (%)"
 
@@ -45,6 +44,17 @@ msgid "Invoice"
 msgstr "Facture"
 
 #. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order
+msgid "Purchase Order"
+msgstr "Bon de commande"
+
+#. module: purchase_triple_discount
 #: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
 msgid "Purchase Order Line"
 msgstr "Ligne de commande d'achat"
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_stock_move
+msgid "Stock Move"
+msgstr "Mouvement de stock"
+

--- a/purchase_triple_discount/i18n/hr.po
+++ b/purchase_triple_discount/i18n/hr.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# Bole <bole@dajmi5.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-03-03 03:48+0000\n"
+"PO-Revision-Date: 2018-03-03 03:48+0000\n"
+"Last-Translator: Bole <bole@dajmi5.com>, 2017\n"
+"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr "Pop. 2 (%)"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr "Pop. 3(%)"
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr "Popust 2 mora biti manje od 100%."
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr "Popust 3 mora biti manje od 100%."
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr "Račun"
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Stavka naloga za nabavu"

--- a/purchase_triple_discount/i18n/it.po
+++ b/purchase_triple_discount/i18n/it.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Riga Ordine d'Acquisto"

--- a/purchase_triple_discount/i18n/nl_NL.po
+++ b/purchase_triple_discount/i18n/nl_NL.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# Peter Hageman <hageman.p@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: Peter Hageman <hageman.p@gmail.com>, 2017\n"
+"Language-Team: Dutch (Netherlands) (https://www.transifex.com/oca/teams/23907/nl_NL/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl_NL\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr "Factuur"
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Inkooporderregel"

--- a/purchase_triple_discount/i18n/pt_BR.po
+++ b/purchase_triple_discount/i18n/pt_BR.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/23907/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Linha da Ordem de Compra"

--- a/purchase_triple_discount/i18n/pt_PT.po
+++ b/purchase_triple_discount/i18n/pt_PT.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Portuguese (Portugal) (https://www.transifex.com/oca/teams/23907/pt_PT/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_PT\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Linha de Encomenda de Compra"

--- a/purchase_triple_discount/i18n/ro.po
+++ b/purchase_triple_discount/i18n/ro.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Romanian (https://www.transifex.com/oca/teams/23907/ro/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Linie comandă achiziție"

--- a/purchase_triple_discount/i18n/sl.po
+++ b/purchase_triple_discount/i18n/sl.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * purchase_triple_discount
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-11-24 07:53+0000\n"
+"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount2
+msgid "Disc. 2 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model.fields,field_description:purchase_triple_discount.field_purchase_order_line_discount3
+msgid "Disc. 3 (%)"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 2 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: sql_constraint:purchase.order.line:0
+msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model:ir.model,name:purchase_triple_discount.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Postavka nabavnega naloga"

--- a/purchase_triple_discount/models/__init__.py
+++ b/purchase_triple_discount/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import account_invoice
+from . import purchase_order

--- a/purchase_triple_discount/models/__init__.py
+++ b/purchase_triple_discount/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import account_invoice
 from . import purchase_order
+from . import stock_move

--- a/purchase_triple_discount/models/account_invoice.py
+++ b/purchase_triple_discount/models/account_invoice.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    def _prepare_invoice_line_from_po_line(self, line):
+        vals = super(AccountInvoice,
+                     self)._prepare_invoice_line_from_po_line(line)
+        vals['discount2'] = line.discount2
+        vals['discount3'] = line.discount3
+        return vals

--- a/purchase_triple_discount/models/account_invoice.py
+++ b/purchase_triple_discount/models/account_invoice.py
@@ -2,7 +2,7 @@
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from openerp import models
 
 
 class AccountInvoice(models.Model):

--- a/purchase_triple_discount/models/purchase_order.py
+++ b/purchase_triple_discount/models/purchase_order.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+from odoo.addons import decimal_precision as dp
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    @api.depends('discount2', 'discount3')
+    def _compute_amount(self):
+        super(PurchaseOrderLine, self)._compute_amount()
+
+    discount2 = fields.Float(
+        'Disc. 2 (%)',
+        digits=dp.get_precision('Discount'),
+        default=0.0,
+    )
+
+    discount3 = fields.Float(
+        'Disc. 3 (%)',
+        digits=dp.get_precision('Discount'),
+        default=0.0,
+    )
+
+    _sql_constraints = [
+        ('discount2_limit', 'CHECK (discount2 <= 100.0)',
+         'Discount 2 must be lower than 100%.'),
+        ('discount3_limit', 'CHECK (discount3 <= 100.0)',
+         'Discount 3 must be lower than 100%.'),
+    ]
+
+    def _get_discounted_price_unit(self):
+        price_unit = super(
+            PurchaseOrderLine, self)._get_discounted_price_unit()
+        if self.discount2:
+            price_unit *= (1 - self.discount2 / 100.0)
+        if self.discount3:
+            price_unit *= (1 - self.discount3 / 100.0)
+        return price_unit

--- a/purchase_triple_discount/models/purchase_order.py
+++ b/purchase_triple_discount/models/purchase_order.py
@@ -2,12 +2,18 @@
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
-from odoo.addons import decimal_precision as dp
+from openerp import api, fields, models
+from openerp.addons import decimal_precision as dp
 
 
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
+
+    @api.model
+    def _calc_line_base_price(self, line):
+        res = super(PurchaseOrderLine, self)._calc_line_base_price(line)
+        return res * (1 - line.discount2 / 100.0) *\
+            (1 - line.discount3 / 100.0)
 
     @api.depends('discount2', 'discount3')
     def _compute_amount(self):
@@ -32,11 +38,35 @@ class PurchaseOrderLine(models.Model):
          'Discount 3 must be lower than 100%.'),
     ]
 
-    def _get_discounted_price_unit(self):
-        price_unit = super(
-            PurchaseOrderLine, self)._get_discounted_price_unit()
-        if self.discount2:
-            price_unit *= (1 - self.discount2 / 100.0)
-        if self.discount3:
-            price_unit *= (1 - self.discount3 / 100.0)
-        return price_unit
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    @api.model
+    def _prepare_inv_line(self, account_id, line):
+        res = super(PurchaseOrder, self)._prepare_inv_line(account_id, line)
+        res.update({
+            'discount2': line.discount2,
+            'discount3': line.discount3,
+        })
+        return res
+
+    @api.model
+    def _prepare_order_line_move(
+            self, order, order_line, picking_id, group_id):
+        res = super(PurchaseOrder, self)._prepare_order_line_move(
+            order, order_line, picking_id, group_id)
+        for vals in res:
+            vals['price_unit'] = (vals.get('price_unit', 0.0) *
+                                  (1 - (order_line.discount2 / 100)) *
+                                  (1 - (order_line.discount3 / 100)))
+        return res
+
+#    def _get_discounted_price_unit(self):
+#        price_unit = super(
+#            PurchaseOrderLine, self)._get_discounted_price_unit()
+#        if self.discount2:
+#            price_unit *= (1 - self.discount2 / 100.0)
+#        if self.discount3:
+#            price_unit *= (1 - self.discount3 / 100.0)
+#        return price_unit

--- a/purchase_triple_discount/models/stock_move.py
+++ b/purchase_triple_discount/models/stock_move.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+# Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    @api.model
+    def _get_invoice_line_vals(self, move, partner, inv_type):
+        res = super(StockMove, self)._get_invoice_line_vals(
+            move, partner, inv_type)
+        order_line = False
+        if move.purchase_line_id:
+            order_line = move.purchase_line_id
+        elif move.origin_returned_move_id.purchase_line_id:
+            order_line = move.origin_returned_move_id.purchase_line_id
+        if order_line:
+            res.update({
+                'discount2': order_line.discount2,
+                'discount3': order_line.discount3,
+            })
+        return res

--- a/purchase_triple_discount/tests/__init__.py
+++ b/purchase_triple_discount/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_purchase_discount

--- a/purchase_triple_discount/tests/test_purchase_discount.py
+++ b/purchase_triple_discount/tests/test_purchase_discount.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestPurchaseOrder(common.SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestPurchaseOrder, cls).setUpClass()
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'Mr. Odoo',
+        })
+        cls.product1 = cls.env['product.product'].create({
+            'name': 'Test Product 1',
+            'purchase_method': 'purchase',
+        })
+        cls.product2 = cls.env['product.product'].create({
+            'name': 'Test Product 2',
+            'purchase_method': 'purchase',
+        })
+        cls.tax = cls.env['account.tax'].create({
+            'name': 'TAX 15%',
+            'amount_type': 'percent',
+            'type_tax_use': 'purchase',
+            'amount': 15.0,
+        })
+        cls.order = cls.env['purchase.order'].create({
+            'partner_id': cls.partner.id
+        })
+        po_line = cls.env['purchase.order.line']
+        cls.po_line1 = po_line.create({
+            'order_id': cls.order.id,
+            'product_id': cls.product1.id,
+            'date_planned': '2018-01-19 00:00:00',
+            'name': 'Line 1',
+            'product_qty': 1.0,
+            'product_uom': cls.product1.uom_id.id,
+            'taxes_id': [(6, 0, [cls.tax.id])],
+            'price_unit': 600.0,
+        })
+        cls.po_line2 = po_line.create({
+            'order_id': cls.order.id,
+            'product_id': cls.product2.id,
+            'date_planned': '2018-01-19 00:00:00',
+            'name': 'Line 2',
+            'product_qty': 10.0,
+            'product_uom': cls.product2.uom_id.id,
+            'taxes_id': [(6, 0, [cls.tax.id])],
+            'price_unit': 60.0,
+        })
+
+    def test_01_purchase_order_classic_discount(self):
+        """ Tests with single discount """
+        self.po_line1.discount = 50.0
+        self.po_line2.discount = 75.0
+        self.assertEqual(self.po_line1.price_subtotal, 300.0)
+        self.assertEqual(self.po_line2.price_subtotal, 150.0)
+        self.assertEqual(self.order.amount_untaxed, 450.0)
+        self.assertEqual(self.order.amount_tax, 67.5)
+        # Mix taxed and untaxed:
+        self.po_line1.taxes_id = False
+        self.assertEqual(self.order.amount_tax, 22.5)
+
+    def test_02_purchase_order_simple_triple_discount(self):
+        """ Tests on a single line """
+        self.po_line2.unlink()
+        # Divide by two on every discount:
+        self.po_line1.discount = 50.0
+        self.po_line1.discount2 = 50.0
+        self.po_line1.discount3 = 50.0
+        self.assertEqual(self.po_line1.price_subtotal, 75.0)
+        self.assertEqual(self.order.amount_untaxed, 75.0)
+        self.assertEqual(self.order.amount_tax, 11.25)
+        # Unset first discount:
+        self.po_line1.discount = 0.0
+        self.assertEqual(self.po_line1.price_subtotal, 150.0)
+        self.assertEqual(self.order.amount_untaxed, 150.0)
+        self.assertEqual(self.order.amount_tax, 22.5)
+        # Set a charge instead:
+        self.po_line1.discount2 = -50.0
+        self.assertEqual(self.po_line1.price_subtotal, 450.0)
+        self.assertEqual(self.order.amount_untaxed, 450.0)
+        self.assertEqual(self.order.amount_tax, 67.5)
+
+    def test_03_purchase_order_complex_triple_discount(self):
+        """ Tests on multiple lines """
+        self.po_line1.discount = 50.0
+        self.po_line1.discount2 = 50.0
+        self.po_line1.discount3 = 50.0
+        self.assertEqual(self.po_line1.price_subtotal, 75.0)
+        self.assertEqual(self.order.amount_untaxed, 675.0)
+        self.assertEqual(self.order.amount_tax, 101.25)
+        self.po_line2.discount3 = 50.0
+        self.assertEqual(self.po_line2.price_subtotal, 300.0)
+        self.assertEqual(self.order.amount_untaxed, 375.0)
+        self.assertEqual(self.order.amount_tax, 56.25)
+
+    def test_04_purchase_order_triple_discount_invoicing(self):
+        """ When a confirmed order is invoiced, the resultant invoice
+            should inherit the discounts """
+        self.po_line1.discount = 50.0
+        self.po_line1.discount2 = 50.0
+        self.po_line1.discount3 = 50.0
+        self.po_line2.discount3 = 50.0
+        self.order.button_confirm()
+        self.invoice = self.env['account.invoice'].create({
+            'partner_id': self.partner.id,
+            'purchase_id': self.order.id,
+            'account_id': self.partner.property_account_payable_id.id,
+            'type': 'in_invoice',
+        })
+        self.invoice.purchase_order_change()
+        self.invoice._onchange_invoice_line_ids()
+        self.assertEqual(self.po_line1.discount,
+                         self.invoice.invoice_line_ids[0].discount)
+        self.assertEqual(self.po_line1.discount2,
+                         self.invoice.invoice_line_ids[0].discount2)
+        self.assertEqual(self.po_line1.discount3,
+                         self.invoice.invoice_line_ids[0].discount3)
+        self.assertEqual(self.po_line2.discount3,
+                         self.invoice.invoice_line_ids[1].discount3)
+        self.assertEqual(self.order.amount_total, self.invoice.amount_total)

--- a/purchase_triple_discount/tests/test_purchase_discount.py
+++ b/purchase_triple_discount/tests/test_purchase_discount.py
@@ -2,55 +2,19 @@
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import common
+from openerp.tests import common
 
 
 class TestPurchaseOrder(common.SavepointCase):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestPurchaseOrder, cls).setUpClass()
-        cls.partner = cls.env['res.partner'].create({
-            'name': 'Mr. Odoo',
-        })
-        cls.product1 = cls.env['product.product'].create({
-            'name': 'Test Product 1',
-            'purchase_method': 'purchase',
-        })
-        cls.product2 = cls.env['product.product'].create({
-            'name': 'Test Product 2',
-            'purchase_method': 'purchase',
-        })
-        cls.tax = cls.env['account.tax'].create({
-            'name': 'TAX 15%',
-            'amount_type': 'percent',
-            'type_tax_use': 'purchase',
-            'amount': 15.0,
-        })
-        cls.order = cls.env['purchase.order'].create({
-            'partner_id': cls.partner.id
-        })
-        po_line = cls.env['purchase.order.line']
-        cls.po_line1 = po_line.create({
-            'order_id': cls.order.id,
-            'product_id': cls.product1.id,
-            'date_planned': '2018-01-19 00:00:00',
-            'name': 'Line 1',
-            'product_qty': 1.0,
-            'product_uom': cls.product1.uom_id.id,
-            'taxes_id': [(6, 0, [cls.tax.id])],
-            'price_unit': 600.0,
-        })
-        cls.po_line2 = po_line.create({
-            'order_id': cls.order.id,
-            'product_id': cls.product2.id,
-            'date_planned': '2018-01-19 00:00:00',
-            'name': 'Line 2',
-            'product_qty': 10.0,
-            'product_uom': cls.product2.uom_id.id,
-            'taxes_id': [(6, 0, [cls.tax.id])],
-            'price_unit': 60.0,
-        })
+    def setUpClass(self):
+        super(TestPurchaseOrder, self).setUpClass()
+        self.partner = self.env.ref('base.res_partner_1')
+        self.receivable_account = self.env.ref('account.a_recv')
+        self.order = self.env.ref('purchase_triple_discount.order')
+        self.po_line1 = self.env.ref('purchase_triple_discount.order_line1')
+        self.po_line2 = self.env.ref('purchase_triple_discount.order_line2')
 
     def test_01_purchase_order_classic_discount(self):
         """ Tests with single discount """
@@ -101,25 +65,18 @@ class TestPurchaseOrder(common.SavepointCase):
     def test_04_purchase_order_triple_discount_invoicing(self):
         """ When a confirmed order is invoiced, the resultant invoice
             should inherit the discounts """
-        self.po_line1.discount = 50.0
-        self.po_line1.discount2 = 50.0
-        self.po_line1.discount3 = 50.0
-        self.po_line2.discount3 = 50.0
-        self.order.button_confirm()
-        self.invoice = self.env['account.invoice'].create({
-            'partner_id': self.partner.id,
-            'purchase_id': self.order.id,
-            'account_id': self.partner.property_account_payable_id.id,
-            'type': 'in_invoice',
-        })
-        self.invoice.purchase_order_change()
-        self.invoice._onchange_invoice_line_ids()
+        self.po_line1.discount = 10.0
+        self.po_line1.discount2 = 20.0
+        self.po_line1.discount3 = 30.0
+        self.po_line2.discount3 = 40.0
+        self.order.signal_workflow('purchase_confirm')
+        self.invoice = self.order.invoice_ids[0]
         self.assertEqual(self.po_line1.discount,
-                         self.invoice.invoice_line_ids[0].discount)
+                         self.invoice.invoice_line[0].discount)
         self.assertEqual(self.po_line1.discount2,
-                         self.invoice.invoice_line_ids[0].discount2)
+                         self.invoice.invoice_line[0].discount2)
         self.assertEqual(self.po_line1.discount3,
-                         self.invoice.invoice_line_ids[0].discount3)
+                         self.invoice.invoice_line[0].discount3)
         self.assertEqual(self.po_line2.discount3,
-                         self.invoice.invoice_line_ids[1].discount3)
+                         self.invoice.invoice_line[1].discount3)
         self.assertEqual(self.order.amount_total, self.invoice.amount_total)

--- a/purchase_triple_discount/views/purchase_view.xml
+++ b/purchase_triple_discount/views/purchase_view.xml
@@ -4,7 +4,7 @@
     <record id="purchase_order_triple_discount_form_view" model="ir.ui.view">
         <field name="name">purchase.order.triple.discount.form</field>
         <field name="model">purchase.order</field>
-        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="inherit_id" ref="purchase_discount.purchase_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='order_line']//tree//field[@name='discount']"
                    position="after">

--- a/purchase_triple_discount/views/purchase_view.xml
+++ b/purchase_triple_discount/views/purchase_view.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<openerp><data>
 
     <record id="purchase_order_triple_discount_form_view" model="ir.ui.view">
         <field name="name">purchase.order.triple.discount.form</field>
         <field name="model">purchase.order</field>
-        <field name="inherit_id" ref="purchase_discount.purchase_order_form" />
+        <field name="inherit_id" ref="purchase_discount.purchase_discount_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='order_line']//tree//field[@name='discount']"
-                   position="after">
-                <field name="discount2"/>
-                <field name="discount3"/>
-            </xpath>
-            <xpath expr="//field[@name='order_line']//form//field[@name='discount']"
                    position="after">
                 <field name="discount2"/>
                 <field name="discount3"/>
@@ -19,4 +14,4 @@
         </field>
     </record>
 
-</odoo>
+</data></openerp>

--- a/purchase_triple_discount/views/purchase_view.xml
+++ b/purchase_triple_discount/views/purchase_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="purchase_order_triple_discount_form_view" model="ir.ui.view">
+        <field name="name">purchase.order.triple.discount.form</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']//tree//field[@name='discount']"
+                   position="after">
+                <field name="discount2"/>
+                <field name="discount3"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//field[@name='discount']"
+                   position="after">
+                <field name="discount2"/>
+                <field name="discount3"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
backport of purchase_triple_discount from 10.0 to 8.0.

only the commit 5f44013 is to review.

~~Note : before merging, check if e2c3748 has been removed. (add temporary dependency to https://github.com/OCA/account-invoicing/pull/361)~~