### PR TITLE
[12.0][FIX] purchase_triple_discount: Missing return raises error + s/procurement_rule/stock_rule across repo

### DIFF
--- a/purchase_discount/models/__init__.py
+++ b/purchase_discount/models/__init__.py
@@ -1,6 +1,6 @@
 from . import account_invoice
 from . import purchase_order
 from . import stock_move
-from . import procurement_rule
+from . import stock_rule
 from . import product_supplierinfo
 from . import res_partner

--- a/purchase_discount/models/stock_rule.py
+++ b/purchase_discount/models/stock_rule.py
@@ -3,7 +3,7 @@
 from odoo import api, models
 
 
-class ProcurementRule(models.Model):
+class StockRule(models.Model):
     _inherit = 'stock.rule'
 
     @api.multi

--- a/purchase_discount/tests/test_product_supplierinfo_discount.py
+++ b/purchase_discount/tests/test_product_supplierinfo_discount.py
@@ -64,7 +64,7 @@ class TestProductSupplierinfoDiscount(common.SavepointCase):
             "6 with partner 1 and qty 1")
 
     def test_004_prepare_purchase_order_line(self):
-        procurement_rule = self.env['stock.rule'].create({
+        stock_rule = self.env['stock.rule'].create({
             'sequence': 20,
             'location_id': self.env.ref('stock.stock_location_locations').id,
             'picking_type_id': self.env.ref('stock.chi_picking_type_in').id,
@@ -89,9 +89,9 @@ class TestProductSupplierinfoDiscount(common.SavepointCase):
             'name': 'WH: Stock -> Customers MTO',
             'product_id': self.product.id,
             'date_planned': fields.Datetime.now(),
-            'rule_id': procurement_rule.id,
+            'rule_id': stock_rule.id,
         }
-        res = procurement_rule._prepare_purchase_order_line(
+        res = stock_rule._prepare_purchase_order_line(
             self.product, 50, self.env.ref('uom.product_uom_unit'),
             po_line_vals, self.purchase_order, self.supplierinfo.name,
         )

--- a/purchase_triple_discount/models/stock_rule.py
+++ b/purchase_triple_discount/models/stock_rule.py
@@ -11,9 +11,9 @@ class StockRule(models.Model):
     @api.model
     def _prepare_purchase_order_line_from_seller(self, seller):
         res = super()._prepare_purchase_order_line_from_seller(seller)
-        if not res:
-            return res
-        res.update({
-            'discount2': seller.discount2,
-            'discount3': seller.discount3,
-        })
+        if res:
+            res.update({
+                'discount2': seller.discount2,
+                'discount3': seller.discount3,
+            })
+        return res

--- a/subcontracted_service/init_hook.py
+++ b/subcontracted_service/init_hook.py
@@ -8,10 +8,10 @@ from odoo.api import Environment
 
 def post_init_hook(cr, pool):
     env = Environment(cr, SUPERUSER_ID, {})
-    create_warehouse_procurement_rules(env)
+    create_warehouse_stock_rules(env)
 
 
-def create_warehouse_procurement_rules(env):
+def create_warehouse_stock_rules(env):
     warehouses = env['stock.warehouse'].with_context(
         active_test=False).search([])
     warehouses._set_subcontracting_service_proc_rule()

--- a/subcontracted_service/tests/test_subcontracted_service.py
+++ b/subcontracted_service/tests/test_subcontracted_service.py
@@ -35,7 +35,7 @@ class TestSubcontractedService(TransactionCase):
             limit=1
         )
 
-    def test_wh_procurement_rule(self):
+    def test_wh_stock_rule(self):
         """Tests if the procurement rule for subcontracting services is
         assigned properly to the warehouse."""
         wh = self.test_wh


### PR DESCRIPTION
Changes applied to solve this issue. 

Steps to reproduce:
1. Install purchase_triple_discount and purchase_discount.
2. Add Make to order and Buy route to a product
3. Sale this product, when confirm the Quotation this error prompts.

```
Error:
Odoo Server Error

Traceback (most recent call last):
  File "/home/hveficent/Eficent/odoo/12.0/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/hveficent/Eficent/odoo/12.0/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/home/hveficent/Eficent/odoo/12.0/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/home/hveficent/Eficent/odoo/12.0/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/home/hveficent/Eficent/odoo/12.0/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/hveficent/Eficent/odoo/12.0/odoo/service/model.py", line 97, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/hveficent/Eficent/odoo/12.0/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/hveficent/Eficent/odoo/12.0/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/home/hveficent/Eficent/odoo/12.0/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/home/hveficent/Eficent/odoo/12.0/addons/web/controllers/main.py", line 966, in call_button
    action = self._call_kw(model, method, args, {})
  File "/home/hveficent/Eficent/odoo/12.0/addons/web/controllers/main.py", line 954, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/hveficent/Eficent/odoo/12.0/odoo/api.py", line 759, in call_kw
    return _call_kw_multi(method, model, args, kwargs)
  File "/home/hveficent/Eficent/odoo/12.0/odoo/api.py", line 746, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/hveficent/Eficent/odoo/12.0/addons/sale_management/models/sale_order.py", line 116, in action_confirm
    res = super(SaleOrder, self).action_confirm()
  File "/home/hveficent/Eficent/odoo/12.0/addons/sale/models/sale.py", line 746, in action_confirm
    self._action_confirm()
  File "/home/hveficent/Eficent/odoo/12.0/addons/sale_stock/models/sale_order.py", line 79, in _action_confirm
    order.order_line._action_launch_stock_rule()
  File "/home/hveficent/Eficent/odoo/12.0/addons/procurement_jit/sale.py", line 12, in _action_launch_stock_rule
    res = super(SaleOrderLine, self)._action_launch_stock_rule()
  File "/home/hveficent/Eficent/odoo/12.0/addons/sale_stock/models/sale_order.py", line 410, in _action_launch_stock_rule
    self.env['procurement.group'].run(line.product_id, product_qty, procurement_uom, line.order_id.partner_shipping_id.property_stock_customer, line.name, line.order_id.name, values)
  File "/home/hveficent/Eficent/odoo/12.0/addons/stock/models/stock_rule.py", line 312, in run
    getattr(rule, '_run_%s' % action)(product_id, product_qty, product_uom, location_id, name, origin, values)
  File "/home/hveficent/Eficent/odoo/12.0/addons/stock/models/stock_rule.py", line 190, in _run_pull
    move._action_confirm()
  File "/home/hveficent/Eficent/odoo/12.0/addons/stock/models/stock_move.py", line 770, in _action_confirm
    values)
  File "/home/hveficent/Eficent/odoo/12.0/addons/stock/models/stock_rule.py", line 312, in run
    getattr(rule, '_run_%s' % action)(product_id, product_qty, product_uom, location_id, name, origin, values)
  File "/home/hveficent/Eficent/odoo/addons/addons-12.0/OCA/purchase-workflow/procurement_purchase_no_grouping/models/stock_rule.py", line 19, in _run_buy
    origin, values)
  File "/home/hveficent/Eficent/odoo/12.0/addons/purchase_stock/models/stock_rule.py", line 75, in _run_buy
    vals = self._prepare_purchase_order_line(product_id, product_qty, product_uom, values, po, partner)
  File "/home/hveficent/Eficent/odoo/addons/addons-12.0/OCA/purchase-workflow/purchase_line_procurement_group/models/stock_rule.py", line 15, in _prepare_purchase_order_line
    product_id, product_qty, product_uom, values, po, supplier)
  File "/home/hveficent/Eficent/odoo/addons/addons-12.0/OCA/purchase-workflow/purchase_discount/models/procurement_rule.py", line 22, in _prepare_purchase_order_line
    res.update(self._prepare_purchase_order_line_from_seller(seller))
TypeError: 'NoneType' object is not iterable
```

CC @bealdav @legalsylvain @pedrobaeza 