### PR TITLE
[11.0][FIX] purchase_request: _action_cancel mail activity

### DIFF
--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -36,7 +36,7 @@ class StockMove(models.Model):
                         'mail.mail_activity_data_todo').id
                 except ValueError:
                     activity_type_id = False
-                self.env['mail.activity'].create({
+                self.env['mail.activity'].sudo().create({
                     'activity_type_id': activity_type_id,
                     'note': _('A sale/manufacturing order that generated this '
                               'purchase request has been cancelled/deleted. '

--- a/purchase_request/models/stock_picking.py
+++ b/purchase_request/models/stock_picking.py
@@ -57,4 +57,7 @@ class StockPicking(models.Model):
                 message = \
                     self._purchase_request_picking_confirm_message_content(
                         picking, request, requests_dict[request_id])
-                request.message_post(body=message, subtype='mail.mt_comment')
+                request.sudo().message_post(
+                    body=message,
+                    subtype='mail.mt_comment',
+                    author_id=self.env.user.partner_id.id)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Allow Inventory Users to cancel Transfers originated from Purchase Requests .


**Current behavior before PR:**

Unless user has Purchase Request User/Manager permissions he can't cancel transfers created from Purchase Request.

When the Cancel Action is triggered, purchases module will create a mail activity to the related PR.
Regarding Inventory User have no write access to PR's he will receive an ACL error.

https://github.com/odoo/odoo/blob/b59369d1e6115392f557e7d58ff61f736d72d692/addons/mail/models/mail_activity.py#L178

**Desired behavior after PR is merged:**

Inventory Users can cancel pickings and mail activity is correctly generated in the related PR if needed.
