### PR TITLE
[FIX] Fix partner product description

### DIFF
--- a/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py
+++ b/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py
@@ -357,5 +357,6 @@ class PurchaseOrderRecommendationLine(models.TransientModel):
         return {
             'order_id': self.wizard_id.order_id.id,
             'product_id': self.product_id.id,
+            'partner_id': self.wizard_id.order_id.partner_id.id,
             'sequence': sequence,
         }


### PR DESCRIPTION
Fix partner product description for recommended products. The partner's description does not appear in the purchase order line.