### PR TITLE
[12.0][IMP] purchase_landed_cost workflow

### DIFF
--- a/purchase_landed_cost/__manifest__.py
+++ b/purchase_landed_cost/__manifest__.py
@@ -29,6 +29,7 @@
         'views/purchase_expense_type_view.xml',
         'views/purchase_order_view.xml',
         'views/stock_picking_view.xml',
+        'views/res_partner_view.xml',
     ],
     'installable': True,
     'images': [

--- a/purchase_landed_cost/__manifest__.py
+++ b/purchase_landed_cost/__manifest__.py
@@ -30,6 +30,7 @@
         'views/purchase_order_view.xml',
         'views/stock_picking_view.xml',
         'views/res_partner_view.xml',
+        'views/res_config_settings_views.xml',
     ],
     'installable': True,
     'images': [

--- a/purchase_landed_cost/models/__init__.py
+++ b/purchase_landed_cost/models/__init__.py
@@ -3,3 +3,4 @@ from . import purchase_expense_type
 from . import purchase_cost_distribution
 from . import purchase_order
 from . import stock_picking
+from . import res_partner

--- a/purchase_landed_cost/models/purchase_order.py
+++ b/purchase_landed_cost/models/purchase_order.py
@@ -20,6 +20,14 @@ class PurchaseOrder(models.Model):
         compute="_compute_cost_distribution_state", default="", store=True,
     )
 
