### PR TITLE
[11.0] [FIX] purchase_request - view reference

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -351,9 +351,9 @@
                             <field name="purchase_lines" mode="tree"
                                    attrs="{'readonly': [('purchase_state', 'in', ('cancel'))]}"
                                    domain="[('product_id', '=', product_id)]"
-                                   context="{'form_view_ref' : 'purchase_order_line_form2_sub',
-                                             'tree_view_ref' : 'purchase_order_line_tree_sub',
-                                             'search_view_ref' : 'purchase_order_line_search_sub'}"/>
+                                   context="{'form_view_ref' : 'purchase_request.purchase_order_line_form2_sub',
+                                             'tree_view_ref' : 'purchase_request.purchase_order_line_tree_sub',
+                                             'search_view_ref' : 'purchase_request.purchase_order_line_search_sub'}"/>
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
Minor fix to solve this warning:
```
2019-01-31 09:12:47,670 1 WARNING test odoo.models: 'tree_view_ref' requires a fully-qualified external id (got: 'purchase_order_line_tree_sub' for model purchase.order.line). Please use the complete `module.view_id` form instead.
```