### PR TITLE
[12.0] [FIX] purchase_request: disable creation from form view

### DIFF
--- a/purchase_request/views/purchase_request_line_view.xml
+++ b/purchase_request/views/purchase_request_line_view.xml
@@ -38,7 +38,7 @@
         <field name="model">purchase.request.line</field>
         <field name="priority" eval="20"/>
         <field name="arch" type="xml">
-            <form string="Purchase Request Line" duplicate="false">
+            <form string="Purchase Request Line" create="false" duplicate="false">
                 <header>
                     <field name="request_state" widget="statusbar"/>
                 </header>


### PR DESCRIPTION
New purchase request line should not be created from `form` view as well.

Create is already disable on list view at https://github.com/OCA/purchase-workflow/blob/12.0/purchase_request/views/purchase_request_line_view.xml#L9