### PR TITLE
[12.0][IMP]purchase_request

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -66,6 +66,7 @@ class PurchaseRequest(models.Model):
     requested_by = fields.Many2one('res.users',
                                    'Requested by',
                                    required=True,
+                                   copy=False,
                                    track_visibility='onchange',
                                    default=_get_default_requested_by)
     assigned_to = fields.Many2one(


### PR DESCRIPTION
`requested_by` should not be copied when duplicating a purchase request

cc @forgeflow