### PR TITLE
[10.0][FIX]purchase_request_procurement

### DIFF
--- a/purchase_request_procurement/models/procurement_order.py
+++ b/purchase_request_procurement/models/procurement_order.py
@@ -92,6 +92,8 @@ class ProcurementOrder(models.Model):
             req = purchase_request_model.create(request_data)
             self.message_post(body=_("Purchase Request created"))
             self.request_id = req
+        else:
+            self.request_id = pr
         request_line_data = self._prepare_purchase_request_line()
         purchase_request_line_model.create(request_line_data),
         self.message_post(body=_("Purchase Request extended."))


### PR DESCRIPTION
Currently the method `_search_existing_purchase_request` is useless as the result is ignored and the procurements are never grouped.