### PR TITLE
[12.0][FIX]allocation creation when min_qty is greater than qty requested

### DIFF
--- a/purchase_request/security/ir.model.access.csv
+++ b/purchase_request/security/ir.model.access.csv
@@ -9,6 +9,6 @@ access_purchase_order_line_user,access.purchase.order.line.user,model_purchase_o
 access_purchase_order_manager,access.purchase.order.manager,model_purchase_order,purchase_request.group_purchase_request_manager,1,0,0,0
 access_purchase_order_line_manager,access.purchase.order.line.manager,model_purchase_order_line,purchase_request.group_purchase_request_manager,1,0,0,0
 access_purchase_request_allocation_manager,purchase.request.allocation,model_purchase_request_allocation,group_purchase_request_manager,1,1,1,1
-access_purchase_request_allocation_user,purchase.request.allocation,model_purchase_request_allocation,base.group_user,1,0,0,0
-access_purchase_request_line_stock_user,purchase.request.line.stock,model_purchase_request_line,stock.group_stock_user,1,0,0,0
+access_purchase_request_allocation_user,purchase.request.allocation,model_purchase_request_allocation,base.group_user,1,1,1,0
+access_purchase_request_line_stock_user,purchase.request.line.stock,model_purchase_request_line,stock.group_stock_user,1,1,1,0
 access_purchase_request_stock_user,purchase.request.stock,model_purchase_request,stock.group_stock_user,1,0,0,0

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -146,16 +146,19 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                     vals[field] = obj._fields[field].convert_to_write(
                         obj[field], obj)
 
-    def create_allocation(self, po_line, pr_line):
-        vals = {'requested_product_uom_qty': po_line.product_uom_qty,
+    def create_allocation(self, po_line, pr_line, new_qty):
+        vals = {'requested_product_uom_qty': new_qty,
                 'purchase_request_line_id': pr_line.id,
                 'purchase_line_id': po_line.id,
                 }
-        self.env['purchase.request.allocation'].create(vals)
+        return self.env['purchase.request.allocation'].create(vals)
 
     @api.model
     def _prepare_purchase_order_line(self, po, item):
+        if not item.product_id:
+            raise UserError("Please select a product for all lines")
         product = item.product_id
+
         # Keep the standard product UOM for purchase order so we should
         # convert the product quantity to this UOM
         qty = item.product_uom_id._compute_quantity(
@@ -247,14 +250,16 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                 po_line = available_po_lines[0]
                 po_line.purchase_request_lines = [(4, line.id)]
                 po_line.move_dest_ids |= line.move_dest_ids
-                self.create_allocation(po_line, line)
+                all_qty = min(po_line.product_uom_qty, item.product_qty)
+                self.create_allocation(po_line, line, all_qty)
             else:
                 po_line_data = self._prepare_purchase_order_line(purchase,
                                                                  item)
                 if item.keep_description:
                     po_line_data['name'] = item.name
                 po_line = po_line_obj.create(po_line_data)
-                self.create_allocation(po_line, line)
+                all_qty = min(po_line.product_uom_qty, item.product_qty)
+                self.create_allocation(po_line, line, all_qty)
             new_qty = pr_line_obj._calc_new_qty(
                 line, po_line=po_line,
                 new_pr_line=new_pr_line)


### PR DESCRIPTION
Basically, allocation system fails when the minimum ordered qty is greater than the qty requested. With the current code we are creating allocations for the minimum order quantity, which is incorrect.

Besides that, I have also give creation and writing permissions to stock user to the allocations model and the purchase request line model. Other wise a basic warehouse user would not be able to receive the purchase orders. The new access control list will not give them menu access to purchase request, so I think security is still consistent.

Ping: @hveficent 