### PR TITLE
[11.0][IMP] purchase_request. Improve searching

### DIFF
--- a/purchase_request/__manifest__.py
+++ b/purchase_request/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Purchase Request",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "summary": "Use this module to have notification of requirements of "
                "materials and/or external services and keep track of such "
                "requirements.",

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -86,6 +86,9 @@ class PurchaseRequest(models.Model):
                                readonly=False,
                                copy=True,
                                track_visibility='onchange')
+    product_id = fields.Many2one('product.product',
+                                 related='line_ids.product_id',
+                                 string='Product')
     state = fields.Selection(selection=_STATES,
                              string='Status',
                              index=True,

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -186,6 +186,7 @@
             <search string="Search Purchase Request">
                 <field name="name" string="Purchase Request"/>
                 <separator/>
+                <field name="product_id"/>
                 <field name="state"/>
                 <filter name="unassigned" string="Unassigned"
                         domain="[('assigned_to','=', False)]"
@@ -260,7 +261,8 @@
         <field name="model">purchase.request.line</field>
         <field name="arch" type="xml">
             <tree string="Purchase Request Lines" create="false"
-                  decoration-muted="cancelled == True">
+                  decoration-muted="cancelled == True"
+                  decoration-info="request_state in ('draft', 'to_approve')">
                 <field name="request_id"/>
                 <field name="request_state"/>
                 <field name="requested_by"/>
@@ -453,7 +455,6 @@
         <field name="res_model">purchase.request.line</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('request_state','!=','draft')]</field>
         <field name="search_view_id" ref="purchase_request_line_search"/>
     </record>
 


### PR DESCRIPTION
Sometimes it is difficult to see if there are existing draft purchase request for specific product because:
- We cannot search by purchase requests by product
- Purchase request lines are filtered by state

This PR makes the changes to search purchase request by product and to see draft purchase request lines. There is already a constraint that prevents to create quotations from draft purchase request lines so this will not cause any break in the flow.