### PR TITLE
[11.0][FIX]  purchase_location_by_line: do not change location_dest_id on 'done' moves

### DIFF
--- a/purchase_location_by_line/models/purchase.py
+++ b/purchase_location_by_line/models/purchase.py
@@ -52,6 +52,6 @@ class PurchaseOrderLine(models.Model):
 
             location = line.location_dest_id or default_picking_location
             if location:
-                line.move_ids.write(
+                line.move_ids.filtered(lambda m: m.state != 'done').write(
                     {'location_dest_id': location.id})
         return res

--- a/purchase_location_by_line/tests/test_purchase_delivery.py
+++ b/purchase_location_by_line/tests/test_purchase_delivery.py
@@ -183,3 +183,13 @@ class TestDeliverySingle(TransactionCase):
         self.assertEquals(
             sorted_pickings[2].scheduled_date[:10], self.date_later,
             "The second picking must be planned at the latest date")
+
+    def test_modify_confirmed(self):
+        # if all moves contain the location no need to update
+
+        self.po.button_confirm()
+        self.po.order_line[0].write({'product_qty': 43})
+        self.assertEqual(
+            self.po.order_line[0].move_ids.mapped('location_dest_id'),
+            self.l1
+        )


### PR DESCRIPTION
Forward port of https://github.com/OCA/purchase-workflow/pull/736.