### PR TITLE
[IMP] [12.0] purchase_delivery_split_date

### DIFF
--- a/purchase_delivery_split_date/__manifest__.py
+++ b/purchase_delivery_split_date/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Purchase Delivery Split Date",
-    "version": "12.0.2.0.0",
+    "version": "12.0.2.1.0",
     "summary": "Allows Purchase Order you confirm to generate one Incoming "
                "Shipment for each expected date indicated in the Purchase "
                "Order Lines",

--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -77,6 +77,23 @@ class PurchaseOrderLine(models.Model):
             self.mapped('order_id')._check_split_pickings()
         return res
 
+    @api.model
+    def create(self, values):
+        line = super().create(values)
+        if line.order_id.state == 'purchase':
+            line.order_id._check_split_pickings()
+        return line
+
+    @api.onchange('product_qty', 'product_uom')
+    def _onchange_quantity(self):
+        date_planned = self.date_planned
+        res = super()._onchange_quantity()
+        # preserve the date which was presumably set on the PO line if it is
+        # later than the date computed from the Vendor information
+        if self.date_planned <= date_planned:
+            self.date_planned = date_planned
+        return res
+
 
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'

--- a/purchase_delivery_split_date/readme/HISTORY.rst
+++ b/purchase_delivery_split_date/readme/HISTORY.rst
@@ -1,3 +1,13 @@
+12.0.2.1.0 (2020-04-30)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [FIX] when adding a new line on a confirmed PO, split the delivery (this was
+  done only if a date was changed on an existing line)
+* [IMP] when the quantity on a line is changed, the onchange would reset the
+  planned date -> change this to prevent setting a date earlier than the one on
+  the line, since if we are using this module the user probably has manually
+  set the date first
+
 12.0.2.0.0 (2020-04-10)
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
* [FIX] when adding a new line on a confirmed PO, split the delivery (this was
  done only if a date was changed on an existing line)

* [IMP] when the quantity on a line is changed, the onchange would reset the
  planned date -> change this to prevent setting a date earlier than the one on
  the line, since if we are using this module the user probably has manually
  set the date first