### PR TITLE
[WIP][10.0][FIX] purchase_request_procurement update procurement state

### DIFF
--- a/purchase_request_procurement/README.rst
+++ b/purchase_request_procurement/README.rst
@@ -83,6 +83,7 @@ Contributors
 * Thomas Binsfeld <thomas.binsfeld@acsone.eu>
 * Benjamin Willig <benjamin.willig@acsone.eu>
 * Lois Rilo Antelo <lois.rilo@eficent.com>
+* Raphaël Reverdy <raphael.reverdy@akretion.com>
 
 Maintainer
 ----------

--- a/purchase_request_procurement/models/procurement_order.py
+++ b/purchase_request_procurement/models/procurement_order.py
@@ -60,6 +60,12 @@ class ProcurementOrder(models.Model):
         return super(ProcurementOrder, self)._run()
 
     @api.multi
+    def _check(self):
+        if self.request_id:
+            return self.request_id.state in ['rejected', 'done']
+        return super(ProcurementOrder, self)._check()
+
+    @api.multi
     def is_create_purchase_request_allowed(self):
         """
         Tell if current procurement order should

--- a/purchase_request_procurement/models/purchase_request.py
+++ b/purchase_request_procurement/models/purchase_request.py
@@ -35,3 +35,9 @@ class PurchaseRequest(models.Model):
     def button_draft(self):
         self._check_reset_allowed()
         return super(PurchaseRequest, self).button_draft()
+
+    @api.multi
+    def button_done(self):
+        res = super(PurchaseRequest, self).button_done()
+        self.line_ids._check_procurement()
+        return res

--- a/purchase_request_procurement/models/purchase_request_line.py
+++ b/purchase_request_procurement/models/purchase_request_line.py
@@ -30,3 +30,10 @@ class PurchaseRequestLine(models.Model):
         lines = self.filtered(lambda l: l.procurement_id.state != 'cancel')
         res = super(PurchaseRequestLine, lines).do_uncancel()
         return res
+
+    @api.multi
+    def _check_procurement(self):
+        """Purchase request has been approved
+
+        Update procurements state."""
+        self.mapped('procurement_id').check()

--- a/purchase_request_procurement/tests/test_purchase_request_procurement.py
+++ b/purchase_request_procurement/tests/test_purchase_request_procurement.py
@@ -96,3 +96,18 @@ class TestPurchaseRequestProcurement(common.SavepointCase):
         line = request.line_ids[0]
         self.assertEqual(line.product_uom_id, self.uom_ten)
         self.assertEqual(line.product_qty, 10)
+
+    def test_purchase_request_state(self):
+        """Test procurement state should be done when PR is done"""
+        proc = self.create_procurement_order('TEST/0001', self.product_1, 4)
+        proc.run()
+        proc.check()
+        # when PR is not done, proc should still be running
+        self.assertEquals(proc.state, 'running')
+
+        request = proc.request_id
+        request.button_approved()
+        proc.check()
+        self.assertEquals(proc.state, 'running')
+        request.button_done()
+        self.assertEquals(proc.state, 'done')


### PR DESCRIPTION
Before this PR:
When a PR is done, the state of its procurements are not updated.
After this PR:
When a PR is done, its procurements states are set to done.

I think the procurement should done if the purchase request is done.
Note: having the procurement in exception if the purchase request is rejected is already in place.

It's related to the issue described in this PR: #719