### PR TITLE
[12.0][REF] purchase_landed_cost: Rename variables

### DIFF
--- a/purchase_landed_cost/__manifest__.py
+++ b/purchase_landed_cost/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Purchase landed costs - Alternative option',
-    'version': '12.0.1.1.0',
+    'version': '12.0.2.0.0',
     "author": "AvanzOSC,"
               "Tecnativa,"
               "Joaquín Gutierrez,"

--- a/purchase_landed_cost/i18n/es.po
+++ b/purchase_landed_cost/i18n/es.po
@@ -22,8 +22,8 @@ msgid "Affected lines"
 msgstr "Líneas afectadas"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__total_amount
-msgid "Amount line"
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_amount
+msgid "Price amount"
 msgstr "Importe de línea"
 
 #. module: purchase_landed_cost
@@ -496,7 +496,7 @@ msgid "Name"
 msgstr "Nombre"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_new
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__landed_cost_unit
 msgid "New cost"
 msgstr "Nuevo coste"
 
@@ -556,7 +556,7 @@ msgid "Prev Pickings"
 msgstr "Albaranes previos"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_old
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_unit
 msgid "Previous cost"
 msgstr "Coste previo"
 
@@ -821,8 +821,8 @@ msgid "Transfer"
 msgstr "Date of Transfer"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__cost_ratio
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__cost_ratio
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__expense_unit
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__expense_unit
 msgid "Unit cost"
 msgstr "Coste unitario"
 

--- a/purchase_landed_cost/i18n/fr.po
+++ b/purchase_landed_cost/i18n/fr.po
@@ -25,8 +25,8 @@ msgid "Affected lines"
 msgstr "Mouvement de réception affecté"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__total_amount
-msgid "Amount line"
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_amount
+msgid "Price amount"
 msgstr "Montant total"
 
 #. module: purchase_landed_cost
@@ -499,7 +499,7 @@ msgid "Name"
 msgstr "Nom"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_new
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__landed_cost_unit
 msgid "New cost"
 msgstr "Prix d'acquisition"
 
@@ -560,7 +560,7 @@ msgid "Prev Pickings"
 msgstr "Opérations précédentes"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_old
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_unit
 msgid "Previous cost"
 msgstr "Ancien prix de revient"
 
@@ -828,8 +828,8 @@ msgid "Transfer"
 msgstr "Opération de réception"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__cost_ratio
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__cost_ratio
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__expense_unit
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__expense_unit
 msgid "Unit cost"
 msgstr "Frais unitaire"
 

--- a/purchase_landed_cost/i18n/it.po
+++ b/purchase_landed_cost/i18n/it.po
@@ -24,8 +24,8 @@ msgid "Affected lines"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__total_amount
-msgid "Amount line"
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_amount
+msgid "Price amount"
 msgstr ""
 
 #. module: purchase_landed_cost
@@ -491,7 +491,7 @@ msgid "Name"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_new
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__landed_cost_unit
 msgid "New cost"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgid "Prev Pickings"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_old
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_unit
 msgid "Previous cost"
 msgstr ""
 
@@ -800,8 +800,8 @@ msgid "Transfer"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__cost_ratio
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__cost_ratio
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__expense_unit
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__expense_unit
 msgid "Unit cost"
 msgstr ""
 

--- a/purchase_landed_cost/i18n/pt_BR.po
+++ b/purchase_landed_cost/i18n/pt_BR.po
@@ -24,8 +24,8 @@ msgid "Affected lines"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__total_amount
-msgid "Amount line"
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_amount
+msgid "Price amount"
 msgstr ""
 
 #. module: purchase_landed_cost
@@ -493,7 +493,7 @@ msgid "Name"
 msgstr "Nome"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_new
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__landed_cost_unit
 msgid "New cost"
 msgstr ""
 
@@ -555,7 +555,7 @@ msgid "Prev Pickings"
 msgstr "Separação"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_old
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_unit
 msgid "Previous cost"
 msgstr ""
 
@@ -806,8 +806,8 @@ msgid "Transfer"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__cost_ratio
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__cost_ratio
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__expense_unit
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__expense_unit
 msgid "Unit cost"
 msgstr ""
 

