### PR TITLE
[FIX] purchase_quick search view primary

### DIFF
--- a/purchase_quick/README.rst
+++ b/purchase_quick/README.rst
@@ -38,31 +38,27 @@ Usage
 
 Inside a purchase order, you can click on "Add products", to open a product tree view, then update "qty to purchase" field.
 
-.. image:: https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/01_purchase_order_create.png
+.. image:: https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/po.png
     :width: 800 px
     :alt: Purchase order create
 
 |
 
-.. image:: https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/02_purchase_order_add_product.png
+.. image:: https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/po-product.png
     :width: 800 px
     :alt: Purchase order Add product
+
+|
+
+.. image:: https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/filter.png
+    :width: 800 px
+    :alt: Filter products
 
 |
 
 The update of "qty to purchase" will add new purchase line or update the existing line. If qty to purchase is 0 it purchase line will deleted if it exists.
 
 |
-
-.. image:: https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/03_purchase_order_updated.png
-    :width: 800 px
-    :alt: Purchase order updated
-
-|
-
-.. image:: https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/04_purchase_order_update_product_qty.png
-    :width: 800 px
-    :alt: Purchase order update product qty.
 
 Known issues / Roadmap
 ======================
@@ -108,6 +104,17 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-PierrickBrun| image:: https://github.com/PierrickBrun.png?size=40px
+    :target: https://github.com/PierrickBrun
+    :alt: PierrickBrun
+.. |maintainer-bealdav| image:: https://github.com/bealdav.png?size=40px
+    :target: https://github.com/bealdav
+    :alt: bealdav
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-PierrickBrun| |maintainer-bealdav| 
 
 This module is part of the `OCA/purchase-workflow <https://github.com/OCA/purchase-workflow/tree/12.0/purchase_quick>`_ project on GitHub.
 

--- a/purchase_quick/__manifest__.py
+++ b/purchase_quick/__manifest__.py
@@ -13,4 +13,5 @@
     "depends": ["base_product_mass_addition", "purchase"],
     "data": ["views/purchase_view.xml", "views/product_view.xml"],
     "installable": True,
+    "maintainers": ["PierrickBrun", "bealdav"],
 }

--- a/purchase_quick/__manifest__.py
+++ b/purchase_quick/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Quick Purchase order",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "license": "AGPL-3",

--- a/purchase_quick/models/purchase_order.py
+++ b/purchase_quick/models/purchase_order.py
@@ -26,6 +26,9 @@ class PurchaseOrder(models.Model):
         res["view_id"] = (
             self.env.ref("purchase_quick.product_tree_view4purchase").id,
         )
+        res["search_view_id"] = (
+            self.env.ref("purchase_quick.product_search_view4purchase").id,
+        )
         return res
 
     def _get_quick_line(self, product):

--- a/purchase_quick/readme/USAGE.rst
+++ b/purchase_quick/readme/USAGE.rst
@@ -1,28 +1,24 @@
 
 Inside a purchase order, you can click on "Add products", to open a product tree view, then update "qty to purchase" field.
 
-.. image:: ../static/description/01_purchase_order_create.png
+.. image:: ../static/description/po.png
     :width: 800 px
     :alt: Purchase order create
 
 |
 
-.. image:: ../static/description/02_purchase_order_add_product.png
+.. image:: ../static/description/po-product.png
     :width: 800 px
     :alt: Purchase order Add product
+
+|
+
+.. image:: ../static/description/filter.png
+    :width: 800 px
+    :alt: Filter products
 
 |
 
 The update of "qty to purchase" will add new purchase line or update the existing line. If qty to purchase is 0 it purchase line will deleted if it exists.
 
 |
-
-.. image:: ../static/description/03_purchase_order_updated.png
-    :width: 800 px
-    :alt: Purchase order updated
-
-|
-
-.. image:: ../static/description/04_purchase_order_update_product_qty.png
-    :width: 800 px
-    :alt: Purchase order update product qty.

--- a/purchase_quick/static/description/index.html
+++ b/purchase_quick/static/description/index.html
@@ -386,11 +386,15 @@ ul.auto-toc {
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id1">Usage</a></h1>
 <p>Inside a purchase order, you can click on “Add products”, to open a product tree view, then update “qty to purchase” field.</p>
-<img alt="Purchase order create" src="https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/01_purchase_order_create.png" style="width: 800px;" />
+<img alt="Purchase order create" src="https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/po.png" style="width: 800px;" />
 <div class="line-block">
 <div class="line"><br /></div>
 </div>
-<img alt="Purchase order Add product" src="https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/02_purchase_order_add_product.png" style="width: 800px;" />
+<img alt="Purchase order Add product" src="https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/po-product.png" style="width: 800px;" />
+<div class="line-block">
+<div class="line"><br /></div>
+</div>
+<img alt="Filter products" src="https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/filter.png" style="width: 800px;" />
 <div class="line-block">
 <div class="line"><br /></div>
 </div>
@@ -398,11 +402,6 @@ ul.auto-toc {
 <div class="line-block">
 <div class="line"><br /></div>
 </div>
-<img alt="Purchase order updated" src="https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/03_purchase_order_updated.png" style="width: 800px;" />
-<div class="line-block">
-<div class="line"><br /></div>
-</div>
-<img alt="Purchase order update product qty." src="https://raw.githubusercontent.com/OCA/purchase-workflow/12.0/purchase_quick/static/description/04_purchase_order_update_product_qty.png" style="width: 800px;" />
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
@@ -441,6 +440,8 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external" href="https://github.com/PierrickBrun"><img alt="PierrickBrun" src="https://github.com/PierrickBrun.png?size=40px" /></a> <a class="reference external" href="https://github.com/bealdav"><img alt="bealdav" src="https://github.com/bealdav.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/purchase-workflow/tree/12.0/purchase_quick">OCA/purchase-workflow</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/purchase_quick/views/product_view.xml
+++ b/purchase_quick/views/product_view.xml
@@ -18,9 +18,10 @@
        </field>
     </record>
 
-    <record id="product_search_form_view" model="ir.ui.view">
+    <record id="product_search_view4purchase" model="ir.ui.view">
         <field name="model">product.product</field>
         <field name="inherit_id" ref="base_product_mass_addition.product_search_form_view"/>
+        <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//filter[last()]" position="after">
                 <filter name="filter_for_current_supplier"


### PR DESCRIPTION
Search view was not primary and the filter added is not useful if not in this context.

Also search_view_id must be forced from the action