### PR TITLE
[11.0][IMP/FIX] purchase_secondary_unit limit secondary uom in order line

### DIFF
--- a/purchase_order_secondary_unit/views/purchase_order_views.xml
+++ b/purchase_order_secondary_unit/views/purchase_order_views.xml
@@ -13,6 +13,7 @@
                 <field name="secondary_uom_qty" class="oe_inline oe_no_button"
                     attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}"/>
                 <field name="secondary_uom_id" class="oe_inline"
+                       domain="[('product_tmpl_id.product_variant_ids', 'in', [product_id])]"
                        attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree//field[@name='product_qty']" position="before">


### PR DESCRIPTION
Added domain to limit `secondary_uom_id` to the one defined in product template