### PR TITLE
[IMP] purchase_order_product_recommendation: more filters

### DIFF
--- a/purchase_order_product_recommendation/i18n/es.po
+++ b/purchase_order_product_recommendation/i18n/es.po
@@ -1,16 +1,15 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* purchase_order_product_recommendation
+#	* purchase_order_product_recommendation
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-01 17:24+0000\n"
-"PO-Revision-Date: 2019-03-01 17:24+0000\n"
+"POT-Creation-Date: 2019-11-27 16:24+0000\n"
+"PO-Revision-Date: 2019-11-27 16:24+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -29,7 +28,7 @@ msgstr "Cancelar"
 #. module: purchase_order_product_recommendation
 #: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__warehouse_ids
 msgid "Constrain search to an specific warehouse"
-msgstr ""
+msgstr "Restringir búsqueda a un almacén concreto"
 
 #. module: purchase_order_product_recommendation
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__create_uid
@@ -41,7 +40,7 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__create_date
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__create_date
 msgid "Created on"
-msgstr "Creado en"
+msgstr "Creado el"
 
 #. module: purchase_order_product_recommendation
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__currency_id
@@ -62,7 +61,12 @@ msgstr "Fecha final"
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__display_name
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__display_name
 msgid "Display Name"
-msgstr "Nombre mostrado"
+msgstr "Nombre a mostrar"
+
+#. module: purchase_order_product_recommendation
+#: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__product_category_ids
+msgid "Filter by product internal category"
+msgstr "Filtrar por categoría interna de producto"
 
 #. module: purchase_order_product_recommendation
 #: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__date_end
@@ -100,13 +104,13 @@ msgstr "Última modificación en"
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__write_uid
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__write_uid
 msgid "Last Updated by"
-msgstr "Última actualización de"
+msgstr "Última actualización por"
 
 #. module: purchase_order_product_recommendation
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__write_date
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__write_date
 msgid "Last Updated on"
-msgstr "Última actualización en"
+msgstr "Última actualización el"
 
 #. module: purchase_order_product_recommendation
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__line_amount
@@ -127,6 +131,11 @@ msgstr "Precio unitario"
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__product_id
 msgid "Product"
 msgstr "Producto"
+
+#. module: purchase_order_product_recommendation
+#: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__product_category_ids
+msgid "Product Categories"
+msgstr "Categorías de productos"
 
 #. module: purchase_order_product_recommendation
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__line_ids
@@ -189,26 +198,27 @@ msgid "Recommended products for current purchase order"
 msgstr "Productos recomendados para el pedido de compra en curso"
 
 #. module: purchase_order_product_recommendation
-#: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_partner_products
-msgid "Show all products"
-msgstr "Mostrar todos los productos"
-
-#. module: purchase_order_product_recommendation
 #: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_partner_products
 msgid "Show all products with supplier infos for this supplier"
 msgstr "Mostrar todos los productos con tarifas de compra para este proveedor"
 
 #. module: purchase_order_product_recommendation
-#: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__line_amount
-msgid ""
-"Stablish a limit on how many recommendations you want to get.Leave it as 0 "
-"to set no limit"
-msgstr ""
-"Establezca un límite de cuántas recomendaciones desea obtener. Déjelo en 0 "
-"si no desea límite"
+#: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_products
+msgid "Show all purchasable products"
+msgstr "Mostrar todos los productos comprables"
 
 #. module: purchase_order_product_recommendation
-#: code:addons/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py:62
+#: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_partner_products
+msgid "Show all supplier products"
+msgstr "Mostrar todos los productos del proveedor"
+
+#. module: purchase_order_product_recommendation
+#: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__line_amount
+msgid "Stablish a limit on how many recommendations you want to get.Leave it as 0 to set no limit"
+msgstr "Establezca un límite de cuántas recomendaciones desea obtener. Déjelo en 0 si no desea límite"
+
+#. module: purchase_order_product_recommendation
+#: code:addons/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py:72
 #, python-format
 msgid "This wizard is only valid for purchases"
 msgstr "Este asistente solo es válido para compras"
@@ -252,6 +262,11 @@ msgstr "Unidades recibidas"
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__units_virtual_available
 msgid "Units Virtual Available"
 msgstr "Cantidad prevista"
+
+#. module: purchase_order_product_recommendation
+#: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_products
+msgid "Useful if a product hasn't been selled by the partner yet"
+msgstr "Resulta útil si un producto aún no ha sido vendido por el proveedor."
 
 #. module: purchase_order_product_recommendation
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__partner_id

