### PR TITLE
[purchase_request] fix in procurement

### DIFF
--- a/purchase_request/models/procurement_rule.py
+++ b/purchase_request/models/procurement_rule.py
@@ -30,7 +30,8 @@ class ProcurementRule(models.Model):
     def _prepare_purchase_request(self, origin, values):
         gpo = self.group_propagation_option
         group_id = (gpo == 'fixed' and self.group_id.id) or \
-                   (gpo == 'propagate' and values['group_id'].id) or False
+                   (gpo == 'propagate' and values.get('group_id')
+                    and values['group_id'].id) or False
         return {
             'origin': origin,
             'company_id': values['company_id'].id,


### PR DESCRIPTION
Without this fix when you create a procurement from an orderpoint, that creates a purchase request, it will raise the error: 
`  File "/parts/purchase-workflow11/purchase_request/models/procurement_rule.py", line 56, in _make_pr_get_domain
    (gpo == 'propagate' and values['group_id'].id) or False
AttributeError: 'bool' object has no attribute 'id'`