### PR TITLE
Set value requested_by from procurement creator

### DIFF
--- a/purchase_request/models/procurement_rule.py
+++ b/purchase_request/models/procurement_rule.py
@@ -37,6 +37,7 @@ class ProcurementRule(models.Model):
             'company_id': values['company_id'].id,
             'picking_type_id': self.picking_type_id.id,
             'group_id': group_id or False,
+            'requested_by': values['group_id'].create_uid.id,
         }
 
     @api.model


### PR DESCRIPTION
If a value is not set, then default admin account with id=1 is used.