### PR TITLE
[FIX] purchase_landed_cost: error on deleting cost lines

### DIFF
--- a/purchase_landed_cost/__manifest__.py
+++ b/purchase_landed_cost/__manifest__.py
@@ -5,14 +5,14 @@
 
 {
     'name': 'Purchase landed costs - Alternative option',
-    'version': '10.0.1.0.0',
-    "author": "OdooMRP team,"
-              "AvanzOSC,"
-              "Tecnativa,"
-              "Joaquín Gutierrez,"
-              "Odoo Community Association (OCA)",
+    'version': '10.0.2.0.0',
+    "author": u"OdooMRP team,"
+              u"AvanzOSC,"
+              u"Tecnativa,"
+              u"Joaquín Gutierrez,"
+              u"Odoo Community Association (OCA)",
     'category': 'Purchase Management',
-    'website': 'http://www.odoomrp.com',
+    'website': 'https://github.com/OCA/purchase-workflow',
     'summary': 'Purchase cost distribution',
     'depends': [
         'stock',

--- a/purchase_landed_cost/i18n/purchase_landed_cost.pot
+++ b/purchase_landed_cost/i18n/purchase_landed_cost.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-10-23 16:33+0000\n"
+"PO-Revision-Date: 2018-10-23 16:33+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -156,7 +158,7 @@ msgid "Cost documentation"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:279
+#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:306
 #, python-format
 msgid "Cost update cannot be undone because there has been a later update. Restore correct price and try again."
 msgstr ""
@@ -481,7 +483,7 @@ msgid "New cost"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:186
+#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:198
 #, python-format
 msgid "No valid distribution type."
 msgstr ""
@@ -519,7 +521,7 @@ msgid "Pickings"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:207
+#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:219
 #, python-format
 msgid "Please enter an amount for all the expenses"
 msgstr ""
@@ -691,7 +693,7 @@ msgid "Technical field used to record the product cost set by the user during a 
 msgstr ""
 
 #. module: purchase_landed_cost
-#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:192
+#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:204
 #, python-format
 msgid "The cost for the line '%s' can't be distributed because the calculation method doesn't provide valid data"
 msgstr ""
@@ -717,7 +719,7 @@ msgid "The volume in m3."
 msgstr ""
 
 #. module: purchase_landed_cost
-#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:211
+#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:223
 #, python-format
 msgid "There is no picking lines in the distribution"
 msgstr ""
@@ -826,6 +828,12 @@ msgstr ""
 #: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:132
 #, python-format
 msgid "You can't delete a confirmed cost distribution"
+msgstr ""
+
+#. module: purchase_landed_cost
+#: code:addons/purchase_landed_cost/models/purchase_cost_distribution.py:150
+#, python-format
+msgid "You can't delete a cost line if it's an affected line of any expense line."
 msgstr ""
 
 #. module: purchase_landed_cost

--- a/purchase_landed_cost/models/purchase_cost_distribution.py
+++ b/purchase_landed_cost/models/purchase_cost_distribution.py
@@ -223,43 +223,50 @@ class PurchaseCostDistribution(models.Model):
             distribution.state = 'calculated'
         return True
 
-    def _product_price_update(self, move, new_price):
+    def _product_price_update(self, product, vals_list):
         """Method that mimicks stock.move's product_price_update_before_done
         method behaviour, but taking into account that calculations are made
-        on an already done move, and prices sources are given as parameters.
+        on an already done moves, and prices sources are given as parameters.
         """
-        if (move.location_id.usage == 'supplier' and
-                move.product_id.cost_method == 'average'):
-            product = move.product_id
-            qty_available = product.product_tmpl_id.qty_available
-            product_avail = qty_available - move.product_qty
-            if product_avail <= 0:
-                new_std_price = new_price
-            else:
-                domain_quant = [
-                    ('product_id', 'in',
-                     product.product_tmpl_id.product_variant_ids.ids),
-                    ('id', 'not in', move.quant_ids.ids),
-                    ('location_id.usage', '=', 'internal')]
-                quants = self.env['stock.quant'].search(domain_quant)
-                current_valuation = sum([(q.cost * q.qty) for q in quants])
-                # Get the standard price
-                new_std_price = (
-                    (current_valuation + new_price * move.product_qty) /
-                    qty_available)
-            # Write the standard price, as SUPERUSER_ID, because a
-            # warehouse manager may not have the right to write on products
-            product.sudo().write({'standard_price': new_std_price})
+        moves_total_qty = 0
+        moves_total_diff_price = 0
+        for move, price_diff in vals_list:
+            moves_total_qty += move.product_qty
+            moves_total_diff_price += move.product_qty * price_diff
+        prev_qty_available = product.qty_available - moves_total_qty
+        if prev_qty_available <= 0:
+            prev_qty_available = 0
+        total_available = prev_qty_available + moves_total_qty
+        new_std_price = (
+            (total_available * product.standard_price +
+             moves_total_diff_price) / total_available
+        )
+        # Write the standard price, as SUPERUSER_ID, because a
+        # warehouse manager may not have the right to write on products
+        product.sudo().write({'standard_price': new_std_price})
 
     @api.multi
     def action_done(self):
+        """Perform all moves that touch the same product in batch."""
         self.ensure_one()
+        if self.cost_update_type != 'direct':
+            return
+        d = {}
         for line in self.cost_lines:
-            if self.cost_update_type == 'direct':
-                line.move_id.quant_ids._price_update(line.standard_price_new)
-                self._product_price_update(
-                    line.move_id, line.standard_price_new)
-                line.move_id.product_price_update_after_done()
+            product = line.move_id.product_id
+            if (product.cost_method != 'average' or
+                    line.move_id.location_id.usage != 'supplier'):
+                continue
+            line.move_id.quant_ids._price_update(line.standard_price_new)
+            d.setdefault(product, [])
+            d[product].append(
+                (line.move_id,
+                 line.standard_price_new - line.standard_price_old),
+            )
+        for product, vals_list in d.items():
+            self._product_price_update(product, vals_list)
+            for vals in vals_list:
+                vals[0].product_price_update_after_done()
         self.state = 'done'
 
     @api.multi
@@ -269,21 +276,34 @@ class PurchaseCostDistribution(models.Model):
 
     @api.multi
     def action_cancel(self):
+        """Perform all moves that touch the same product in batch."""
         self.ensure_one()
-        for line in self.cost_lines:
-            if self.cost_update_type == 'direct':
-                if self.currency_id.compare_amounts(
-                        line.move_id.quant_ids[0].cost,
-                        line.standard_price_new) != 0:
-                    raise exceptions.UserError(
-                        _('Cost update cannot be undone because there has '
-                          'been a later update. Restore correct price and try '
-                          'again.'))
-                line.move_id.quant_ids._price_update(line.standard_price_old)
-                self._product_price_update(
-                    line.move_id, line.standard_price_old)
-                line.move_id.product_price_update_after_done()
         self.state = 'draft'
+        if self.cost_update_type != 'direct':
+            return
+        d = {}
+        for line in self.cost_lines:
+            product = line.move_id.product_id
+            if (product.cost_method != 'average' or
+                    line.move_id.location_id.usage != 'supplier'):
+                continue
+            if self.currency_id.compare_amounts(
+                    line.move_id.quant_ids[0].cost,
+                    line.standard_price_new) != 0:
+                raise exceptions.UserError(
+                    _('Cost update cannot be undone because there has '
+                      'been a later update. Restore correct price and try '
+                      'again.'))
+            line.move_id.quant_ids._price_update(line.standard_price_old)
+            d.setdefault(product, [])
+            d[product].append(
+                (line.move_id,
+                 line.standard_price_old - line.standard_price_new),
+            )
+        for product, vals_list in d.items():
+            self._product_price_update(product, vals_list)
+            for vals in vals_list:
+                vals[0].product_price_update_after_done()
 
 
 class PurchaseCostDistributionLine(models.Model):

--- a/purchase_landed_cost/tests/__init__.py
+++ b/purchase_landed_cost/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_purchase_landed_cost

--- a/purchase_landed_cost/tests/test_purchase_landed_cost.py
+++ b/purchase_landed_cost/tests/test_purchase_landed_cost.py
@@ -1,0 +1,143 @@
+# Copyright 2018 Tecnativa - Vicent Cubells
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.exceptions import UserError
+from odoo.tests import common
+
+
+class TestPurchaseLandedCost(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestPurchaseLandedCost, cls).setUpClass()
+        cls.type_amount = cls.env['purchase.expense.type'].create({
+            'name': 'Type Amount',
+            'calculation_method': 'amount',
+            'default_amount': True,
+        })
+        cls.type_price = cls.env['purchase.expense.type'].create({
+            'name': 'Type Price',
+            'calculation_method': 'price',
+        })
+        cls.type_qty = cls.env['purchase.expense.type'].create({
+            'name': 'Type Qty',
+            'calculation_method': 'qty',
+        })
+        cls.type_weight = cls.env['purchase.expense.type'].create({
+            'name': 'Type Weight',
+            'calculation_method': 'weight',
+        })
+        cls.type_volume = cls.env['purchase.expense.type'].create({
+            'name': 'Type Volume',
+            'calculation_method': 'volume',
+        })
+        cls.type_equal = cls.env['purchase.expense.type'].create({
+            'name': 'Type Equal',
+            'calculation_method': 'equal',
+        })
+        cls.distribution = cls.env['purchase.cost.distribution'].create({
+            'name': '/',
+        })
+        cls.product = cls.env['product.product'].create({
+            'name': 'Product',
+            'type': 'product',
+            'standard_price': 3.0,
+            'property_cost_method': 'average',
+        })
+        cls.service = cls.env['product.product'].create({
+            'name': 'Service',
+            'type': 'service',
+            'standard_price': 10.0,
+        })
+        categ_unit = cls.env.ref('product.product_uom_categ_unit')
+        cls.uom_unit = cls.env['product.uom'].create({
+            'name': 'Test-Unit',
+            'category_id': categ_unit.id,
+            'rounding': 1.0,
+        })
+        cls.supplier = cls.env['res.partner'].create({
+            'name': 'Supplier',
+            'supplier': True,
+        })
+        picking_type_in = cls.env.ref('stock.picking_type_in')
+        cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.picking = cls.env['stock.picking'].create({
+            'picking_type_id': picking_type_in.id,
+            'location_id': cls.supplier_location.id,
+            'location_dest_id': cls.stock_location.id,
+            'partner_id': cls.supplier.id,
+            'move_lines': [(0, 0, {
+                'product_id': cls.product.id,
+                'product_uom_qty': 5.0,
+                'name': cls.product.name,
+                'product_uom': cls.uom_unit.id,
+            })]
+        })
+        user_type = cls.env.ref('account.data_account_type_expenses')
+        account = cls.env['account.account'].create({
+            'name': 'Account',
+            'code': 'CODE',
+            'user_type_id': user_type.id,
+        })
+        cls.invoice = cls.env['account.invoice'].create({
+            'partner_id': cls.supplier.id,
+            'type': 'in_invoice',
+            'invoice_line_ids': [(0, 0, {
+                'product_id': cls.service.id,
+                'name': cls.service.name,
+                'account_id': account.id,
+                'price_unit': cls.service.standard_price,
+            })]
+        })
+
+    def test_distribution_without_lines(self):
+        self.assertNotEqual(self.distribution.name, '/')
+        with self.assertRaises(UserError):
+            self.distribution.action_calculate()
+        self.assertEqual(self.distribution.state, 'draft')
+
+    def test_distribution_import_shipment(self):
+        self.picking.action_confirm()
+        self.picking.action_assign()
+        self.env['stock.move.line'].create({
+            'product_id': self.product.id,
+            'qty_done': 5,
+            'product_uom_id': self.uom_unit.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'move_id': self.picking.move_lines[:1].id,
+        })
+        self.picking.action_done()
+        self.assertEqual(self.picking.state, 'done')
+        wiz = self.env['picking.import.wizard'].with_context(
+            active_id=self.distribution.id).create({
+                'supplier': self.supplier.id,
+                'pickings': [(6, 0, [self.picking.id])],
+            })
+        wiz.action_import_picking()
+        self.assertEqual(len(self.distribution.cost_lines.ids), 1)
+        self.assertAlmostEqual(self.distribution.total_uom_qty, 5.0)
+        self.assertAlmostEqual(self.distribution.amount_total, 15.0)
+        self.assertEqual(self.invoice.state, 'draft')
+        self.invoice.action_invoice_open()
+        self.assertEqual(self.invoice.state, 'open')
+        wiz = self.env['import.invoice.line.wizard'].with_context(
+            active_id=self.distribution.id).create({
+                'supplier': self.supplier.id,
+                'invoice': self.invoice.id,
+                'invoice_line': self.invoice.invoice_line_ids[:1].id,
+                'expense_type': self.type_amount.id,
+        })
+        wiz.action_import_invoice_line()
+        self.assertEqual(len(self.distribution.expense_lines.ids), 1)
+        self.assertAlmostEqual(self.distribution.total_uom_qty, 5.0)
+        self.assertAlmostEqual(self.distribution.amount_total, 25.0)
+        self.distribution.action_calculate()
+        self.assertAlmostEqual(self.distribution.total_expense, 10.0)
+        self.assertEqual(self.distribution.state, 'calculated')
+        self.assertAlmostEqual(self.product.standard_price, 3.0)
+        self.distribution.action_done()
+        self.assertEqual(self.distribution.state, 'done')
+        self.assertAlmostEqual(self.product.standard_price, 4.0)
+        self.product.standard_price = 3.0
+        self.distribution.action_cancel()

--- a/purchase_landed_cost/tests/test_purchase_landed_cost.py
+++ b/purchase_landed_cost/tests/test_purchase_landed_cost.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 # Copyright 2018 Tecnativa - Vicent Cubells
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo.exceptions import UserError
 from odoo.tests import common
+from odoo import fields
 
 
 class TestPurchaseLandedCost(common.SavepointCase):
@@ -40,39 +42,26 @@ class TestPurchaseLandedCost(common.SavepointCase):
         cls.product = cls.env['product.product'].create({
             'name': 'Product',
             'type': 'product',
-            'standard_price': 3.0,
             'property_cost_method': 'average',
-        })
-        cls.service = cls.env['product.product'].create({
-            'name': 'Service',
-            'type': 'service',
-            'standard_price': 10.0,
-        })
-        categ_unit = cls.env.ref('product.product_uom_categ_unit')
-        cls.uom_unit = cls.env['product.uom'].create({
-            'name': 'Test-Unit',
-            'category_id': categ_unit.id,
-            'rounding': 1.0,
         })
         cls.supplier = cls.env['res.partner'].create({
             'name': 'Supplier',
             'supplier': True,
         })
-        picking_type_in = cls.env.ref('stock.picking_type_in')
-        cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')
-        cls.stock_location = cls.env.ref('stock.stock_location_stock')
-        cls.picking = cls.env['stock.picking'].create({
-            'picking_type_id': picking_type_in.id,
-            'location_id': cls.supplier_location.id,
-            'location_dest_id': cls.stock_location.id,
+        cls.purchase_order = cls.env['purchase.order'].create({
             'partner_id': cls.supplier.id,
-            'move_lines': [(0, 0, {
+            'order_line': [(0, 0, {
                 'product_id': cls.product.id,
-                'product_uom_qty': 5.0,
+                'product_qty': 5.0,
                 'name': cls.product.name,
-                'product_uom': cls.uom_unit.id,
+                'product_uom': cls.product.uom_id.id,
+                'price_unit': 3.0,
+                'date_planned': fields.Date.today(),
             })]
         })
+        cls.purchase_order.button_confirm()
+        cls.picking = cls.purchase_order.picking_ids
+        cls.picking.action_done()
         user_type = cls.env.ref('account.data_account_type_expenses')
         account = cls.env['account.account'].create({
             'name': 'Account',
@@ -83,12 +72,21 @@ class TestPurchaseLandedCost(common.SavepointCase):
             'partner_id': cls.supplier.id,
             'type': 'in_invoice',
             'invoice_line_ids': [(0, 0, {
-                'product_id': cls.service.id,
-                'name': cls.service.name,
+                'name': 'Test service',
                 'account_id': account.id,
-                'price_unit': cls.service.standard_price,
+                'price_unit': 10.0,
             })]
         })
+        cls.invoice.action_invoice_open()
+        wiz = cls.env['import.invoice.line.wizard'].with_context(
+            active_id=cls.distribution.id,
+        ).create({
+            'supplier': cls.supplier.id,
+            'invoice': cls.invoice.id,
+            'invoice_line': cls.invoice.invoice_line_ids[:1].id,
+            'expense_type': cls.type_qty.id,
+        })
+        wiz.action_import_invoice_line()
 
     def test_distribution_without_lines(self):
         self.assertNotEqual(self.distribution.name, '/')
@@ -97,47 +95,81 @@ class TestPurchaseLandedCost(common.SavepointCase):
         self.assertEqual(self.distribution.state, 'draft')
 
     def test_distribution_import_shipment(self):
-        self.picking.action_confirm()
-        self.picking.action_assign()
-        self.env['stock.move.line'].create({
-            'product_id': self.product.id,
-            'qty_done': 5,
-            'product_uom_id': self.uom_unit.id,
-            'location_id': self.supplier_location.id,
-            'location_dest_id': self.stock_location.id,
-            'move_id': self.picking.move_lines[:1].id,
-        })
-        self.picking.action_done()
         self.assertEqual(self.picking.state, 'done')
         wiz = self.env['picking.import.wizard'].with_context(
-            active_id=self.distribution.id).create({
-                'supplier': self.supplier.id,
-                'pickings': [(6, 0, [self.picking.id])],
-            })
+            active_id=self.distribution.id,
+        ).create({
+            'supplier': self.supplier.id,
+            'pickings': [(6, 0, self.picking.ids)],
+        })
         wiz.action_import_picking()
         self.assertEqual(len(self.distribution.cost_lines.ids), 1)
         self.assertAlmostEqual(self.distribution.total_uom_qty, 5.0)
-        self.assertAlmostEqual(self.distribution.amount_total, 15.0)
-        self.assertEqual(self.invoice.state, 'draft')
-        self.invoice.action_invoice_open()
-        self.assertEqual(self.invoice.state, 'open')
-        wiz = self.env['import.invoice.line.wizard'].with_context(
-            active_id=self.distribution.id).create({
-                'supplier': self.supplier.id,
-                'invoice': self.invoice.id,
-                'invoice_line': self.invoice.invoice_line_ids[:1].id,
-                'expense_type': self.type_amount.id,
-        })
-        wiz.action_import_invoice_line()
+        self.assertAlmostEqual(self.distribution.total_purchase, 15.0)
+        self.assertAlmostEqual(self.distribution.amount_total, 25.0)
+        # Expense part
         self.assertEqual(len(self.distribution.expense_lines.ids), 1)
         self.assertAlmostEqual(self.distribution.total_uom_qty, 5.0)
-        self.assertAlmostEqual(self.distribution.amount_total, 25.0)
         self.distribution.action_calculate()
+        self.assertAlmostEqual(self.distribution.cost_lines[0].cost_ratio, 2)
         self.assertAlmostEqual(self.distribution.total_expense, 10.0)
+        self.assertAlmostEqual(self.distribution.cost_lines[0].cost_ratio, 2)
         self.assertEqual(self.distribution.state, 'calculated')
         self.assertAlmostEqual(self.product.standard_price, 3.0)
         self.distribution.action_done()
         self.assertEqual(self.distribution.state, 'done')
-        self.assertAlmostEqual(self.product.standard_price, 4.0)
-        self.product.standard_price = 3.0
+        self.assertAlmostEqual(self.product.standard_price, 5.0)
         self.distribution.action_cancel()
+        self.assertAlmostEqual(self.product.standard_price, 3.0)
+
+    def test_distribution_two_moves(self):
+        order2 = self.purchase_order.copy()
+        order2.order_line.price_unit = 2
+        order2.button_confirm()
+        picking2 = order2.picking_ids
+        picking2.action_done()
+        wiz = self.env['picking.import.wizard'].with_context(
+            active_id=self.distribution.id,
+        ).create({
+            'supplier': self.supplier.id,
+            'pickings': [(6, 0, (self.picking + picking2).ids)],
+        })
+        wiz.action_import_picking()
+        self.assertEqual(len(self.distribution.cost_lines.ids), 2)
+        self.assertAlmostEqual(self.distribution.total_uom_qty, 10.0)
+        self.assertAlmostEqual(self.distribution.total_purchase, 25.0)
+        self.distribution.action_calculate()
+        self.assertAlmostEqual(self.distribution.cost_lines[0].cost_ratio, 1)
+        self.assertAlmostEqual(self.product.standard_price, 2.5)
+        self.distribution.action_done()
+        self.assertAlmostEqual(self.product.standard_price, 3.5)
+        self.distribution.action_cancel()
+        self.assertAlmostEqual(self.product.standard_price, 2.5)
+
+    def test_distribution_two_moves_existing_stock(self):
+        order2 = self.purchase_order.copy()
+        order2.order_line.price_unit = 2
+        order2.button_confirm()
+        picking2 = order2.picking_ids
+        picking2.action_done()
+        order3 = self.purchase_order.copy()
+        order3.order_line.price_unit = 1
+        order3.button_confirm()
+        picking3 = order3.picking_ids
+        picking3.action_done()
+        wiz = self.env['picking.import.wizard'].with_context(
+            active_id=self.distribution.id,
+        ).create({
+            'supplier': self.supplier.id,
+            'pickings': [(6, 0, (picking2 + picking3).ids)],
+        })
+        wiz.action_import_picking()
+        self.assertAlmostEqual(self.distribution.total_uom_qty, 10.0)
+        self.assertAlmostEqual(self.distribution.total_purchase, 15.0)
+        self.distribution.action_calculate()
+        self.assertAlmostEqual(self.distribution.cost_lines[0].cost_ratio, 1)
+        self.assertAlmostEqual(self.product.standard_price, 2)
+        self.distribution.action_done()
+        self.assertAlmostEqual(self.product.standard_price, 2.67, 2)
+        self.distribution.action_cancel()
+        self.assertAlmostEqual(self.product.standard_price, 2)


### PR DESCRIPTION
Before this pr:
If user try to delete some cost line and this cost line is referenced in any expense line into the field 'affected lines', a not _sensitive_ error is shown to user.

After this pr:
Error is catched and an _clear_ message is shown to user.

cc @Tecnativa