### PR TITLE
[11.0][purchase_workflow_tier_valiation] add the status 'to approve' to the initiating states to trigger the validation.

### DIFF
--- a/purchase_tier_validation/__manifest__.py
+++ b/purchase_tier_validation/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Purchase Tier Validation",
     "summary": "Extends the functionality of Purchase Orders to "
                "support a tier validation process.",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Purchases",
     "website": "https://github.com/OCA/purchase-workflow",
     "author": "Eficent, Odoo Community Association (OCA)",

--- a/purchase_tier_validation/models/purchase_order.py
+++ b/purchase_tier_validation/models/purchase_order.py
@@ -7,5 +7,5 @@ from odoo import models
 class PurchaseOrder(models.Model):
     _name = "purchase.order"
     _inherit = ['purchase.order', 'tier.validation']
-    _state_from = ['draft', 'sent']
+    _state_from = ['draft', 'sent', 'to approve']
     _state_to = ['purchase', 'approved']

--- a/purchase_tier_validation/views/purchase_order_view.xml
+++ b/purchase_tier_validation/views/purchase_order_view.xml
@@ -11,11 +11,11 @@
             <button name="button_confirm" position="before">
                 <button name="request_validation"
                     string="Request Validation"
-                    attrs="{'invisible': ['|','|',('need_validation', '!=', True),('rejected','=',True),('state','not in',['draft','sent'])]}"
+                    attrs="{'invisible': ['|','|',('need_validation', '!=', True),('rejected','=',True),('state','not in',['draft','sent','to approve'])]}"
                     type="object"/>
                 <button name="restart_validation"
                     string="Restart Validation"
-                    attrs="{'invisible': ['|',('review_ids', '=', []),('state','not in',['draft','sent'])]}"
+                    attrs="{'invisible': ['|',('review_ids', '=', []),('state','not in',['draft','sent','to approve'])]}"
                     type="object"/>
             </button>
             <header position="after">
@@ -24,7 +24,7 @@
                 <field name="rejected" invisible="1"/>
                 <div class="alert alert-warning"
                      attrs="{'invisible': ['|', '|', '|',
-                     ('validated', '=', True), ('state', 'not in', ['draft','sent']),
+                     ('validated', '=', True), ('state', 'not in', ['draft','sent','to approve']),
                      ('rejected', '=', True), ('review_ids', '=', [])]}"
                      style="margin-bottom:0px;">
                     <p><i class="fa fa-info-circle"/>This PO needs to be
@@ -45,12 +45,12 @@
                     </p>
                 </div>
                 <div class="alert alert-success"
-                     attrs="{'invisible': ['|', '|', ('validated', '!=', True), ('state', 'not in', ['draft','sent']), ('review_ids', '=', [])]}"
+                     attrs="{'invisible': ['|', '|', ('validated', '!=', True), ('state', 'not in', ['draft','sent','to approve']), ('review_ids', '=', [])]}"
                      style="margin-bottom:0px;">
                     <p><i class="fa fa-thumbs-up"/> Operation has been <b>validated</b>!</p>
                 </div>
                 <div class="alert alert-danger"
-                     attrs="{'invisible': ['|', '|', ('rejected', '!=', True), ('state', 'not in', ['draft','sent']), ('review_ids', '=', [])]}"
+                     attrs="{'invisible': ['|', '|', ('rejected', '!=', True), ('state', 'not in', ['draft','sent','to approve']), ('review_ids', '=', [])]}"
                      style="margin-bottom:0px;">
                     <p><i class="fa fa-thumbs-down"/> Operation has been <b>rejected</b>.</p>
                 </div>
@@ -70,7 +70,7 @@
         <field name="arch" type="xml">
             <filter name="message_needaction" position="after">
                 <filter name="needs_review" string="Needs my Review"
-                        domain="[('reviewer_ids','in',uid), ('state', 'not in', ['done', 'cancel'])]"
+                        domain="[('reviewer_ids','in',uid), ('state', 'not in', ['done', 'cancel','to approve'])]"
                         help="My Purchases to review"/>
                 <filter name="tier_validated" string="Validated"
                         domain="[('validated', '=', True)]"

--- a/purchase_tier_validation/views/purchase_order_view.xml
+++ b/purchase_tier_validation/views/purchase_order_view.xml
@@ -55,11 +55,9 @@
                     <p><i class="fa fa-thumbs-down"/> Operation has been <b>rejected</b>.</p>
                 </div>
             </header>
-            <notebook position="inside">
-                <page string="Reviews" name="tier_validation">
-                    <field name="review_ids" readonly="1"/>
-                </page>
-            </notebook>
+            <div name="button_box" position="inside">
+                <field name="review_ids" widget="review_popup" attrs="{'invisible':[('review_ids', '=', [])]}"/>
+            </div>
         </field>
     </record>
 


### PR DESCRIPTION
Fixes a compatibility problem with https://github.com/OCA/purchase-workflow/tree/11.0/purchase_order_approval_block

cc @etobella 