### PR TITLE
[IMP] procurement_purchase_no_grouping: Add company level policy

### DIFF
--- a/procurement_purchase_no_grouping/README.rst
+++ b/procurement_purchase_no_grouping/README.rst
@@ -26,7 +26,8 @@ Procurement Purchase No Grouping
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
 This module allows to not group generated purchase orders from procurements.
-The grouping behaviour can be configurable at product category level.
+The grouping behaviour can be configurable at product category level or fall back
+to system default.
 
 **Table of contents**
 
@@ -39,11 +40,16 @@ Configuration
 Go to each product category, and select one of these values in the field
 "Procured purchase grouping":
 
-* *Standard grouping (default)*: With this option, procurements will generate
+* *Standard grouping*: With this option, procurements will generate
   purchase orders as always, grouping lines and orders when possible.
 * *No line grouping*: With this value, if there are any open purchase order
   for the same supplier, it will be reused, but lines won't be merged.
 * *No order grouping*: This option will prevent any kind of grouping.
+* *<empty>*: If you select nothing, default value set up in System
+  settings will be applied.
+
+System default behaviour can be set up in System settings / Purchase / Procurement
+Purchase Grouping
 
 Bug Tracker
 ===========
@@ -76,6 +82,7 @@ Contributors
 
 * Ana Juaristi <ajuaristo@gmail.com>
 * Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
+* Radovan Skolnik <radovan@skolnik.info>
 
 Maintainers
 ~~~~~~~~~~~

--- a/procurement_purchase_no_grouping/__manifest__.py
+++ b/procurement_purchase_no_grouping/__manifest__.py
@@ -10,7 +10,7 @@
     "website": "https://github.com/OCA/purchase-workflow",
     "category": "Procurements",
     "depends": ["purchase_stock"],
-    "data": ["views/product_category_view.xml"],
+    "data": ["views/product_category_view.xml", "views/res_config_settings_views.xml"],
     "installable": True,
     "license": "AGPL-3",
 }

--- a/procurement_purchase_no_grouping/models/__init__.py
+++ b/procurement_purchase_no_grouping/models/__init__.py
@@ -1,3 +1,5 @@
 from . import product_category
 from . import stock_rule
 from . import purchase_order
+from . import res_config_settings
+from . import res_company

--- a/procurement_purchase_no_grouping/models/res_company.py
+++ b/procurement_purchase_no_grouping/models/res_company.py
@@ -1,12 +1,11 @@
-# Copyright 2015 AvanzOsc (http://www.avanzosc.es)
-# Copyright 2015-2016 - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2020 - Radovan Skolnik <radovan@skolnik.info>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields, models
 
 
-class ProductCategory(models.Model):
-    _inherit = "product.category"
+class ResCompany(models.Model):
+    _inherit = "res.company"
 
     procured_purchase_grouping = fields.Selection(
         [
@@ -15,15 +14,15 @@ class ProductCategory(models.Model):
             ("order", "No order grouping"),
         ],
         string="Procured purchase grouping",
+        default="standard",
         help="Select the behaviour for grouping procured purchases for the "
         "the products of this category:\n"
-        "* Standard grouping (default): Procurements will generate "
+        "* Standard grouping: Procurements will generate "
         "purchase orders as always, grouping lines and orders when "
         "possible.\n"
         "* No line grouping: If there are any open purchase order for "
         "the same supplier, it will be reused, but lines won't be "
         "merged.\n"
         "* No order grouping: This option will prevent any kind of "
-        "grouping.\n"
-        "* <empty>: If no value is selected, system-wide default will be used.",
+        "grouping.",
     )

--- a/procurement_purchase_no_grouping/models/res_config_settings.py
+++ b/procurement_purchase_no_grouping/models/res_config_settings.py
@@ -1,0 +1,15 @@
+# Copyright 2020 - Radovan Skolnik <radovan@skolnik.info>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    """Configuration of default value for procurement purchase grouping."""
+
+    _inherit = "res.config.settings"
+    _description = "Procurement purchase grouping settings"
+
+    procured_purchase_grouping = fields.Selection(
+        related="company_id.procured_purchase_grouping", readonly=False,
+    )

--- a/procurement_purchase_no_grouping/models/stock_rule.py
+++ b/procurement_purchase_no_grouping/models/stock_rule.py
@@ -1,6 +1,7 @@
 # Copyright 2015 AvanzOsc (http://www.avanzosc.es)
 # Copyright 2015-2016 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Tecnativa - Carlos Dauden
+# Copyright 2020 Radovan Skolnik
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import models
@@ -11,9 +12,10 @@ class StockRule(models.Model):
 
     def _run_buy(self, procurements):
         for procurement, _rule in procurements:
-            procurement.values[
-                "grouping"
-            ] = procurement.product_id.categ_id.procured_purchase_grouping
+            grouping = procurement.product_id.categ_id.procured_purchase_grouping
+            if not grouping:
+                grouping = self.env.company.procured_purchase_grouping
+            procurement.values["grouping"] = grouping
         return super()._run_buy(procurements)
 
     def _make_po_get_domain(self, company_id, values, partner):