--- a/purchase_order_product_recommendation/i18n/purchase_order_product_recommendation.pot
+++ b/purchase_order_product_recommendation/i18n/purchase_order_product_recommendation.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-11-29 16:18+0000\n"
+"PO-Revision-Date: 2019-11-29 16:18+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -59,6 +61,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__display_name
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: purchase_order_product_recommendation
+#: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__product_category_ids
+msgid "Filter by product internal category"
 msgstr ""
 
 #. module: purchase_order_product_recommendation
@@ -126,6 +133,11 @@ msgid "Product"
 msgstr ""
 
 #. module: purchase_order_product_recommendation
+#: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__product_category_ids
+msgid "Product Categories"
+msgstr ""
+
+#. module: purchase_order_product_recommendation
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__line_ids
 msgid "Products"
 msgstr ""
@@ -186,13 +198,18 @@ msgid "Recommended products for current purchase order"
 msgstr ""
 
 #. module: purchase_order_product_recommendation
-#: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_partner_products
-msgid "Show all products"
+#: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_partner_products
+msgid "Show all products with supplier infos for this supplier"
 msgstr ""
 
 #. module: purchase_order_product_recommendation
-#: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_partner_products
-msgid "Show all products with supplier infos for this supplier"
+#: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_products
+msgid "Show all purchasable products"
+msgstr ""
+
+#. module: purchase_order_product_recommendation
+#: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_partner_products
+msgid "Show all supplier products"
 msgstr ""
 
 #. module: purchase_order_product_recommendation
@@ -201,7 +218,7 @@ msgid "Stablish a limit on how many recommendations you want to get.Leave it as 
 msgstr ""
 
 #. module: purchase_order_product_recommendation
-#: code:addons/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py:62
+#: code:addons/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py:72
 #, python-format
 msgid "This wizard is only valid for purchases"
 msgstr ""
@@ -247,6 +264,11 @@ msgid "Units Virtual Available"
 msgstr ""
 
 #. module: purchase_order_product_recommendation
+#: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation__show_all_products
+msgid "Useful if a product hasn't been selled by the partner yet"
+msgstr ""
+
+#. module: purchase_order_product_recommendation
 #: model:ir.model.fields,field_description:purchase_order_product_recommendation.field_purchase_order_recommendation_line__partner_id
 msgid "Vendor"
 msgstr ""
@@ -270,4 +292,3 @@ msgstr ""
 #: model:ir.model.fields,help:purchase_order_product_recommendation.field_purchase_order_recommendation_line__partner_id
 msgid "You can find a vendor by its Name, TIN, Email or Internal Reference."
 msgstr ""
-

--- a/purchase_order_product_recommendation/readme/USAGE.rst
+++ b/purchase_order_product_recommendation/readme/USAGE.rst
@@ -12,5 +12,8 @@ customer locations, and finally it makes a simple estimation of how many
 quantites would be necesary to order given the forcasted stock and the computed
 demand.
 
+If you want to constrain results to only some categories, you can also select
+them in the wizard.
+
 If you have multiple warehouses, you can also constrain the recommendations to
 the deliveries of specific ones.

