### PR TITLE
10.0 add purchase_order_line_change_supplier

### DIFF
--- a/purchase_order_line_change_supplier/__init__.py
+++ b/purchase_order_line_change_supplier/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models
+from . import wizard

--- a/purchase_order_line_change_supplier/__manifest__.py
+++ b/purchase_order_line_change_supplier/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Purchase Order Line Change Supplier',
+    'version': '10.0.1.0.0',
+    'author': "PlanetaTIC, Odoo Community Association (OCA)",
+    'category': 'Purchase',
+    'description': '''This module permits to change supplier of purchase order
+ line, moving selected lines of a purchase order to a new purchase order
+ of selected supplier.''',
+    'depends': [
+        'purchase',
+    ],
+    'website': 'https://github.com/OCA/purchase-workflow',
+    'data': [
+        'views/purchase_view.xml',
+        'wizard/change_purchase_line_supplier_view.xml',
+    ],
+    'test': [],
+    'license': 'AGPL-3',
+    'installable': True,
+    'auto_install': False,
+}

--- a/purchase_order_line_change_supplier/i18n/es.po
+++ b/purchase_order_line_change_supplier/i18n/es.po
@@ -1,0 +1,100 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_order_line_change_supplier
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-10-14 07:44+0000\n"
+"PO-Revision-Date: 2019-10-14 07:44+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.ui.view,arch_db:purchase_order_line_change_supplier.change_purchase_line_supplierwizard_view
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.actions.act_window,name:purchase_order_line_change_supplier.change_purchase_line_supplier_wizard_action
+#: model:ir.ui.view,arch_db:purchase_order_line_change_supplier.change_purchase_line_supplierwizard_view
+msgid "Change Purchase Line Supplier"
+msgstr "Cambiar las líneas de compra de proveedor"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model,name:purchase_order_line_change_supplier.model_change_purchase_line_supplier_wizard
+msgid "Change Purchase Line Supplier Wizard"
+msgstr "Cambiar las líneas de compra de proveedor"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model.fields,field_description:purchase_order_line_change_supplier.field_change_purchase_line_supplier_wizard_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model.fields,field_description:purchase_order_line_change_supplier.field_change_purchase_line_supplier_wizard_create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model.fields,field_description:purchase_order_line_change_supplier.field_change_purchase_line_supplier_wizard_display_name
+msgid "Display Name"
+msgstr "Nombre a mostrar"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model.fields,field_description:purchase_order_line_change_supplier.field_change_purchase_line_supplier_wizard_id
+msgid "ID"
+msgstr "ID"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model.fields,field_description:purchase_order_line_change_supplier.field_change_purchase_line_supplier_wizard___last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model.fields,field_description:purchase_order_line_change_supplier.field_change_purchase_line_supplier_wizard_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model.fields,field_description:purchase_order_line_change_supplier.field_change_purchase_line_supplier_wizard_write_date
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model,name:purchase_order_line_change_supplier.model_purchase_order
+msgid "Purchase Order"
+msgstr "Pedido de compra"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model,name:purchase_order_line_change_supplier.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Línea pedido de compra"
+
+#. module: purchase_order_line_change_supplier
+#: code:addons/purchase_order_line_change_supplier/wizard/change_purchase_line_supplier.py:35
+#, python-format
+msgid "Request for Quotation"
+msgstr "Solicitud de presupuesto"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.actions.act_window,name:purchase_order_line_change_supplier.show_purchase_lines_action
+msgid "Show Purchase Lines"
+msgstr "Mostrar líneas de compra"
+
+#. module: purchase_order_line_change_supplier
+#: model:ir.model.fields,field_description:purchase_order_line_change_supplier.field_change_purchase_line_supplier_wizard_supplier_id
+msgid "Supplier"
+msgstr "Proveedor"
+
+#. module: purchase_order_line_change_supplier
+#: code:addons/purchase_order_line_change_supplier/wizard/change_purchase_line_supplier.py:29
+#, python-format
+msgid "There are no lines to change supplier."
+msgstr "No se ha seleccionado ninguna línea."
+

--- a/purchase_order_line_change_supplier/models/__init__.py
+++ b/purchase_order_line_change_supplier/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import purchase

