### PR TITLE
[IMP] 12.0 purchase_delivery_split_date

### DIFF
--- a/purchase_delivery_split_date/__manifest__.py
+++ b/purchase_delivery_split_date/__manifest__.py
@@ -4,11 +4,11 @@
 
 {
     "name": "Purchase Delivery Split Date",
-    "version": "12.0.1.0.1",
+    "version": "12.0.2.0.0",
     "summary": "Allows Purchase Order you confirm to generate one Incoming "
                "Shipment for each expected date indicated in the Purchase "
                "Order Lines",
-    "author": "Numerigraphe, Eficent, Odoo Community Association (OCA)",
+    "author": "Numerigraphe, Eficent, Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "category": "Purchase Management",
     "license": "AGPL-3",

--- a/purchase_delivery_split_date/readme/CONTRIBUTORS.rst
+++ b/purchase_delivery_split_date/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Lionel Sausin <ls@numerigraphe.com> (modularization for v7+)
 * Jordi Ballester Alomar <jordi.ballester@eficent.com> (modularization v8, v9)
 * Lois Rilo <lois.rilo@eficent.com> (migration to v10)
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>

--- a/purchase_delivery_split_date/readme/HISTORY.rst
+++ b/purchase_delivery_split_date/readme/HISTORY.rst
@@ -1,3 +1,9 @@
+12.0.2.0.0 (2020-04-10)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Improve the module: when changing the date on a purchase line, this will
+  cause a split or a merge of the pickings, to keep 1 picking per date.
+
 
 11.0.1.0.0 (2018-09-16)
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This changeset implements a missing part in the module description. If
you have a purchase order with several lines, confirmed, then you change
the dates on some of the line, this would be reflected in the related
stock moves but not in the stock pickings which would not be split or
merged by date.