--- a/purchase_landed_cost/i18n/purchase_landed_cost.pot
+++ b/purchase_landed_cost/i18n/purchase_landed_cost.pot
@@ -19,8 +19,8 @@ msgid "Affected lines"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__total_amount
-msgid "Amount line"
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_amount
+msgid "Price amount"
 msgstr ""
 
 #. module: purchase_landed_cost
@@ -481,7 +481,7 @@ msgid "Name"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_new
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__landed_cost_unit
 msgid "New cost"
 msgstr ""
 
@@ -540,7 +540,7 @@ msgid "Prev Pickings"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_old
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_unit
 msgid "Previous cost"
 msgstr ""
 
@@ -778,8 +778,8 @@ msgid "Transfer"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__cost_ratio
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__cost_ratio
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__expense_unit
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__expense_unit
 msgid "Unit cost"
 msgstr ""
 

--- a/purchase_landed_cost/i18n/ro.po
+++ b/purchase_landed_cost/i18n/ro.po
@@ -25,8 +25,8 @@ msgid "Affected lines"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__total_amount
-msgid "Amount line"
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_amount
+msgid "Price amount"
 msgstr ""
 
 #. module: purchase_landed_cost
@@ -493,7 +493,7 @@ msgid "Name"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_new
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__landed_cost_unit
 msgid "New cost"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgid "Prev Pickings"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_old
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_unit
 msgid "Previous cost"
 msgstr ""
 
@@ -804,8 +804,8 @@ msgid "Transfer"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__cost_ratio
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__cost_ratio
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__expense_unit
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__expense_unit
 msgid "Unit cost"
 msgstr ""
 

--- a/purchase_landed_cost/i18n/sl.po
+++ b/purchase_landed_cost/i18n/sl.po
@@ -23,9 +23,9 @@ msgid "Affected lines"
 msgstr "Prizadete postavke"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__total_amount
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_amount
 #, fuzzy
-msgid "Amount line"
+msgid "Price amount"
 msgstr "Po znesku postavke"
 
 #. module: purchase_landed_cost
@@ -505,7 +505,7 @@ msgid "Name"
 msgstr "Naziv"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_new
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__landed_cost_unit
 #, fuzzy
 msgid "New cost"
 msgstr "Stroški iztovarjanja"
@@ -569,7 +569,7 @@ msgid "Prev Pickings"
 msgstr "Prejšnji zbirniki"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_old
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_unit
 msgid "Previous cost"
 msgstr "Prejšnji stroški"
 
@@ -834,8 +834,8 @@ msgid "Transfer"
 msgstr ""
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__cost_ratio
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__cost_ratio
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__expense_unit
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__expense_unit
 msgid "Unit cost"
 msgstr "Cena enote"
 

--- a/purchase_landed_cost/i18n/zh_CN.po
+++ b/purchase_landed_cost/i18n/zh_CN.po
@@ -22,8 +22,8 @@ msgid "Affected lines"
 msgstr "受影响的行"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__total_amount
-msgid "Amount line"
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_amount
+msgid "Price amount"
 msgstr "总计"
 
 #. module: purchase_landed_cost
@@ -486,7 +486,7 @@ msgid "Name"
 msgstr "名称"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_new
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__landed_cost_unit
 msgid "New cost"
 msgstr "新的成本"
 
@@ -545,7 +545,7 @@ msgid "Prev Pickings"
 msgstr "上一个拣货"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__standard_price_old
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__product_price_unit
 msgid "Previous cost"
 msgstr "以前的费用"
 
@@ -784,8 +784,8 @@ msgid "Transfer"
 msgstr "调拨"
 
 #. module: purchase_landed_cost
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__cost_ratio
-#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__cost_ratio
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line__expense_unit
+#: model:ir.model.fields,field_description:purchase_landed_cost.field_purchase_cost_distribution_line_expense__expense_unit
 msgid "Unit cost"
 msgstr "单位成本"
 

