### PR TITLE
[10.0][IMP]do not need to update location in stock moves if it is already set.

### DIFF
--- a/purchase_location_by_line/models/purchase.py
+++ b/purchase_location_by_line/models/purchase.py
@@ -51,7 +51,8 @@ class PurchaseOrderLine(models.Model):
                 default_picking_location_id)
 
             location = line.location_dest_id or default_picking_location
-            if location:
+            if location and \
+                    line.move_ids.mapped('location_dest_id') != location:
                 line.move_ids.write(
                     {'location_dest_id': location.id})
         return res

--- a/purchase_location_by_line/tests/test_purchase_delivery.py
+++ b/purchase_location_by_line/tests/test_purchase_delivery.py
@@ -181,3 +181,13 @@ class TestDeliverySingle(TransactionCase):
         self.assertEquals(
             sorted_pickings[2].min_date[:10], self.date_later,
             "The second picking must be planned at the latest date")
+
+    def test_modify_confirmed(self):
+        # if all moves contain the location no need to update
+
+        self.po.button_confirm()
+        self.po.order_line[0].write({'product_qty': 43})
+        self.assertEqual(
+            self.po.order_line[0].move_ids.mapped('location_dest_id'),
+            self.l1
+        )


### PR DESCRIPTION
There is a very nice feature introduced in Odoo 10 that allows to increase or decrease the qty in confirmed  PO lines. puchase_location_by_line module disables this feature because it writes the location of destination in the stock moves even if those already had that location #498 

The proposed fix is just not to update the stock moves destination location if it is not needed.

This PR https://github.com/OCA/purchase-workflow/pull/499 means to solve #498 without restricting the state of the PO as it is done here #499

I rather prefer this approach as this will not disable the ability of editing confirmed PO lines.

Regards.