--- a/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py
+++ b/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py
@@ -43,9 +43,19 @@ class PurchaseOrderRecommendation(models.TransientModel):
              'Leave it as 0 to set no limit',
     )
     show_all_partner_products = fields.Boolean(
-        string='Show all products',
+        string='Show all supplier products',
         default=False,
         help='Show all products with supplier infos for this supplier',
+    )
+    show_all_products = fields.Boolean(
+        string='Show all purchasable products',
+        default=False,
+        help="Useful if a product hasn't been selled by the partner yet",
+    )
+    product_category_ids = fields.Many2many(
+        comodel_name='product.category',
+        string="Product Categories",
+        help='Filter by product internal category',
     )
     warehouse_ids = fields.Many2many(
         comodel_name='stock.warehouse',
@@ -68,17 +78,29 @@ class PurchaseOrderRecommendation(models.TransientModel):
         day = (self.date_end + timedelta(days=1) - self.date_begin).days
         return day
 
-    @api.multi
-    def _find_move_line(self, src='internal', dst='customer'):
-        """"Returns a dictionary from the move lines in a range of dates
-            from and to given location types"""
+    def _get_supplier_products(self):
+        """Common method to be used for field domain filters"""
         supplierinfo_obj = self.env['product.supplierinfo'].with_context(
             prefetch_fields=False)
         partner = self.order_id.partner_id.commercial_partner_id
         supplierinfos = supplierinfo_obj.search([('name', '=', partner.id)])
         product_tmpls = supplierinfos.mapped('product_tmpl_id')
         products = supplierinfos.mapped('product_id')
-        products |= product_tmpls.mapped('product_variant_ids')
+        products += product_tmpls.mapped('product_variant_ids')
+        return products
+
+    def _get_products(self):
+        """Override to filter products show_all_partner_products is set"""
+        products = self._get_supplier_products()
+        # Filter products by category if set.
+        # It will apply to show_all_partner_products as well
+        if self.product_category_ids:
+            products = products.filtered(
+                lambda x: x.categ_id in self.product_category_ids)
+        return products
+
+    def _get_move_line_domain(self, products, src, dst):
+        """Allows to easily extend the domain by third modules"""
         combine = datetime.combine
         domain = [
             ('product_id', 'in', products.ids),
@@ -91,6 +113,23 @@ class PurchaseOrderRecommendation(models.TransientModel):
         if self.warehouse_ids:
             domain += [('picking_id.picking_type_id.warehouse_id', 'in',
                         self.warehouse_ids.ids)]
+        return domain
+
+    def _get_all_products_domain(self):
+        """Override to add more product filters if show_all_products is set"""
+        domain = [
+            ('purchase_ok', '=', True),
+        ]
+        if self.product_category_ids:
+            domain += [('categ_id', 'in', self.product_category_ids.ids)]
+        return domain
+
+    @api.multi
+    def _find_move_line(self, src='internal', dst='customer'):
+        """"Returns a dictionary from the move lines in a range of dates
+            from and to given location types"""
+        products = self._get_products()
+        domain = self._get_move_line_domain(products, src, dst)
         found_lines = self.env['stock.move.line'].read_group(
             domain, ['product_id', 'qty_done'], ['product_id'])
         # Manual ordering that circumvents ORM limitations
@@ -110,8 +149,12 @@ class PurchaseOrderRecommendation(models.TransientModel):
             'qty_done': x['qty_done']
         } for x in found_lines]
         found_lines = {l['id']: l for l in found_lines}
+        # Show every purchaseable product
+        if self.show_all_products:
+            products += self.env['product.product'].search(
+                self._get_all_products_domain())
         # Show all products with supplier infos belonging to a partner
-        if self.show_all_partner_products:
+        if self.show_all_partner_products or self.show_all_products:
             for product in products.filtered(
                     lambda p: p.id not in found_lines.keys()):
                 found_lines.update({
@@ -163,7 +206,8 @@ class PurchaseOrderRecommendation(models.TransientModel):
 
     @api.multi
     @api.onchange('order_id', 'date_begin', 'date_end', 'line_amount',
-                  'show_all_partner_products', 'warehouse_ids')
+                  'show_all_partner_products', 'show_all_products',
+                  'product_category_ids', 'warehouse_ids')
     def _generate_recommendations(self):
         """Generate lines according to received and delivered items"""
         self.line_ids = False

--- a/purchase_order_product_recommendation/wizards/purchase_order_recommendation_view.xml
+++ b/purchase_order_product_recommendation/wizards/purchase_order_recommendation_view.xml
@@ -8,17 +8,23 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
-                    <group>
-                        <field name="order_id" invisible="1"/>
-                        <field name="warehouse_count" invisible="1"/>
-                        <field name="date_begin"/>
-                        <field name="date_end"/>
-                        <field name="warehouse_ids"
-                               widget="many2many_tags"
-                               options="{'no_open': True, 'no_create': True}"
-                               attrs="{'invisible': [('warehouse_count', '&lt;', 2)]}"/>
-                        <field name="line_amount"/>
-                        <field name="show_all_partner_products"/>
+                    <group name="group_sup">
+                        <group name="col_left">
+                            <field name="order_id" invisible="1"/>
+                            <field name="warehouse_count" invisible="1"/>
+                            <field name="date_begin"/>
+                            <field name="date_end"/>
+                            <field name="product_category_ids" widget="many2many_tags" options="{'no_create': True}"/>
+                            <field name="warehouse_ids"
+                                widget="many2many_tags"
+                                options="{'no_open': True, 'no_create': True}"
+                                attrs="{'invisible': [('warehouse_count', '&lt;', 2)]}"/>
+                            <field name="line_amount"/>
+                        </group>
+                        <group name="col_right">
+                            <field name="show_all_partner_products" attrs="{'invisible': [('show_all_products', '!=', False)]}"/>
+                            <field name="show_all_products"/>
+                        </group>
                     </group>
                     <group>
                         <field name="line_ids" nolabel="1">


### PR DESCRIPTION
Bring changes from https://github.com/OCA/purchase-workflow/pull/805 as well as split tests for better inherability

- Extract domain build to an independent method for easy extension by
third modules
- Extract product filter to an independent method for easy extension.
- New product internal category filter.
- New "Show all products" filter that allows to easily show all
purchable products.
- Make tests extensible by other modules

cc @Tecnativa TT20722