### PR TITLE
[12.0][FIX] purchase_work_acceptance, no purchase_line_id in wa_line coz of readonly flag

### DIFF
--- a/purchase_work_acceptance/models/work_acceptance.py
+++ b/purchase_work_acceptance/models/work_acceptance.py
@@ -216,7 +216,7 @@ class WorkAcceptanceLine(models.Model):
         string='Purchase Order Line',
         ondelete='set null',
         index=True,
-        readonly=True,
+        readonly=False,
     )
 
     def _compute_amount(self):


### PR DESCRIPTION
When PO -> create WA. The readonly nature of reference purchase_line_id cause no link to WA because purchase_line_id was not written when saved.

Note: I surprise why it works before, but this should be very simple fix to fast forward.