### PR TITLE
[FIX] Do not round the unit price after discount is applied

### DIFF
--- a/purchase_discount/__manifest__.py
+++ b/purchase_discount/__manifest__.py
@@ -10,7 +10,7 @@
               "Tecnativa, "
               "ACSONE SA/NV,"
               "Odoo Community Association (OCA)",
-    "version": "10.0.1.0.4",
+    "version": "10.0.1.0.5",
     "category": "Purchase Management",
     "depends": ["purchase"],
     "data": [


### PR DESCRIPTION
To prevent differences with the invoice that is created from the purchase,
the unit price must not be rounded after the discount is applied.

E.g. 195PCE of a 14.49 product against 7% discount should be computed as
round(195 * 14.49 * .93, prec), not as 195 * round(14.49 * .93, prec)