### PR TITLE
[10.0][ENH]better extensibility for messages in purchase requests

### DIFF
--- a/purchase_request_to_rfq/models/purchase_order.py
+++ b/purchase_request_to_rfq/models/purchase_order.py
@@ -22,12 +22,17 @@ class PurchaseOrder(models.Model):
             request.name, self.name)
 
         for line in request_dict.values():
+            if line['request_line'].product_id:
+                display_name = line['request_line'].product_id.display_name
+            else:
+                display_name = line['request_line'].name
+
             message += _(
                 '<li><b>%s</b>: Ordered quantity %s %s, Planned date %s</li>'
-            ) % (line['name'],
-                 line['product_qty'],
-                 line['product_uom'],
-                 line['date_planned'],
+            ) % (display_name,
+                 line['line'].product_qty,
+                 line['line'].product_uom.name,
+                 line['line'].order_id.date_planned,
                  )
         message += '</ul>'
         return message
@@ -42,12 +47,9 @@ class PurchaseOrder(models.Model):
                     request_id = request_line.request_id.id
                     if request_id not in requests_dict:
                         requests_dict[request_id] = {}
-                    date_planned = "%s" % line.date_planned
                     data = {
-                        'name': request_line.name,
-                        'product_qty': line.product_qty,
-                        'product_uom': line.product_uom.name,
-                        'date_planned': date_planned,
+                        'request_line': request_line,
+                        'line': line,
                     }
                     requests_dict[request_id][request_line.id] = data
             for request_id in requests_dict:

--- a/purchase_request_to_rfq/models/stock.py
+++ b/purchase_request_to_rfq/models/stock.py
@@ -22,11 +22,15 @@ class StockPicking(models.Model):
             request.name, picking.name)
         message += '<ul>'
         for line in request_dict.values():
+            if line['request_line'].product_id:
+                display_name = line['request_line'].product_id.display_name
+            else:
+                display_name = line['request_line'].name
             message += _(
                 '<li><b>%s</b>: Received quantity %s %s</li>'
-            ) % (line['name'],
-                 line['product_qty'],
-                 line['product_uom'],
+            ) % (display_name,
+                 line['stock_move'].product_qty,
+                 line['stock_move'].product_uom.name,
                  )
         message += '</ul>'
         return message
@@ -48,9 +52,8 @@ class StockPicking(models.Model):
                         if request_id not in requests_dict:
                             requests_dict[request_id] = {}
                         data = {
-                            'name': request_line.name,
-                            'product_qty': move.product_qty,
-                            'product_uom': move.product_uom.name,
+                            'request_line': request_line,
+                            'stock_move': move,
                         }
                         requests_dict[request_id][request_line.id] = data
             for request_id in requests_dict:


### PR DESCRIPTION
This PR does two things:

-  Pass the objects to the methods that makes the messages instead of the values directly. This way we can easily change the message in a another module.

- Displays the display_name of the product, instead of the description in the purchase request (This is the only functional change here. It makes sense as we have stock moves and products involved)


