### PR TITLE
[FIX] purchase_triple_discount: bad display of discounts 2 and 3 in supplierinfo form view

### DIFF
--- a/purchase_triple_discount/views/product_supplierinfo_view.xml
+++ b/purchase_triple_discount/views/product_supplierinfo_view.xml
@@ -4,16 +4,10 @@
          <field name="model">product.supplierinfo</field>
          <field name="inherit_id" ref="purchase_discount.product_supplierinfo_form_view"/>
          <field name="arch" type="xml">
-              <xpath expr="//field[@name='discount']/.." position="after">
-                   <label for="discount2"/>
-                   <div>
-                      <field name="discount2" class="oe_inline"/>
-                   </div>
-                   <label for="discount3"/>
-                   <div>
-                      <field name="discount3" class="oe_inline"/>
-                   </div>
-              </xpath>
+              <field name="discount" position="after">
+                  <field name="discount2"/>
+                  <field name="discount3"/>
+              </field>
          </field>
      </record>
 


### PR DESCRIPTION
Trivial patch.

## Before

![image](https://user-images.githubusercontent.com/3407482/84682020-4db42300-af35-11ea-8ea4-3bffefe6100f.png)

## After

![image](https://user-images.githubusercontent.com/3407482/84682229-a1bf0780-af35-11ea-9906-44500c699a7e.png)


Thanks for your review.