### PR TITLE
[12.0][purchase_line_procurement_group] fixes an error that prevented confirming a PO when a product and a service was included

### DIFF
--- a/purchase_line_procurement_group/models/purchase.py
+++ b/purchase_line_procurement_group/models/purchase.py
@@ -21,6 +21,7 @@ class PurchaseOrderLine(models.Model):
     @api.multi
     def _prepare_stock_moves(self, picking):
         res = super()._prepare_stock_moves(picking)
-        res[0]['group_id'] = (
-            self.procurement_group_id.id or self.order_id.group_id.id)
+        if res and res[0] and 'group_id' in res[0]:
+            res[0]['group_id'] = (
+                self.procurement_group_id.id or self.order_id.group_id.id)
         return res


### PR DESCRIPTION
The service does not create a stock move.

Steps to reproduce:
Create a PO with a storable and a service products. Confirm. Boom!

Error:
Odoo Server Error
Traceback (most recent call last):
  File "/.repo_requirements/odoo/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/.repo_requirements/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/.repo_requirements/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/.repo_requirements/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/.repo_requirements/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/service/model.py", line 97, in wrapper
    return f(dbname, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/OCB-12.0/addons/web/controllers/main.py", line 966, in call_button
    action = self._call_kw(model, method, args, {})
  File "/home/odoo/OCB-12.0/addons/web/controllers/main.py", line 954, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 759, in call_kw
    return _call_kw_multi(method, model, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 746, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/build/OCA/purchase-workflow/purchase_request/models/purchase_order.py", line 73, in button_confirm
    res = super(PurchaseOrder, self).button_confirm()
  File "/home/odoo/build/OCA/purchase-workflow/purchase_exception/models/purchase.py", line 62, in button_confirm
    return super(PurchaseOrder, self).button_confirm()
  File "/home/odoo/OCB-12.0/addons/purchase/models/purchase.py", line 331, in button_confirm
    order.button_approve()
  File "/home/odoo/OCB-12.0/addons/purchase_requisition/models/purchase_requisition.py", line 375, in button_approve
    res = super(PurchaseOrder, self).button_approve(force=force)
  File "/home/odoo/build/OCA/purchase-workflow/purchase_order_approved/models/purchase_order.py", line 41, in button_approve
    force=force)
  File "/home/odoo/OCB-12.0/addons/purchase_stock/models/purchase.py", line 87, in button_approve
    self._create_picking()
  File "/home/odoo/OCB-12.0/addons/purchase_stock/models/purchase.py", line 212, in _create_picking
    moves = order.order_line._create_stock_moves(picking)
  File "/home/odoo/build/OCA/purchase-workflow/purchase_location_by_line/models/purchase.py", line 46, in _create_stock_moves
    res = super(PurchaseOrderLine, self)._create_stock_moves(picking)
  File "/home/odoo/build/OCA/purchase-workflow/purchase_delivery_split_date/models/purchase.py", line 59, in _create_stock_moves
    first_picking)
  File "/home/odoo/OCB-12.0/addons/purchase_stock/models/purchase.py", line 360, in _create_stock_moves
    for val in line._prepare_stock_moves(picking):
  File "/home/odoo/build/OCA/purchase-workflow/purchase_request/models/purchase_order.py", line 115, in _prepare_stock_moves
    val = super(PurchaseOrderLine, self)._prepare_stock_moves(picking)
  File "/home/odoo/build/OCA/purchase-workflow/purchase_line_procurement_group/models/purchase.py", line 25, in _prepare_stock_moves
    self.procurement_group_id.id or self.order_id.group_id.id)
IndexError: list index out of range