### PR TITLE
[11.0][FIX] purchase_request: Always use Product Unit Of Measure precision

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -266,8 +266,10 @@ class PurchaseRequestLine(models.Model):
     cancelled = fields.Boolean(
         string="Cancelled", readonly=True, default=False, copy=False)
 
-    purchased_qty = fields.Float(string='Quantity in RFQ or PO',
-                                 compute="_compute_purchased_qty")
+    purchased_qty = fields.Float(
+        string='Quantity in RFQ or PO',
+        digits=dp.get_precision('Product Unit of Measure'),
+        compute="_compute_purchased_qty")
     purchase_lines = fields.Many2many(
         'purchase.order.line', 'purchase_request_purchase_order_line_rel',
         'purchase_request_line_id',

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -270,8 +270,9 @@ class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):
     product_id = fields.Many2one('product.product', string='Product',
                                  related='line_id.product_id')
     name = fields.Char(string='Description', required=True)
-    product_qty = fields.Float(string='Quantity to purchase',
-                               digits=dp.get_precision('Product UoS'))
+    product_qty = fields.Float(
+        string='Quantity to purchase',
+        digits=dp.get_precision('Product Unit of Measure'))
     product_uom_id = fields.Many2one('product.uom', string='UoM')
     keep_description = fields.Boolean(string='Copy descriptions to new PO',
                                       help='Set true if you want to keep the '


### PR DESCRIPTION
Port to v11 of https://github.com/OCA/purchase-workflow/pull/740/commits/d8876cdb8c22948a4a39666409f516ce394ed288

@hparfr as we merged purchase request I couldn't cherry-pick it