--- a/purchase_order_line_change_supplier/models/purchase.py
+++ b/purchase_order_line_change_supplier/models/purchase.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, SUPERUSER_ID, _
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def get_domain_draft_purchase_order(self, supplier_id):
+        domain = [
+            ('partner_id', '=', supplier_id),
+            ('state', '=', 'draft'),
+            ('picking_type_id', '=', self.picking_type_id.id),
+            ('company_id', '=', self.company_id.id),
+        ]
+
+        return domain
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    @api.multi
+    def change_supplier(self, supplier_id):
+        purchase_obj = self.env['purchase.order']
+
+        original_order = self[0].order_id
+
+        # search for already existing purchase order to add new products or
+        # create a new purchase order with supplier_id
+        domain = original_order.get_domain_draft_purchase_order(supplier_id)
+        purchase_orders = purchase_obj.search(domain)
+        if purchase_orders:
+            quotation_purchase_order = purchase_orders[0]
+        else:
+            group_id =\
+                (self.sale_ids and self.sale_ids[0].procurement_group_id and\
+                self.sale_ids[0].procurement_group_id.id) or False
+            quotation_purchase_order = purchase_obj.create({
+                'partner_id': supplier_id,
+                'group_id': group_id,
+            })
+
+        self.write({'order_id': quotation_purchase_order.id})
+
+        return quotation_purchase_order.id

--- a/purchase_order_line_change_supplier/models/purchase.py
+++ b/purchase_order_line_change_supplier/models/purchase.py
@@ -2,7 +2,7 @@
 # Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo import api, models
 
 
 class PurchaseOrder(models.Model):
@@ -26,7 +26,8 @@ class PurchaseOrderLine(models.Model):
     def change_supplier(self, supplier_id):
         purchase_obj = self.env['purchase.order']
 
-        original_order = self[0].order_id
+        first_line = self[0]
+        original_order = first_line.order_id
 
         # search for already existing purchase order to add new products or
         # create a new purchase order with supplier_id
@@ -36,8 +37,9 @@ class PurchaseOrderLine(models.Model):
             quotation_purchase_order = purchase_orders[0]
         else:
             group_id =\
