### PR TITLE
[FIX] purchase_discount: Use sudo in purchase lines

### DIFF
--- a/purchase_discount/models/stock_move.py
+++ b/purchase_discount/models/stock_move.py
@@ -13,7 +13,10 @@ class StockMove(models.Model):
         maximum inheritability.
         """
         price_unit = False
-        po_line = self.purchase_line_id
+        # We do it with sudo to avoid permission errors in case
+        # the user validates the order and does not have permission to
+        # modifiy purchase lines
+        po_line = self.purchase_line_id.sudo()
         if po_line and self.product_id == po_line.product_id:
             price = po_line._get_discounted_price_unit()
             if price != po_line.price_unit:


### PR DESCRIPTION
 We do it with sudo to avoid permission errors in case the user validates the order and does not have permission to modify purchase lines.

For ex: User with not allow to purchase, and try to validate an order and the purchase order line has discount applied.