### PR TITLE
[FIX] purchase_order_general_discount: reset to default

### DIFF
--- a/purchase_order_general_discount/models/res_config_settings.py
+++ b/purchase_order_general_discount/models/res_config_settings.py
@@ -8,6 +8,5 @@ class ResConfigSettings(models.TransientModel):
 
     purchase_general_discount_field = fields.Selection(
         related='company_id.purchase_general_discount_field',
-        default='discount',
         readonly=False,
     )


### PR DESCRIPTION
- A related field shoudn't have a default value. This was making the
setting to be reset from time to time.

cc @Tecnativa TT20861