### PR TITLE
[12.0][IMP] purchase_request: store preferred supplier

### DIFF
--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -70,7 +70,8 @@ class PurchaseRequestLine(models.Model):
                                      store=True)
     supplier_id = fields.Many2one('res.partner',
                                   string='Preferred supplier',
-                                  compute="_compute_supplier_id")
+                                  compute="_compute_supplier_id",
+                                  store=True)
     cancelled = fields.Boolean(
         string="Cancelled", readonly=True, default=False, copy=False)
 
@@ -228,6 +229,7 @@ class PurchaseRequestLine(models.Model):
             rec.is_editable = False
 
     @api.multi
+    @api.depends('product_id', 'product_id.seller_ids')
     def _compute_supplier_id(self):
         for rec in self:
             if rec.product_id:


### PR DESCRIPTION
With this change, now it is possible to sort Purchase Request Lines by preferred supplier, giving user the chance to group PO creating with that lines