### PR TITLE
[12.0][FIX] purchase_open_qty

### DIFF
--- a/purchase_open_qty/models/purchase_order.py
+++ b/purchase_open_qty/models/purchase_order.py
@@ -26,7 +26,7 @@ class PurchaseOrderLine(models.Model):
                 line.qty_to_invoice = line.product_qty - line.qty_invoiced
 
     @api.depends('move_ids.state', 'move_ids.product_uom',
-                 'move_ids.product_uom_qty')
+                 'move_ids.product_uom_qty', 'order_id.state')
     def _compute_qty_to_receive(self):
         for line in self:
             total = line.product_uom_qty


### PR DESCRIPTION
Quick fix to trigger computation on PO state changed, otherwise it is not computed when the module is installed together with purchase_manual_delivery.

cc ~ @ForgeFlow @JordiBForgeFlow 