### PR TITLE
[12.0][FIX] purchase_order_approved

### DIFF
--- a/purchase_order_approved/views/res_config_view.xml
+++ b/purchase_order_approved/views/res_config_view.xml
@@ -6,9 +6,9 @@
     <record id="view_purchase_configuration" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.inherit.purchase - purchase_order_approved</field>
         <field name="model">res.config.settings</field>
-        <field name="inherit_id" ref="purchase.res_config_settings_view_form_purchase"/>
+        <field name="inherit_id" ref="purchase_stock.res_config_settings_view_form_purchase"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('o_settings_container')][1]" position="inside">
+            <xpath expr="//div[@data-key='purchase']//div[hasclass('o_settings_container')][1]" position="inside">
                 <div class="col-12 col-lg-6 o_setting_box">
                     <div class="o_setting_left_pane">
                         <field name="purchase_approve_active"/>


### PR DESCRIPTION
Currently, when there are apps installed whose configuration settings appear before Purchase, the configuration setting introduced by this module falls in the first app as shown in the figure below:

![image](https://user-images.githubusercontent.com/44768500/64609351-13798c00-d3cd-11e9-9637-3d9f00a9f004.png)


Fixed with a more explicit expression in the xpath tag

cc ~ @Eficent
