### PR TITLE
[11.0][FIX] purchase_request

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -428,9 +428,9 @@ class PurchaseRequestLine(models.Model):
 
         rl_qty = 0.0
         # Recompute quantity by adding existing running procurements.
-        for rl in po_line.purchase_request_lines:
-            rl_qty += rl.product_uom_id._compute_quantity(
-                rl.product_qty, purchase_uom)
+        for rl in po_line:
+            rl_qty += rl.purchase_request_lines.product_uom_id\
+                ._compute_quantity(rl.product_qty, purchase_uom)
         qty = max(rl_qty, supplierinfo_min_qty)
         return qty
 

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -429,8 +429,9 @@ class PurchaseRequestLine(models.Model):
         rl_qty = 0.0
         # Recompute quantity by adding existing running procurements.
         for rl in po_line:
-            rl_qty += rl.purchase_request_lines.product_uom_id\
-                ._compute_quantity(rl.product_qty, purchase_uom)
+            for purchase_request_line in rl.purchase_request_lines:
+                rl_qty += purchase_request_line.product_uom_id\
+                    ._compute_quantity(rl.product_qty, purchase_uom)
         qty = max(rl_qty, supplierinfo_min_qty)
         return qty
 


### PR DESCRIPTION
When creating a RFQ from Purchase Request Lines, in the wizard, the quantity to purchase is not transfered to the RFQ and the quantity is set to the request line quantity. This PR fixes that issue.