--- a/procurement_purchase_no_grouping/readme/CONFIGURE.rst
+++ b/procurement_purchase_no_grouping/readme/CONFIGURE.rst
@@ -1,8 +1,13 @@
 Go to each product category, and select one of these values in the field
 "Procured purchase grouping":
 
-* *Standard grouping (default)*: With this option, procurements will generate
+* *Standard grouping*: With this option, procurements will generate
   purchase orders as always, grouping lines and orders when possible.
 * *No line grouping*: With this value, if there are any open purchase order
   for the same supplier, it will be reused, but lines won't be merged.
 * *No order grouping*: This option will prevent any kind of grouping.
+* *<empty>*: If you select nothing, default value set up in System
+  settings will be applied.
+
+System default behaviour can be set up in System settings / Purchase / Procurement
+Purchase Grouping

--- a/procurement_purchase_no_grouping/readme/CONTRIBUTORS.rst
+++ b/procurement_purchase_no_grouping/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 
 * Ana Juaristi <ajuaristo@gmail.com>
 * Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
+* Radovan Skolnik <radovan@skolnik.info>

--- a/procurement_purchase_no_grouping/readme/DESCRIPTION.rst
+++ b/procurement_purchase_no_grouping/readme/DESCRIPTION.rst
@@ -1,2 +1,3 @@
 This module allows to not group generated purchase orders from procurements.
-The grouping behaviour can be configurable at product category level.
+The grouping behaviour can be configurable at product category level or fall back
+to system default.

--- a/procurement_purchase_no_grouping/static/description/index.html
+++ b/procurement_purchase_no_grouping/static/description/index.html
@@ -369,7 +369,8 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/purchase-workflow/tree/13.0/procurement_purchase_no_grouping"><img alt="OCA/purchase-workflow" src="https://img.shields.io/badge/github-OCA%2Fpurchase--workflow-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/purchase-workflow-13-0/purchase-workflow-13-0-procurement_purchase_no_grouping"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/142/13.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
 <p>This module allows to not group generated purchase orders from procurements.
-The grouping behaviour can be configurable at product category level.</p>
+The grouping behaviour can be configurable at product category level or fall back
+to system default.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -388,12 +389,16 @@ The grouping behaviour can be configurable at product category level.</p>
 <p>Go to each product category, and select one of these values in the field
 “Procured purchase grouping”:</p>
 <ul class="simple">
-<li><em>Standard grouping (default)</em>: With this option, procurements will generate
+<li><em>Standard grouping</em>: With this option, procurements will generate
 purchase orders as always, grouping lines and orders when possible.</li>
 <li><em>No line grouping</em>: With this value, if there are any open purchase order
 for the same supplier, it will be reused, but lines won’t be merged.</li>
 <li><em>No order grouping</em>: This option will prevent any kind of grouping.</li>
+<li><em>&lt;empty&gt;</em>: If you select nothing, default value set up in System
+settings will be applied.</li>
 </ul>
+<p>System default behaviour can be set up in System settings / Purchase / Procurement
+Purchase Grouping</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
@@ -424,6 +429,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </li>
 <li>Ana Juaristi &lt;<a class="reference external" href="mailto:ajuaristo&#64;gmail.com">ajuaristo&#64;gmail.com</a>&gt;</li>
 <li>Alfredo de la Fuente &lt;<a class="reference external" href="mailto:alfredodelafuente&#64;avanzosc.es">alfredodelafuente&#64;avanzosc.es</a>&gt;</li>
+<li>Radovan Skolnik &lt;<a class="reference external" href="mailto:radovan&#64;skolnik.info">radovan&#64;skolnik.info</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/procurement_purchase_no_grouping/views/res_config_settings_views.xml
+++ b/procurement_purchase_no_grouping/views/res_config_settings_views.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record
+        id="res_config_settings_view_form_procurement_purchase_grouping"
+        model="ir.ui.view"
+    >
+        <field
+            name="name"
+        >res.config.settings.view.form.inherit.procurement.purchase.grouping</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="50" />
+        <field name="inherit_id" ref="base.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('settings')]" position="inside">
+                <div
+                    class="app_settings_block"
+                    data-string="Purchase"
+                    string="Purchase"
+                    data-key="purchase"
+                    groups="purchase.group_purchase_manager"
+                >
+                    <h2>Procurement Purchase Grouping</h2>
+                    <div class="row mt16 o_settings_container">
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_right_pane">
+                                <span class="o_form_label">Grouping</span>
+                                <span
+                                    class="fa fa-lg fa-object-group"
+                                    title="Value to be used if individual category is set to 'System default'"
+                                    aria-label="Value set here is default. Specific values are set per category."
+                                    role="img"
+                                />
+                                <div class="text-muted">
+                                    Set the default procurement purchase grouping type
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16 row">
+                                        <label
+                                            for="procured_purchase_grouping"
+                                            string="Grouping"
+                                            class="col-3 col-lg-3 o_light_label"
+                                        />
+                                        <field
+                                            name="procured_purchase_grouping"
+                                            class="oe_inline"
+                                            required="1"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This is my attempt to create a slightly enhanced version of procurement_purchase_no_grouping. The idea here is to provide also System default setting that will cause the logic fall back to system-wide setting set up in System settings. The reason for this is we have more than 250k products in more than 300 categories so setting up each category would be rather laborious. This should also work for existing users - they only need to setup the system-wide default.