-                (self.sale_ids and self.sale_ids[0].procurement_group_id and
-                 self.sale_ids[0].procurement_group_id.id) or False
+                (first_line.sale_ids and
+                 first_line.sale_ids[0].procurement_group_id and
+                 first_line.sale_ids[0].procurement_group_id.id) or False
             quotation_purchase_order = purchase_obj.create({
                 'partner_id': supplier_id,
                 'group_id': group_id,

--- a/purchase_order_line_change_supplier/models/purchase.py
+++ b/purchase_order_line_change_supplier/models/purchase.py
@@ -36,8 +36,8 @@ class PurchaseOrderLine(models.Model):
             quotation_purchase_order = purchase_orders[0]
         else:
             group_id =\
-                (self.sale_ids and self.sale_ids[0].procurement_group_id and\
-                self.sale_ids[0].procurement_group_id.id) or False
+                (self.sale_ids and self.sale_ids[0].procurement_group_id and
+                 self.sale_ids[0].procurement_group_id.id) or False
             quotation_purchase_order = purchase_obj.create({
                 'partner_id': supplier_id,
                 'group_id': group_id,

--- a/purchase_order_line_change_supplier/readme/CONTRIBUTORS.rst
+++ b/purchase_order_line_change_supplier/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Marc Poch Mallandrich <mpoch@planetatic.com>

--- a/purchase_order_line_change_supplier/readme/DESCRIPTION.rst
+++ b/purchase_order_line_change_supplier/readme/DESCRIPTION.rst
@@ -1,1 +1,1 @@
-This module permits to change supplier of purchase order line, moving selected lines of a purchase order to a new purchase order of selected supplier.
+This module permits to select purchase order lines of a quotation purchase order and select a supplier. Selected purchase order lines will be moved to an already existing quotation purchase order of a selected supplier, if selected supplier has no quotation purchase order a new one will be created.

--- a/purchase_order_line_change_supplier/readme/DESCRIPTION.rst
+++ b/purchase_order_line_change_supplier/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module permits to change supplier of purchase order line, moving selected lines of a purchase order to a new purchase order of selected supplier.

--- a/purchase_order_line_change_supplier/readme/USAGE.rst
+++ b/purchase_order_line_change_supplier/readme/USAGE.rst
@@ -4,5 +4,5 @@ To use this module:
 * Select the lines you want to change the supplier
 * Click on Actions->Change Supplier
 ** Select the new supplier
-* You will be moved to a new purchsae quotation of selected supplier with the selected lines (these lines were remove from the original purchase quotation to the new one)
- 
+* If selected supplier already has a quotation purchase order, selected lines will be moved to this quotation purchase order. Otherwise, a new quotation purchase order will be created containing selected lines.
+** User interface will display the new (or updated) quotation purchase order.

--- a/purchase_order_line_change_supplier/readme/USAGE.rst
+++ b/purchase_order_line_change_supplier/readme/USAGE.rst
@@ -1,0 +1,8 @@
+To use this module:
+* Go to a Purchases->Requests for Quotation and select one purchase quotation
+* Click on Actions->"View order lines", you will see the list of selected purchase quotation lines
+* Select the lines you want to change the supplier
+* Click on Actions->Change Supplier
+** Select the new supplier
+* You will be moved to a new purchsae quotation of selected supplier with the selected lines (these lines were remove from the original purchase quotation to the new one)
+ 

--- a/purchase_order_line_change_supplier/views/purchase_view.xml
+++ b/purchase_order_line_change_supplier/views/purchase_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<data>
+
+    <act_window id="show_purchase_lines_action"
+        name="Show Purchase Lines"
+        src_model="purchase.order"
+        res_model="purchase.order.line"
+        domain="[('order_id', 'in', active_ids), ('state', '=', 'draft')]"
+        view_type="form" view_mode="tree,form"
+        key2="client_action_multi"/>
+
+</data>
+</odoo>

--- a/purchase_order_line_change_supplier/wizard/__init__.py
+++ b/purchase_order_line_change_supplier/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import change_purchase_line_supplier

--- a/purchase_order_line_change_supplier/wizard/change_purchase_line_supplier.py
+++ b/purchase_order_line_change_supplier/wizard/change_purchase_line_supplier.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo.exceptions import UserError
+
+
+class ChangePurchaseLineSupplierWizard(models.TransientModel):
+    """
+        A wizard to change purchase order line's supplier.
+    """
+
+    _name = 'change.purchase.line.supplier.wizard'
+    _description = 'Change Purchase Line Supplier Wizard'
+
+    supplier_id = fields.Many2one(
+        'res.partner', string='Supplier', domain=[('supplier', '=', True)],
+        required=True)
+
+    @api.multi
+    def confirm_change_purchase_lines_supplier(self):
+        purchase_line_obj = self.env['purchase.order.line']
+
+        self.ensure_one()
+
+        purchase_line_ids = self._context.get('active_ids', False)
+        if not purchase_line_ids:
+            raise UserError(_('There are no lines to change supplier.'))
+        purchase_lines = purchase_line_obj.browse(purchase_line_ids)
+
+        purchase_id = purchase_lines.change_supplier(self.supplier_id.id)
+
+        return {
+            'name': _('Request for Quotation'),
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'purchase.order',
+            'view_id': self.env.ref('purchase.purchase_order_form').id,
+            'type': 'ir.actions.act_window',
+            'res_id': purchase_id,
+            'context': self.env.context,
+            'target': 'current',
+        }

--- a/purchase_order_line_change_supplier/wizard/change_purchase_line_supplier_view.xml
+++ b/purchase_order_line_change_supplier/wizard/change_purchase_line_supplier_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<data>
+    <!-- wizard action on change.purchase.line.supplier -->
+    <act_window id="change_purchase_line_supplier_wizard_action"
+        name="Change Purchase Line Supplier"
+        src_model="purchase.order.line"
+        res_model="change.purchase.line.supplier.wizard"
+        view_type="form" view_mode="form"
+        key2="client_action_multi" target="new"/>
+
+    <!-- wizard view -->
+    <record id="change_purchase_line_supplierwizard_view" model="ir.ui.view">
+        <field name="name">Change Purchase Line Supplier</field>
+        <field name="model">change.purchase.line.supplier.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Change Purchase Line Supplier">
+                <group>
+                    <field name="supplier_id" />
+                </group>
+                <footer>
+                    <button string="Change Purchase Line Supplier" name="confirm_change_purchase_lines_supplier" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</data>
+</odoo>


### PR DESCRIPTION
purchase_order_line_change_supplier permits to select purchase order lines of a quotation purchase order and select a supplier. Selected purchase order lines will be moved to an already existing quotation purchase order of a selected supplier, if selected supplier has no quotation purchase order a new one will be created.