### PR TITLE
[11.0][FIX] last_purchase_price_info: not rounding price to the unit

### DIFF
--- a/purchase_last_price_info/models/product.py
+++ b/purchase_last_price_info/models/product.py
@@ -42,7 +42,8 @@ class ProductProduct(models.Model):
                 # Compute Price Unit in the Product base UoM
                 price_unit_uom = product.product_tmpl_id.uom_id.\
                     _compute_quantity(last_line.price_unit,
-                                      last_line.product_uom)
+                                      last_line.product_uom,
+                                      round=False)
                 last_supplier = last_line.order_id.partner_id
 
             # Assign values to record


### PR DESCRIPTION
It doesn't make sense rounding a price field with a unit measure. I don't know if function _compute_quantity is ok here but in any case, a price must have decimal precision.