--- a/purchase_landed_cost/migrations/12.0.2.0.0/pre-migration.py
+++ b/purchase_landed_cost/migrations/12.0.2.0.0/pre-migration.py
@@ -1,0 +1,49 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+
+    # Force delete old `product_price_unit` field as the name will be reused
+    # to rename `standard_price_old`
+    env.ref(
+        "purchase_landed_cost.field_purchase_cost_distribution_line__product_price_unit"
+    ).with_context({"_force_unlink": True}).unlink()
+
+    openupgrade.rename_fields(
+        env,
+        [
+            (
+                "purchase.cost.distribution.line",
+                "purchase_cost_distribution_line",
+                "standard_price_old",
+                "product_price_unit",
+            ),
+            (
+                "purchase.cost.distribution.line",
+                "purchase_cost_distribution_line",
+                "total_amount",
+                "product_price_amount",
+            ),
+            (
+                "purchase.cost.distribution.line",
+                "purchase_cost_distribution_line",
+                "standard_price_new",
+                "landed_cost_unit",
+            ),
+            (
+                "purchase.cost.distribution.line",
+                "purchase_cost_distribution_line",
+                "cost_ratio",
+                "expense_unit",
+            ),
+            (
+                "purchase.cost.distribution.line.expense",
+                "purchase_cost_distribution_line_expense",
+                "cost_ratio",
+                "expense_unit",
+            ),
+        ],
+    )

--- a/purchase_landed_cost/tests/test_purchase_landed_cost.py
+++ b/purchase_landed_cost/tests/test_purchase_landed_cost.py
@@ -72,6 +72,10 @@ class TestPurchaseLandedCost(common.SavepointCase):
             'code': 'CODE',
             'user_type_id': user_type.id,
         })
+        # Unlink default expenses to avoid unknown results
+        for expense_line in cls.distribution.expense_lines:
+            expense_line.unlink()
+        # Add an expense with an amount of 10.0
         cls.invoice = cls.env['account.invoice'].create({
             'partner_id': cls.supplier.id,
             'type': 'in_invoice',
@@ -107,6 +111,7 @@ class TestPurchaseLandedCost(common.SavepointCase):
             'pickings': [(6, 0, self.picking.ids)],
         })
         wiz.action_import_picking()
+
         self.assertEqual(len(self.distribution.cost_lines.ids), 1)
         self.assertAlmostEqual(self.distribution.total_uom_qty, 5.0)
         self.assertAlmostEqual(self.distribution.total_purchase, 15.0)
@@ -115,9 +120,9 @@ class TestPurchaseLandedCost(common.SavepointCase):
         self.assertEqual(len(self.distribution.expense_lines.ids), 1)
         self.assertAlmostEqual(self.distribution.total_uom_qty, 5.0)
         self.distribution.action_calculate()
-        self.assertAlmostEqual(self.distribution.cost_lines[0].cost_ratio, 2)
+        self.assertAlmostEqual(self.distribution.cost_lines[0].expense_unit, 2)
         self.assertAlmostEqual(self.distribution.total_expense, 10.0)
-        self.assertAlmostEqual(self.distribution.cost_lines[0].cost_ratio, 2)
+        self.assertAlmostEqual(self.distribution.cost_lines[0].expense_unit, 2)
         self.assertEqual(self.distribution.state, 'calculated')
         self.assertAlmostEqual(self.product.standard_price, 3.0)
         self.distribution.action_done()
@@ -146,7 +151,7 @@ class TestPurchaseLandedCost(common.SavepointCase):
         self.assertAlmostEqual(self.distribution.total_uom_qty, 10.0)
         self.assertAlmostEqual(self.distribution.total_purchase, 25.0)
         self.distribution.action_calculate()
-        self.assertAlmostEqual(self.distribution.cost_lines[0].cost_ratio, 1)
+        self.assertAlmostEqual(self.distribution.cost_lines[0].expense_unit, 1)
         self.assertAlmostEqual(self.product.standard_price, 2.5)
         self.distribution.action_done()
         self.assertAlmostEqual(self.product.standard_price, 3.5)
@@ -180,7 +185,7 @@ class TestPurchaseLandedCost(common.SavepointCase):
         self.assertAlmostEqual(self.distribution.total_uom_qty, 10.0)
         self.assertAlmostEqual(self.distribution.total_purchase, 15.0)
         self.distribution.action_calculate()
