### PR TITLE
[FIX] Incorrect mapping in compute

### DIFF
--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -67,7 +67,7 @@ class StockMove(models.Model):
     def _compute_purchase_request_ids(self):
         for rec in self:
             rec.purchase_request_ids = rec.\
-                purchase_request_allocation_ids.mapped('purchase_request_id')
+            purchase_request_allocation_ids.purchase_request_line_id.mapped('request_id')
 
     def _merge_moves_fields(self):
         res = super(StockMove, self)._merge_moves_fields()


### PR DESCRIPTION
Fixes traceback:
ValueError: <class 'KeyError'>: "purchase_request_id" while evaluating

purchase_request_allocation_ids doesn't have purchase_request_id field.

Replaces #792 