### PR TITLE
[10.0][FIX]purchase_order_line_sequence. 

### DIFF
--- a/purchase_order_line_sequence/models/purchase.py
+++ b/purchase_order_line_sequence/models/purchase.py
@@ -31,12 +31,14 @@ class PurchaseOrder(models.Model):
         for order in self:
             if any([ptype in ['product', 'consu'] for ptype in
                     order.order_line.mapped('product_id.type')]):
-                picking = order.picking_ids.filtered(
-                    lambda x: x.state not in ('done', 'cancel'))[0]
-                for move, line in zip(
-                        sorted(picking.move_lines,
-                               key=lambda m: m.id), order.order_line):
-                    move.write({'sequence': line.sequence})
+                pickings = order.picking_ids.filtered(
+                    lambda x: x.state not in ('done', 'cancel'))
+                if pickings:
+                    picking = pickings[0]
+                    for move, line in zip(
+                            sorted(picking.move_lines,
+                                   key=lambda m: m.id), order.order_line):
+                        move.write({'sequence': line.sequence})
         return res
 
     @api.multi


### PR DESCRIPTION
Do not update move sequence in move if not updateable move.

_create_picking method is called on write when decreasing the quantity. If all incoming shipments are done then you get an error on this module.