### PR TITLE
[FIX] 10.0 purchase_request_to_rfq: linked procurements

### DIFF
--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -231,6 +231,8 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                 new_pr_line = False
                 po_line = available_po_lines[0]
                 po_line.purchase_request_lines = [(4, line.id)]
+                if line.procurement_id:
+                    po_line.procurement_ids = [(4, line.procurement_id.id)]
             else:
                 po_line_data = self._prepare_purchase_order_line(purchase,
                                                                  item)


### PR DESCRIPTION
Before this PR, if a purchase order line was created from multiple purchase request lines linked to multiple procurement orders, the created purchase order line was only linked to the first procurement. This PR fixes this behavior.