### PR TITLE
[FIX] purchase_discount: set currency rate correctly

### DIFF
--- a/purchase_discount/tests/test_purchase_discount.py
+++ b/purchase_discount/tests/test_purchase_discount.py
@@ -19,12 +19,20 @@ class TestPurchaseOrder(common.SavepointCase):
             'name': 'Test product 2',
         })
         po_model = cls.env['purchase.order.line']
+        currency_rate_model = cls.env['res.currency.rate']
         # Set the Exchange rate for the currency of the company to 1
         # to avoid issues with rates
-        cls.env['res.currency.rate'].create({
-            'currency_id': cls.env.user.company_id.currency_id.id,
-            'rate': 1.00,
-            'name': fields.Date.today()
+        latest_currency_rate_line = currency_rate_model.search([
+            ('currency_id', '=', cls.env.user.company_id.currency_id.id),
+            ('name', '=', fields.Date.today())], limit=1)
+        if latest_currency_rate_line \
+                and latest_currency_rate_line.rate != 1.0:
+            latest_currency_rate_line.rate = 1.0
+        elif not latest_currency_rate_line:
+            currency_rate_model.create({
+                'currency_id': cls.env.user.company_id.currency_id.id,
+                'rate': 1.00,
+                'name': fields.Date.today()
             })
         cls.purchase_order = cls.env['purchase.order'].create({
             'partner_id': cls.env.ref('base.res_partner_3').id,


### PR DESCRIPTION
As mentioned on https://github.com/OCA/purchase-workflow/pull/923#issuecomment-640065252

Before this commit, we was creating new currency rate for same date which was triggering https://github.com/odoo/odoo/commit/01142701cc566b3084326af9649fd85db02b4220 constraints so the tests were failing.

No we search for currency rate of the same day and set rate to `1.0` or create new rate.