### PR TITLE
[10.0][FIX]  purchase_location_by_line: do not change location_dest_id on 'done' moves

### DIFF
--- a/purchase_location_by_line/models/purchase.py
+++ b/purchase_location_by_line/models/purchase.py
@@ -52,6 +52,6 @@ class PurchaseOrderLine(models.Model):
 
             location = line.location_dest_id or default_picking_location
             if location:
-                line.move_ids.write(
+                line.move_ids.filtered(lambda m: m.state != 'done').write(
                     {'location_dest_id': location.id})
         return res

--- a/purchase_location_by_line/tests/test_purchase_delivery.py
+++ b/purchase_location_by_line/tests/test_purchase_delivery.py
@@ -181,3 +181,13 @@ class TestDeliverySingle(TransactionCase):
         self.assertEquals(
             sorted_pickings[2].min_date[:10], self.date_later,
             "The second picking must be planned at the latest date")
+
+    def test_modify_confirmed(self):
+        # if all moves contain the location no need to update
+
+        self.po.button_confirm()
+        self.po.order_line[0].write({'product_qty': 43})
+        self.assertEqual(
+            self.po.order_line[0].move_ids.mapped('location_dest_id'),
+            self.l1
+        )


### PR DESCRIPTION
Fixes https://github.com/OCA/purchase-workflow/issues/498

Closes https://github.com/OCA/purchase-workflow/pull/499
Closes https://github.com/OCA/purchase-workflow/pull/703

Thanks to @jarmokortetjarvi