### PR TITLE
[10][FIX]purchase_request_to_rfq Always use Product Unit Of Measure precision

### DIFF
--- a/purchase_request_to_rfq/models/purchase_request.py
+++ b/purchase_request_to_rfq/models/purchase_request.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, exceptions, fields, models
+import odoo.addons.decimal_precision as dp
 
 
 class PurchaseRequestLine(models.Model):
@@ -60,8 +61,10 @@ class PurchaseRequestLine(models.Model):
                     temp_purchase_state = 'draft'
             rec.purchase_state = temp_purchase_state
 
-    purchased_qty = fields.Float(string='Quantity in RFQ or PO',
-                                 compute="_compute_purchased_qty")
+    purchased_qty = fields.Float(
+        string='Quantity in RFQ or PO',
+        digits=dp.get_precision('Product Unit of Measure'),
+        compute="_compute_purchased_qty")
     purchase_lines = fields.Many2many(
         'purchase.order.line', 'purchase_request_purchase_order_line_rel',
         'purchase_request_line_id',

--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -277,9 +277,10 @@ class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):
                                  readonly=True)
     product_id = fields.Many2one('product.product', string='Product')
     name = fields.Char(string='Description', required=True)
-    product_qty = fields.Float(string='Quantity to purchase',
-                               digits=dp.get_precision('Product UoS'),
-                               readonly=True)
+    product_qty = fields.Float(
+        string='Quantity to purchase',
+        digits=dp.get_precision('Product Unit of Measure'),
+        readonly=True)
     product_uom_id = fields.Many2one('product.uom', string='UoM',
                                      readonly=True)
     keep_description = fields.Boolean(string='Copy descriptions to new PO',


### PR DESCRIPTION
Be consistent with : https://github.com/OCA/purchase-workflow/blob/10.0/purchase_request/models/purchase_request.py#L250