-        self.assertAlmostEqual(self.distribution.cost_lines[0].cost_ratio, 1)
+        self.assertAlmostEqual(self.distribution.cost_lines[0].expense_unit, 1)
         self.assertAlmostEqual(self.product.standard_price, 2)
         self.distribution.action_done()
         self.assertAlmostEqual(self.product.standard_price, 2.67, 2)

--- a/purchase_landed_cost/views/purchase_cost_distribution_line_expense_view.xml
+++ b/purchase_landed_cost/views/purchase_cost_distribution_line_expense_view.xml
@@ -23,7 +23,7 @@
                 <field name="distribution_line" />
                 <field name="distribution_expense" />
                 <field name="expense_amount" />
-                <field name="cost_ratio" />
+                <field name="expense_unit" />
             </tree>
         </field>
     </record>

--- a/purchase_landed_cost/views/purchase_cost_distribution_view.xml
+++ b/purchase_landed_cost/views/purchase_cost_distribution_view.xml
@@ -143,11 +143,11 @@
                                     <field name="product_id" readonly="1"/>
                                     <field name="product_qty"/>
                                     <field name="product_price_unit"/>
-                                    <field name="total_amount"/>
+                                    <field name="product_price_amount"/>
+                                    <field name="expense_unit"/>
                                     <field name="expense_amount"/>
-                                    <field name="cost_ratio"/>
-                                    <field name="standard_price_old"/>
-                                    <field name="standard_price_new"/>
+                                    <field name="currency_id" invisible="1"/>
+                                    <field name="landed_cost_unit" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                                 </tree>
                             </field>
                         </page>
@@ -226,7 +226,7 @@
                 <field name="product_id" readonly="1"/>
                 <field name="product_qty"/>
                 <field name="product_price_unit"/>
-                <field name="total_amount"/>
+                <field name="product_price_amount"/>
             </tree>
         </field>
     </record>
@@ -257,12 +257,12 @@
                         <field name="product_uom" readonly="1"/>
                         <field name="product_weight" readonly="1"/>
                         <field name="product_volume" readonly="1"/>
-                        <field name="standard_price_old" readonly="1"/>
+                        <field name="product_price_unit" readonly="1"/>
                     </group>
                 </group>
                 <group string="Cost distribution line information">
                     <group>
-                        <field name="total_amount"/>
+                        <field name="product_price_amount"/>
                         <field name="total_volume"/>
                     </group>
                     <group>
@@ -273,7 +273,7 @@
                     <tree string="Cost Line Expenses">
                         <field name="type"/>
                         <field name="expense_amount" sum="Total Expenses"/>
-                        <field name="cost_ratio" sum="Calculated Cost"/>
+                        <field name="expense_unit" sum="Unit Expenses"/>
                     </tree>
                 </field>
             </form>


### PR DESCRIPTION
This PR is linked with #897 where I opened suggestions to improve purchase_landed_cost.

Here, the objective is to :
1. Avoid confusion between product's `standard_price` (which will be modified by clicking on 'Update Cost') and the sought-after "product's Landed Cost"
2. Avoid confusion between the words 'price', 'expenses' and 'cost'. Following the idea that :
    Cost = Price + Expenses

Thus, the following changes were made :

- delete `product_price_unit` (a **related** field to stock move's
`price_unit`)
- rename `standard_price_old` into **`product_price_unit`** (a **calculated**
 field which give stock move's `price_unit`)
- rename `standard_price_new` into **`landed_cost_unit`** (and reset it to
zero when the Cost Distribution calculation is canceled)
- rename `total_amount` into **`product_price_amount`**
- rename `cost_ratio` into **`expense_unit`**

----

The question I ask myself right now is if it will be useful to add two more fields :

- `standard_price_old` which would be the real _"old product's standard_price before the stock_move"_ 
- and `standard_price_new` which would be the real _"new updated product's standard_price after clicking on 'Update Cost' "_

These two fields may be interesting, but it might be difficult to display them on the same o2m tree view which already have 9 columns :

![image](https://user-images.githubusercontent.com/31664455/80656171-e9a5d000-8a56-11ea-856c-ee9a2499fe93.png)
  