### PR TITLE
[FIX] purchase_order_product_recommendation_brand: onchange fields

### DIFF
--- a/purchase_order_product_recommendation_brand/README.rst
+++ b/purchase_order_product_recommendation_brand/README.rst
@@ -42,6 +42,14 @@ To use this module, you need to:
 #. Press *Recommended Products* button.
 #. Now you can also filter by product brands.
 
+Known issues / Roadmap
+======================
+
+* Due to `api.onchange` overriding limitations the full original list of
+  fields for `_generate_recommendations` is copied here so we can add the new
+  `product_brand_ids` field. This can cause that other modules extending
+  `purchase_order_product_recommendation` could shadow this field list.
+
 Bug Tracker
 ===========
 

--- a/purchase_order_product_recommendation_brand/readme/ROADMAP.rst
+++ b/purchase_order_product_recommendation_brand/readme/ROADMAP.rst
@@ -1,0 +1,4 @@
+* Due to `api.onchange` overriding limitations the full original list of
+  fields for `_generate_recommendations` is copied here so we can add the new
+  `product_brand_ids` field. This can cause that other modules extending
+  `purchase_order_product_recommendation` could shadow this field list.

--- a/purchase_order_product_recommendation_brand/static/description/index.html
+++ b/purchase_order_product_recommendation_brand/static/description/index.html
@@ -373,11 +373,12 @@ ul.auto-toc {
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -392,8 +393,17 @@ ul.auto-toc {
 <li>Now you can also filter by product brands.</li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>Due to <cite>api.onchange</cite> overriding limitations the full original list of
+fields for <cite>_generate_recommendations</cite> is copied here so we can add the new
+<cite>product_brand_ids</cite> field. This can cause that other modules extending
+<cite>purchase_order_product_recommendation</cite> could shadow this field list.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/purchase-workflow/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -401,15 +411,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>David Vidal</li>
@@ -418,7 +428,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/purchase_order_product_recommendation_brand/wizards/purchase_order_recommendation.py
+++ b/purchase_order_product_recommendation_brand/wizards/purchase_order_recommendation.py
@@ -29,7 +29,10 @@ class PurchaseOrderRecommendation(models.TransientModel):
             domain += [('product_brand_id', 'in', self.product_brand_ids.ids)]
         return domain
 
-    @api.onchange('product_brand_ids')
+    @api.onchange(
+        'order_id', 'date_begin', 'date_end', 'line_amount',
+        'show_all_partner_products', 'show_all_products',
+        'product_category_ids', 'warehouse_ids', 'product_brand_ids')
     def _generate_recommendations(self):
         """Just to add field to the onchange method"""
         return super()._generate_recommendations()


### PR DESCRIPTION
* Due to `api.onchange` overriding limitations the full original list of
  fields for `_generate_recommendations` is copied here so we can add the new
  `product_brand_ids` field. This can cause that other modules extending
  `purchase_order_product_recommendation` could shadow this field list.

cc @Tecnativa TT20723