### PR TITLE
[11.0][IMP] purchase_request: Allow change product on make PO

### DIFF
--- a/purchase_request/__manifest__.py
+++ b/purchase_request/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Purchase Request",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
-    "version": "11.0.1.2.0",
+    "version": "11.0.1.2.1",
     "summary": "Use this module to have notification of requirements of "
                "materials and/or external services and keep track of such "
                "requirements.",

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -31,7 +31,7 @@
                                    options="{'no_open': true}"
                                    invisible="1"/>
                               <field name="request_id" readonly="1"/>
-                              <field name="product_id" readonly="1"/>
+                              <field name="product_id"/>
                               <field name="name"/>
                               <field name="product_qty"/>
                               <field name="product_uom_id"


### PR DESCRIPTION
Allow change product on make purchase order wizard allows this workflow case:
- Purchase request users create a PR without a specific product
- Once it is validated, the responsible, who can be the same user if it also is in purchase user or the responsible of create PO's, can modify product before create the PO.

CC @Eficent 