### PR TITLE
[12.0][FIX] Purchase request incorrect mapping in compute

### DIFF
--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -66,7 +66,8 @@ class StockMove(models.Model):
     @api.depends('purchase_request_allocation_ids')
     def _compute_purchase_request_ids(self):
         for rec in self:
-            rec.purchase_request_ids = rec.purchase_request_allocation_ids.purchase_request_line_id.mapped('request_id')
+            rec.purchase_request_ids = rec.\
+                purchase_request_allocation_ids.purchase_request_line_id.mapped('request_id')
 
     def _merge_moves_fields(self):
         res = super(StockMove, self)._merge_moves_fields()

--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -67,7 +67,9 @@ class StockMove(models.Model):
     def _compute_purchase_request_ids(self):
         for rec in self:
             rec.purchase_request_ids = rec.\
-                purchase_request_allocation_ids.purchase_request_line_id.mapped('request_id')
+            rec.purchase_request_ids = \
+                rec.purchase_request_allocation_ids.\
+                purchase_request_line_id.mapped('request_id')
 
     def _merge_moves_fields(self):
         res = super(StockMove, self)._merge_moves_fields()

--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -66,8 +66,7 @@ class StockMove(models.Model):
     @api.depends('purchase_request_allocation_ids')
     def _compute_purchase_request_ids(self):
         for rec in self:
-            rec.purchase_request_ids = rec.\
-                purchase_request_allocation_ids.mapped('purchase_request_id')
+            rec.purchase_request_ids = rec.purchase_request_allocation_ids.purchase_request_line_id.mapped('request_id')
 
     def _merge_moves_fields(self):
         res = super(StockMove, self)._merge_moves_fields()


### PR DESCRIPTION
Fixes traceback:
`ValueError: <class 'KeyError'>: "purchase_request_id" while evaluating`

purchase_request_allocation_ids doesn't have purchase_request_id field.