### PR TITLE
[9.0][REF]purchase_request_to_rfq: use separate method to post cancel msg

### DIFF
--- a/purchase_request_to_rfq/__openerp__.py
+++ b/purchase_request_to_rfq/__openerp__.py
@@ -7,7 +7,7 @@
     "author": "Eficent, "
               "Acsone SA/NV,"
               "Odoo Community Association (OCA)",
-    "version": "9.0.1.0.1",
+    "version": "9.0.1.0.2",
     "summary": "This module adds the possibility to create or update Requests "
                "for Quotation (RFQ) from Purchase Request Lines.",
     "website": "http://www.eficent.com/",

--- a/purchase_request_to_rfq/models/purchase_order.py
+++ b/purchase_request_to_rfq/models/purchase_order.py
@@ -115,12 +115,8 @@ class PurchaseOrder(models.Model):
             # Post a msg in purchase requests:
             request_po_lines = order.order_line.filtered(
                 lambda pol: pol.purchase_request_lines)
-            for line in request_po_lines:
-                message = \
-                    line._po_line_purchase_request_cancel_message_content()
-                requests = line.purchase_request_lines.mapped('request_id')
-                for req in requests:
-                    req.message_post(body=message, subtype='mail.mt_comment')
+            self._post_po_line_purchase_request_cancel_message(
+                request_po_lines)
             # Search for lines not created from a Purchase request and end
             # the process
             # TODO: remove PO from procurement ?!
@@ -139,6 +135,15 @@ class PurchaseOrder(models.Model):
                 moves.filtered(
                     lambda r: r.state != 'cancel').action_cancel()
         self.write({'state': 'cancel'})
+
+    @api.model
+    def _post_po_line_purchase_request_cancel_message(self, request_po_lines):
+        for line in request_po_lines:
+            message = \
+                line._po_line_purchase_request_cancel_message_content()
+            requests = line.purchase_request_lines.mapped('request_id')
+            for req in requests:
+                req.message_post(body=message, subtype='mail.mt_comment')
 
 
 class PurchaseOrderLine(models.Model):


### PR DESCRIPTION

The `cancel_po_from_request` is very long method and doesn't have any
inheritance point to customize the requests on which the notification
will be post to. This PR aims to fix that issue by taking out the code
related to posting the message out from `cancel_po_from_request` and put
it in a new method `_post_po_line_purchase_request_cancel_message`. This
will give an inheritance point to that method for any customization
need.