+    @api.onchange("partner_id", "company_id")
+    def onchange_partner_id(self):
+        res = super(PurchaseOrder, self).onchange_partner_id()
+        self.cost_distribution_ok = (
+            self.partner_id.commercial_partner_id.cost_distribution_ok
+        )
+        return res
+
     @api.multi
     def _compute_is_picking_ok(self):
         """Check if at least one of the Purchase Order's pickings is 'assigned' or

--- a/purchase_landed_cost/models/purchase_order.py
+++ b/purchase_landed_cost/models/purchase_order.py
@@ -2,11 +2,92 @@
 # Copyright 2014-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3
 
-from odoo import api, models
+from odoo import api, models, fields
 
 
 class PurchaseOrder(models.Model):
-    _inherit = 'purchase.order'
+    _inherit = "purchase.order"
+
+    is_picking_ok = fields.Boolean(compute="_compute_is_picking_ok", default=False)
+
+    cost_distribution_ok = fields.Boolean(
+        "Must be linked to Landed Costs",
+        default=False,
+        help="If checked, allow to display Landed Cost buttons",
+    )
+
+    cost_distribution_state = fields.Char(
+        compute="_compute_cost_distribution_state", default="", store=True,
+    )
+
+    @api.multi
+    def _compute_is_picking_ok(self):
+        """Check if at least one of the Purchase Order's pickings is 'assigned' or
+        'done' in order to display Landed Costs options"""
+        for order in self:
+            for picking in order.mapped("picking_ids"):
+                if picking.state in ["assigned", "done"]:
+                    order.is_picking_ok = True
+                    break
+
+    @api.multi
+    @api.depends("order_line", "picking_ids.state")
+    def _compute_cost_distribution_state(self):
+        """Compute the lowest Cost Distribution state of the Cost distribution lines
+        related to the Purchase Order in order to display Landed Cost buttons and filter
+        Purchase Orders depending on this Cost Distribution state"""
+
+        for order in self:
+            lines = self.env["purchase.cost.distribution.line"].search(
+                [("purchase_id", "=", order.id)]
+            )
+            if lines:
+                distributions_states = [line.distribution.state for line in lines]
+                for state in ["draft", "calculated", "done"]:
+                    if state in distributions_states:
+                        order.cost_distribution_state = state
+                        break
+            elif order.is_picking_ok:
+                order.cost_distribution_state = "required"
+
+    @api.multi
+    def button_confirm(self):
+        """Update 'cost_distribution_state' in both Picking and Purchase Order when
+        confirming order (and creating picking)"""
+        res = super().button_confirm()
+        for order in self:
+            order._compute_is_picking_ok()
+            order._compute_cost_distribution_state()
+            for picking in order.mapped("picking_ids"):
+                picking._compute_cost_distribution_state()
+        return res
+
+    @api.multi
+    def action_create_cost_distribution(self):
+        self.ensure_one()
+        line_obj = self.env["purchase.cost.distribution.line"]
+        if not line_obj.search([("purchase_id", "=", self.id)]):
+            # Create a new Cost Distribution
+            distribution = self.env["purchase.cost.distribution"].create({})
+            # Link the Purchase Order's pickings to this new Cost Distribution
+            list_picking_ids = []
+            for picking in self.mapped("picking_ids"):
+                if picking.state in ["assigned", "done"]:
+                    list_picking_ids.append(picking.id)
+            import_picking_wizard = (
+                self.with_context(active_id=distribution.id)
+                .env["picking.import.wizard"]
+                .create(
+                    {
+                        "supplier": self.partner_id.id,
+                        "pickings": [(6, 0, list_picking_ids)],
+                    }
+                )
+            )
+            import_picking_wizard.action_import_picking()
+            # Then display the new Cost Distribution form view
+            lines = line_obj.search([("purchase_id", "=", self.id)])
+            return lines.get_action_purchase_cost_distribution()
 
     @api.multi
     def action_open_landed_cost(self):

--- a/purchase_landed_cost/models/res_partner.py
+++ b/purchase_landed_cost/models/res_partner.py
@@ -1,0 +1,14 @@
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3
+
+from odoo import models, fields
+
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    cost_distribution_ok = fields.Boolean(
+        "Products linked to Landed Costs",
+        default="True",
+        help="""If checked, storable Products from this Vendor will need
+            to be linked to Landed Costs by default""",
+    )

--- a/purchase_landed_cost/models/stock_picking.py
+++ b/purchase_landed_cost/models/stock_picking.py
@@ -1,11 +1,62 @@
 # Copyright 2013 Joaquín Gutierrez
 # Copyright 2014-2016 Tecnativa - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3
-from odoo import api, models
+from odoo import api, models, fields
 
 
 class StockPicking(models.Model):
-    _inherit = 'stock.picking'
+    _inherit = "stock.picking"
+
+    cost_distribution_ok = fields.Boolean(
+        related="purchase_id.cost_distribution_ok",
+        readonly=True,
+        default=False,
+        help="If checked, allow to display Landed Cost buttons",
+    )
+
+    cost_distribution_state = fields.Char(
+        compute="_compute_cost_distribution_state", default="", store=True,
+    )
+
+    @api.multi
+    @api.depends("state")
+    def _compute_cost_distribution_state(self):
+        """Compute the lowest Cost Distribution state of the Cost distribution lines
+        related to the Picking in order to display Landed Cost buttons and filter
+        Pickings depending on this Cost Distribution state"""
+
+        for picking in self:
+            lines = self.env["purchase.cost.distribution.line"].search(
+                [("picking_id", "=", picking.id)]
+            )
+            if lines:
+                distributions_states = [line.distribution.state for line in lines]
+                for state in ["draft", "calculated", "done"]:
+                    if state in distributions_states:
+                        picking.cost_distribution_state = state
+                        break
+            elif picking.state in ["assigned", "done"]:
+                picking.cost_distribution_state = "required"
+
+    @api.multi
+    def action_create_cost_distribution(self):
+        self.ensure_one()
+        line_obj = self.env["purchase.cost.distribution.line"]
+        if not line_obj.search([("picking_id", "=", self.id)]):
+            # Create a new Cost Distribution
+            distribution = self.env["purchase.cost.distribution"].create({})
+            # Link the Picking to this new Cost Distribution
+            import_picking_wizard = (
+                self.with_context(active_id=distribution.id)
+                .env["picking.import.wizard"]
+                .create(
+                    {"supplier": self.partner_id.id, "pickings": [(6, 0, [self.id])]}
+                )
+            )
+            import_picking_wizard.action_import_picking()
+            # Then display the new Cost Distribution form view
+            lines = line_obj.search([("picking_id", "=", self.id)])
+            return lines.get_action_purchase_cost_distribution()
 
     @api.multi
     def action_open_landed_cost(self):

--- a/purchase_landed_cost/views/purchase_order_view.xml
+++ b/purchase_landed_cost/views/purchase_order_view.xml
@@ -5,14 +5,27 @@
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
+            <xpath expr="//button[@name='button_unlock']" position="after">
+                <field name="is_picking_ok" invisible="1" />
+                <field name="cost_distribution_state" invisible="1" />
+                <button name="action_create_cost_distribution" type="object"
+                        string="Register Landed Costs" class="oe_highlight"
+                        attrs="{'invisible': ['|', ('cost_distribution_state', '!=', 'required'),
+                                              ('cost_distribution_ok', '=', False)]}" />
+            </xpath>
             <div name="button_box" position="inside">
-                <button class="oe_stat_button"
-                        name="action_open_landed_cost"
-                        icon="fa-credit-card"
-                        type="object"
-                        string="Landed costs">
-                </button>
+                <button class="oe_stat_button" name="action_open_landed_cost"
+                        icon="fa-credit-card" type="object" string="Landed costs"
+                        attrs="{'invisible': [
+                                '|', '|',
+                                ('is_picking_ok', '!=', True),
+                                ('cost_distribution_ok', '=', False),
+                                ('cost_distribution_state', 'not in', ['draft', 'calculated', 'done']),
+                            ]}" />
             </div>
+            <xpath expr="//field[@name='company_id']/.." position="inside">
+                <field name="cost_distribution_ok" />
+            </xpath>
         </field>
     </record>
 

--- a/purchase_landed_cost/views/purchase_order_view.xml
+++ b/purchase_landed_cost/views/purchase_order_view.xml
@@ -29,4 +29,22 @@
         </field>
     </record>
 
+    <record model="ir.ui.view" id="view_purchase_order_filter">
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.view_purchase_order_filter" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='invoiced']" position="after">
+                <separator />
+                <filter name="distribution_required" string="Required Costs Dist."
+                        domain="[('cost_distribution_state','=', 'required')]" />
+                <filter name="distribution_draft" string="Draft Costs Dist."
+                        domain="[('cost_distribution_state','=', 'draft')]" />
+                <filter name="distribution_calculated" string="Calculated Costs Dist."
+                        domain="[('cost_distribution_state','=', 'calculated')]" />
+                <filter name="distribution_done" string="Done Costs Dist."
+                        domain="[('cost_distribution_state','=', 'done')]" />
+            </xpath>
+        </field>
+    </record>
+
 </odoo>

--- a/purchase_landed_cost/views/res_config_settings_views.xml
+++ b/purchase_landed_cost/views/res_config_settings_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="stock_account.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='module_stock_landed_costs']/../../.." position="attributes">
+                    <attribute name="invisible">True</attribute>
+                </xpath>
+                <xpath expr="//field[@name='module_stock_landed_costs']/../../.." position="after">
+                  <div class="col-12 col-lg-6 mt16 o_settings_container o_setting_box text-muted">
+                      <p>The Odoo core module <b>stock_landed_cost</b> is disabled because the OCA module
+                      <b>purchase_landed_cost</b> is installed and the two modules are incompatible.<br/>
+                      <br/>
+                      To affect landed costs on reception operations, go to the Purchase app and create
+                      a new <b>Cost Distribution</b>.</p>
+                  </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/purchase_landed_cost/views/res_partner_view.xml
+++ b/purchase_landed_cost/views/res_partner_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+
+            <xpath expr="//group[@name='purchase']" position="inside">
+                <field name="cost_distribution_ok"
+                       attrs="{'invisible': ['|', ('supplier', '=', False), ('is_company', '=', False)]}" />
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/purchase_landed_cost/views/stock_picking_view.xml
+++ b/purchase_landed_cost/views/stock_picking_view.xml
@@ -1,18 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-    <record model="ir.ui.view" id="view_picking_form">
+    <record id="view_picking_form" model="ir.ui.view">
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_toggle_is_locked']" position="after">
+              <field name="cost_distribution_state" invisible="1" />
+              <button class="oe_highlight" name="action_create_cost_distribution"
+                      type="object" string="Register Landed Costs"
+                      attrs="{'invisible': ['|', ('cost_distribution_state', '!=', 'required'),
+                          ('cost_distribution_ok', '=', False)]}" />
+            </xpath>
             <div name="button_box" position="inside">
-                <button class="oe_stat_button"
-                        name="action_open_landed_cost"
-                        icon="fa-credit-card"
-                        type="object"
-                        string="Landed costs">
-                </button>
+                <button class="oe_stat_button" name="action_open_landed_cost"
+                        icon="fa-credit-card" type="object" string="Landed costs"
+                        attrs="{'invisible': [
+                                '|', '|',
+                                ('state', 'not in', ['assigned', 'done']),
+                                ('cost_distribution_ok', '=', False),
+                                ('cost_distribution_state', 'not in', ['draft', 'calculated', 'done'])
+                            ]}" />
             </div>
+            <xpath expr="//field[@name='origin']/.." position="inside">
+                <field name="cost_distribution_ok" />
+            </xpath>
         </field>
     </record>
 

--- a/purchase_landed_cost/views/stock_picking_view.xml
+++ b/purchase_landed_cost/views/stock_picking_view.xml
@@ -28,4 +28,22 @@
         </field>
     </record>
 
+    <record id="view_picking_internal_search" model="ir.ui.view">
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_internal_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='backorder']" position="after">
+                <separator />
+                <filter name="distribution_required" string="Required Costs Dist."
+                        domain="[('cost_distribution_state','=', 'required')]" />
+                <filter name="distribution_draft" string="Draft Costs Dist."
+                        domain="[('cost_distribution_state','=', 'draft')]" />
+                <filter name="distribution_calculated" string="Calculated Costs Dist."
+                        domain="[('cost_distribution_state','=', 'calculated')]" />
+                <filter name="distribution_done" string="Done Costs Dist."
+                        domain="[('cost_distribution_state','=', 'done')]" />
+            </xpath>
+        </field>
+    </record>
+
 </odoo>

--- a/purchase_landed_cost/wizard/picking_import_wizard.py
+++ b/purchase_landed_cost/wizard/picking_import_wizard.py
@@ -28,7 +28,9 @@ class PickingImportWizard(models.TransientModel):
     pickings = fields.Many2many(
         comodel_name='stock.picking',
         relation='distribution_import_picking_rel', column1='wizard_id',
-        column2='picking_id', string='Incoming shipments', required=True)
+        column2='picking_id', string='Incoming shipments', required=True,
+        help="Only Pickings in status 'Ready' or 'Done' can be imported\
+        into a Cost Distribution")
     prev_pickings = fields.Many2many(comodel_name='stock.picking')
 
     def _prepare_distribution_line(self, move):

--- a/purchase_landed_cost/wizard/picking_import_wizard_view.xml
+++ b/purchase_landed_cost/wizard/picking_import_wizard_view.xml
@@ -6,6 +6,9 @@
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form string="Select incoming shipment wizard">
+                <p>Select the <b>Incoming shipments</b> on which <b>Expenses</b> will be
+                    affected in order to calculate the operation's products <b>Landed Costs</b>.
+                </p>
                 <group>
                     <field name="prev_pickings" invisible="1" widget="many2many_tags"/>
                     <field name="supplier"/>

--- a/purchase_landed_cost/wizard/picking_import_wizard_view.xml
+++ b/purchase_landed_cost/wizard/picking_import_wizard_view.xml
@@ -6,16 +6,16 @@
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form string="Select incoming shipment wizard">
-                <p>Select the <b>Incoming shipments</b> on which <b>Expenses</b> will be
-                    affected in order to calculate the operation's products <b>Landed Costs</b>.
-                </p>
+              <p>Select the <b>Incoming shipments</b> on which <b>Expenses</b> will be
+                  affected in order to calculate the operation's products <b>Landed Costs</b>.
+              </p>
                 <group>
                     <field name="prev_pickings" invisible="1" widget="many2many_tags"/>
                     <field name="supplier"/>
                     <field name="pickings" widget="many2many_tags"
                            domain="[('partner_id', 'child_of', supplier),
                ('location_id.usage', '=', 'supplier'),
-               ('state', '=', 'done')]"/>
+               ('state', 'in', ['assigned', 'done'])]"/>
                 </group>
                 <footer>
                     <button string="Import"


### PR DESCRIPTION
These 3 commits aim to improve the `purchase_landed_cost` workflow and fix small bugs.

The basic idea is to add the possibility to **create/open a Cost Distribution directly from the Purchase Order/Picking**.
It adds a boolean on the PO and the Picking that allows the user to create/access the related Cost Distribution from there. It also adds an option on `res_partner` in order to pre-fill this boolean on PO and Pickings linked with some specified vendors :
![image](https://user-images.githubusercontent.com/31664455/79916053-7076ff00-83fe-11ea-9955-48aab03075b0.png)


Beside that, the Fix helps linking Invoice Lines with Cost Distribution Expenses even when the user fill the `invoice_line` field directly from the Cost Distribution Expense o2m list without using the button "Import Invoice Line".

What do you think about it @percevaq @pedrobaeza @cubells @ernestotejeda ?

----

Starting from here, I would like to open a discussion about **renaming some variable names** in order to be more meaningful and help users and other developers to understand how the module works.

For instance, objects from `'purchase.cost.distribution.line'` are called in too many different ways :

- `cost_lines` in the model `purchase.cost.distribution `
- `distribution_line` in the model `purchase.cost.distribution.line.expense` 
- `affected_lines` or `imported_lines` in the model `purchase.cost.distribution.expense`
- `dist_line` when needed inside its own model.

... while in fact they all refer to some kind of `stock.move` objects. Thus names like **`moves`**, `distribution_move`, `affected_moves` and `imported_moves` would make more sense, wouldn't they ?
But it may involve to rename the model `'purchase.cost.distribution.move'` and other modifications if you all agree with it.

----

Another renaming work would be on these `'purchase.cost.distribution.line'` fields :

- **`standard_price_old`** doesn't refer to what would be _"the product's standard_price before the picking was done_" as we can imagine, but refers to the Product move's purchase price (via his definition through `dist_line.move_id._get_price_unit()`).
Thus it looks like a duplicate of the other field `product_price_unit` while the real information about _"the product's standard_price before the picking was done_" seems to be quite relevant to be calculated and displayed to the user.
- **`standard_price_new`** doesn't refer to what would be the "_new product's standard_price afther the cost update_", but refer to the (sought-after) product's "_Landed Cost_".
I would suggest to call it `landed_price_unit` if you agree.

**WIP in #901**

----

Finally, it looks like some improvements are needed in the **link between Cost Distribution's Expenses and their related Invoice Lines**.

Firs of all I would suggest to rename the title "_Supplier Invoice line_" into something more relevant like "_Expense Invoice line_" to avoid confusions with the Invoice line linked to the purchase of the product we are updating the price.

Then, the button "_Import from Pickings_" in the Invoice form is not really obvious to use. Maybe a more explicit name like "_Link Invoice Line to Cost Distribution Expense_" would be better, imagining that it would display a wizard allowing to chose a real Cost Distribution Expense object and not a Stock Picking.

----

Thank you very much for your reading,
I hope you found these inputs interesting. Of course I am available to work on the suggestions I made if you agree with some of them and I'm opened to other ideas in order to improve this useful module.

cc @rvalyi 



