### PR TITLE
[FIX] purchase_work_acceptance: pass context to wa_line_ids

### DIFF
--- a/purchase_work_acceptance/models/work_acceptance.py
+++ b/purchase_work_acceptance/models/work_acceptance.py
@@ -216,7 +216,6 @@ class WorkAcceptanceLine(models.Model):
         string='Purchase Order Line',
         ondelete='set null',
         index=True,
-        readonly=True,
     )
 
     def _compute_amount(self):


### PR DESCRIPTION
Before: don't show related work acceptances on the purchase order
![Peek 2020-07-13 12-04](https://user-images.githubusercontent.com/51266019/87272946-f5574d80-c501-11ea-85dc-5aa4783b3b98.gif)

After: show related work acceptances on the purchase order
![Peek 2020-07-13 12-06](https://user-images.githubusercontent.com/51266019/87272992-191a9380-c502-11ea-9603-34b98efbfb29.gif)
