### PR TITLE
[10.0][FIX]purchase_request Remove failing domain

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -310,7 +310,6 @@
                                 </div>
                                 <field name="analytic_account_id"
                                        groups="analytic.group_analytic_accounting"
-                                       domain="[('type','not in',('view','template'))]"
                                        attrs="{'readonly': [('is_editable','=', False)]}"/>
                                 <field name="date_required"
                                        attrs="{'readonly': [('is_editable','=', False)]}"/>


### PR DESCRIPTION
There is no type in analytic domain.

Step to reproduce: open a draft purchase request line, click on analytic account. You will get an error.