### PR TITLE
[12.0][FIX] purchase_open_qty

### DIFF
--- a/purchase_open_qty/readme/CONTRIBUTORS.rst
+++ b/purchase_open_qty/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Miquel Raïch <miquel.raich@eficent.com>
 * Andreas Dian Sukarno Putro <andreasdian777@gmail.com>
+* Eric Antones <eantones@nuobit.com>

--- a/purchase_open_qty/views/purchase_view.xml
+++ b/purchase_open_qty/views/purchase_view.xml
@@ -36,10 +36,10 @@
             <filter name="hide_cancelled" position="after">
                 <filter name="pending_qty_to_invoice"
                         string="Pending Qty to Bill"
-                        domain="[('pending_qty_to_invoice','=',True)]"/>
+                        domain="[('qty_to_invoice','>',0.0)]"/>
                 <filter name="pending_qty_to_receive"
                         string="Pending Qty to Receive"
-                        domain="[('pending_qty_to_receive','=',True)]"/>
+                        domain="[('qty_to_receive','>',0.0)]"/>
             </filter>
         </field>
     </record>


### PR DESCRIPTION
This module introduces two filters, in the Purchase Order Line search view, which use the fields:
* pending_qty_to_invoice
* pending_qty_to_receive

However, those fields are not defined in the model so every time we try to use them it gives an error. This PR fixes that issue by adding those two fields to the purchase.order.line model.

cc ~ @ForgeFlow