### PR TITLE
[12.0][FIX]purchase_request. Migration scripts failing.

### DIFF
--- a/purchase_request/migrations/12.0.1.0.0/post-migration.py
+++ b/purchase_request/migrations/12.0.1.0.0/post-migration.py
@@ -120,7 +120,7 @@ def allocate_service(env):
         purchase_request_line = env['purchase.request.line'].browse(
             purchase_request_line_id)
         product_alloc_uom = \
-            purchase_request_line.product_uom_id.id or pol_product_uom
+            purchase_request_line.product_uom_id or pol_product_uom
         pol_product_uom = env['uom.uom'].browse(pol_product_uom)
         product_alloc_qty = pol_product_uom._compute_quantity(
             product_qty, product_alloc_uom)


### PR DESCRIPTION
The method `_compute_quantity` in `uom_uom` requires the object not the id

cc @HviorForgeFlow 