### PR TITLE
[12.0][FIX] purchase_request: Don't copy allocation information on duplication

### DIFF
--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -88,7 +88,8 @@ class PurchaseOrderLine(models.Model):
     purchase_request_allocation_ids = fields.One2many(
         comodel_name='purchase.request.allocation',
         inverse_name='purchase_line_id',
-        string='Purchase Request Allocation')
+        string='Purchase Request Allocation',
+        copy=False,)
 
     @api.multi
     def action_openRequestLineTreeView(self):


### PR DESCRIPTION
Duplicating a PO created from a Purchase Request were copying allocation information.

CC ~ @Eficent