### PR TITLE
[13.0] [FIX] purchase_discount: set currency rate correctly

### DIFF
--- a/purchase_discount/tests/test_purchase_discount.py
+++ b/purchase_discount/tests/test_purchase_discount.py
@@ -19,15 +19,26 @@ class TestPurchaseOrder(common.SavepointCase):
         )
         cls.product_2 = product_obj.create({"name": "Test product 2"})
         po_model = cls.env["purchase.order.line"]
+        currency_rate_model = cls.env["res.currency.rate"]
         # Set the Exchange rate for the currency of the company to 1
         # to avoid issues with rates
-        cls.env["res.currency.rate"].create(
-            {
-                "currency_id": cls.env.user.company_id.currency_id.id,
-                "rate": 1.00,
-                "name": fields.Date.today(),
-            }
+        latest_currency_rate_line = currency_rate_model.search(
+            [
+                ("currency_id", "=", cls.env.user.company_id.currency_id.id),
+                ("name", "=", fields.Date.today()),
+            ],
+            limit=1,
         )
+        if latest_currency_rate_line and latest_currency_rate_line.rate != 1.0:
+            latest_currency_rate_line.rate = 1.0
+        elif not latest_currency_rate_line:
+            currency_rate_model.create(
+                {
+                    "currency_id": cls.env.user.company_id.currency_id.id,
+                    "rate": 1.00,
+                    "name": fields.Date.today(),
+                }
+            )
         cls.purchase_order = cls.env["purchase.order"].create(
             {"partner_id": cls.env.ref("base.res_partner_3").id}
         )


### PR DESCRIPTION
As mentioned on #923 (comment)

Before this commit, we was creating new currency rate for same date which was triggering odoo/odoo@0114270 constraints so the tests were failing.

No we search for currency rate of the same day and set rate to `1.0` or create new rate.