### PR TITLE
[12.0][FIX]purchase_request

### DIFF
--- a/purchase_request/models/stock_rule.py
+++ b/purchase_request/models/stock_rule.py
@@ -54,7 +54,8 @@ class StockRule(models.Model):
         )
         gpo = self.group_propagation_option
         group_id = (gpo == 'fixed' and self.group_id.id) or \
-                   (gpo == 'propagate' and values['group_id'].id) or False
+                   (gpo == 'propagate' and values['group_id'] and
+                    values['group_id'].id) or False
         if group_id:
             domain += (
                 ('group_id', '=', group_id),


### PR DESCRIPTION
Fails when there is no group id in values, this happens on automatic reordering like reordering rules scenarios, no manual purchase requests.