### PR TITLE
[11.0][FIX] purchase_open_qty: not able to filter by pending/receiving quan…

### DIFF
--- a/purchase_open_qty/readme/CONTRIBUTORS.rst
+++ b/purchase_open_qty/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Miquel Raïch <miquel.raich@eficent.com>
 * Andreas Dian Sukarno Putro <andreasdian777@gmail.com>
+* Eric Antones <eantones@nuobit.com>

--- a/purchase_open_qty/views/purchase_view.xml
+++ b/purchase_open_qty/views/purchase_view.xml
@@ -33,10 +33,10 @@
             <filter name="hide_cancelled" position="after">
                 <filter name="pending_qty_to_invoice"
                         string="Pending Qty to Bill"
-                        domain="[('pending_qty_to_invoice','=',True)]"/>
+                        domain="[('qty_to_invoice','>',0.0)]"/>
                 <filter name="pending_qty_to_receive"
                         string="Pending Qty to Receive"
-                        domain="[('pending_qty_to_receive','=',True)]"/>
+                        domain="[('qty_to_receive','>',0.0)]"/>
             </filter>
         </field>
     </record>


### PR DESCRIPTION
…tity at line level

Wrong filter fields at line level, the module is trying to use the
computed fields of the order instead of the line ones.