### PR TITLE
[10.0] Allow copy analytic field from procurement on purchase request lines

### DIFF
--- a/purchase_request_procurement/models/procurement_order.py
+++ b/purchase_request_procurement/models/procurement_order.py
@@ -28,6 +28,7 @@ class ProcurementOrder(models.Model):
             'product_uom_id': product.uom_po_id.id,
             'product_qty': procurement_uom_po_qty,
             'request_id': self.request_id.id,
+            'analytic_account_id': self.account_analytic_id.id, 
             'procurement_id': self.id
         }
 


### PR DESCRIPTION
Add analytic field in the return to be copied from procurement