### PR TITLE
[12.0] Add module purchase_reception_status

### DIFF
--- a/purchase_reception_status/__init__.py
+++ b/purchase_reception_status/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_reception_status/__manifest__.py
+++ b/purchase_reception_status/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Purchase Reception Status',
+    'version': '12.0.1.0.0',
+    'category': 'Purchases',
+    'license': 'AGPL-3',
+    'summary': 'Add reception status on purchase orders',
+    'author': 'Akretion,Odoo Community Association (OCA)',
+    'maintainers': ['alexis-via'],
+    'website': 'https://github.com/OCA/purchase-workflow',
+    'depends': ['purchase'],
+    'data': [
+        'views/purchase_order.xml',
+    ],
+    'installable': True,
+}

--- a/purchase_reception_status/models/__init__.py
+++ b/purchase_reception_status/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order

--- a/purchase_reception_status/models/purchase_order.py
+++ b/purchase_reception_status/models/purchase_order.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+from odoo.tools import float_compare
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    reception_status = fields.Selection([
+        ('no', 'Nothing Received'),
+        ('partial', 'Partially Received'),
+        ('received', 'Fully Received'),
+        ], compute='_compute_reception_status',
+        string='Reception Status', store=True)
+    force_received = fields.Boolean(
+        string='Force Received',
+        readonly=True, states={'done': [('readonly', False)]}, copy=False,
+        help="If true, the reception status will be forced to Fully Received, "
+        "even if some lines are not fully received. "
+        "To be able to modify this field, you must first lock the order.")
+
+    @api.depends(
+        'state', 'force_received',
+        'order_line.qty_received', 'order_line.product_qty')
+    def _compute_reception_status(self):
+        prec = self.env['decimal.precision'].precision_get(
+            'Product Unit of Measure')
+        for order in self:
+            status = 'no'
+            if order.state in ('purchase', 'done'):
+                if order.force_received:
+                    status = 'received'
+                elif all([
+                        float_compare(
+                            line.qty_received,
+                            line.product_qty,
+                            precision_digits=prec) >= 0
+                        for line in order.order_line]):
+                    status = 'received'
+                elif any([
+                        float_compare(
+                            line.qty_received,
+                            0,
+                            precision_digits=prec) > 0
+                        for line in order.order_line]):
+                    status = 'partial'
+            order.reception_status = status

--- a/purchase_reception_status/readme/CONTRIBUTORS.rst
+++ b/purchase_reception_status/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Alexis de Lattre <alexis.delattre@akretion.com>

--- a/purchase_reception_status/readme/DESCRIPTION.rst
+++ b/purchase_reception_status/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module adds a field *Receiption Status* on purchase orders. On a confirmed purchase order, it can have 3 different values:
+
+* Nothing Received
+* Partially Received
+* Fully Received

--- a/purchase_reception_status/readme/USAGE.rst
+++ b/purchase_reception_status/readme/USAGE.rst
@@ -1,0 +1,1 @@
+If you are part of the *Purchase Manager* group, you can force a confirmed purchase order to **Full Received** status: you should first *lock* the order, then check the field **Force Received** located in the *Other Information* tab.

--- a/purchase_reception_status/views/purchase_order.xml
+++ b/purchase_reception_status/views/purchase_order.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2020 Akretion France (http://www.akretion.com/)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<odoo>
+
+
+<record id="purchase_order_form" model="ir.ui.view">
+    <field name="name">received_status.purchase.order.form</field>
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase.purchase_order_form"/>
+    <field name="arch" type="xml">
+        <field name="invoice_status" position="before">
+            <field name="reception_status" states="purchase,done"/>
+            <field name="force_received" groups="purchase.group_purchase_manager" states="purchase,done"/>
+        </field>
+    </field>
+</record>
+
+<record id="purchase_order_tree" model="ir.ui.view">
+    <field name="name">received_status.purchase.order.tree</field>
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase.purchase_order_tree"/>
+    <field name="arch" type="xml">
+        <field name="invoice_status" position="before">
+            <field name="reception_status"/>
+        </field>
+    </field>
+</record>
+
+<record id="view_purchase_order_filter" model="ir.ui.view">
+    <field name="name">received_status.purchase.order.search</field>
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase.view_purchase_order_filter"/>
+    <field name="arch" type="xml">
+        <filter name="not_invoiced" position="before">
+            <filter name="not_fully_received" string="Not Fully Received" domain="[('reception_status', 'in', ('no', 'partial'))]"/>
+            <filter name="fully_received" string="Fully Received" domain="[('reception_status', '=', 'received')]"/>
+            <separator/>
+        </filter>
+        <group expand="0" position="inside">
+            <filter string="Reception Status" name="reception_status_groupby" context="{'group_by': 'reception_status'}"/>
+        </group>
+    </field>
+</record>
+
+
+</odoo>


### PR DESCRIPTION
I may have missed something, but I didn't find a simple module that would add the reception status of the purchase order. The OCA module purchase_picking_state by @chafique-delli  could do the job, but it depends on purchase_stock. On the long term, I think this module could replace the module purchase_picking_state.

