### PR TITLE
[FIX] vendor_transport_lead_time: fixing 'delay' field + PO integration

### DIFF
--- a/vendor_transport_lead_time/__manifest__.py
+++ b/vendor_transport_lead_time/__manifest__.py
@@ -3,11 +3,15 @@
 {
     "name": "Vendor transport lead time",
     "summary": "Purchase delay based on transport and supplier delays",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     "website": "https://odoo-community.org/",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["product"],
-    "data": ["views/product_supplierinfo.xml"],
+    "depends": ["product", "purchase"],
+    "data": [
+        "views/product_supplierinfo.xml",
+        "views/purchase_order_line.xml",
+        "report/purchase_order_template.xml",
+    ],
     "installable": True,
 }

--- a/vendor_transport_lead_time/models/__init__.py
+++ b/vendor_transport_lead_time/models/__init__.py
@@ -1,1 +1,2 @@
 from . import product_supplierinfo
+from . import purchase_order_line

--- a/vendor_transport_lead_time/models/purchase_order_line.py
+++ b/vendor_transport_lead_time/models/purchase_order_line.py
@@ -1,0 +1,47 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import api, fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    supplier_date_planned = fields.Datetime(
+        string="Supplier Scheduled Date", compute="_compute_supplier_date_planned",
+    )
+    report_date_planned = fields.Datetime(
+        string="Date planned (used by report)", compute="_compute_report_date_planned",
+    )
+
+    @api.depends("date_planned")
+    def _compute_supplier_date_planned(self):
+        for line in self:
+            line.supplier_date_planned = line._get_supplier_date_planned()
+
+    def _get_supplier_date_planned(self):
+        """Return the datetime value to use as Supplier Schedule Date
+        (``supplier_date_planned``) for the current PO line.
+
+        :rtype: datetime
+        :return: desired Supplier Schedule Date for the PO line or False
+        """
+        self.ensure_one()
+        if not self.product_id or not self.date_planned:
+            return False
+        seller = self.product_id._select_seller(
+            partner_id=self.partner_id,
+            quantity=self.product_qty,
+            date=self.order_id.date_order and self.order_id.date_order.date(),
+            uom_id=self.product_uom,
+        )
+        if not seller:
+            return False
+        return fields.Datetime.subtract(self.date_planned, days=seller.transport_delay)
+
+    def _compute_report_date_planned(self):
+        for line in self:
+            line.report_date_planned = line.date_planned
+            if line.date_planned and line.supplier_date_planned:
+                if line.supplier_date_planned < line.date_planned:
+                    line.report_date_planned = line.supplier_date_planned

--- a/vendor_transport_lead_time/report/purchase_order_template.xml
+++ b/vendor_transport_lead_time/report/purchase_order_template.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2020 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="report_purchaseorder_document"
+        inherit_id="purchase.report_purchaseorder_document"
+    >
+        <span t-field="line.date_planned" position="attributes">
+            <attribute name="style">display: None;</attribute>
+        </span>
+        <span t-field="line.date_planned" position="after">
+            <span t-field="line.report_date_planned" />
+        </span>
+    </template>
+</odoo>

--- a/vendor_transport_lead_time/tests/__init__.py
+++ b/vendor_transport_lead_time/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_delay
+from . import test_purchase_order

--- a/vendor_transport_lead_time/tests/test_purchase_order.py
+++ b/vendor_transport_lead_time/tests/test_purchase_order.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields
+from odoo.tests.common import Form, SavepointCase
+
+
+class TestPurchaseOrderDelay(SavepointCase):
+    at_install = False
+    post_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.vendor = cls.env["res.partner"].create({"name": "vendor1"})
+        cls.product_consu = cls.env["product.product"].create(
+            {
+                "name": "Product A",
+                "type": "consu",
+                "seller_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": cls.vendor.id,
+                            "min_qty": 1,
+                            "price": 10,
+                            "supplier_delay": 6,
+                            "transport_delay": 4,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_supplier_date_planned(self):
+        po = Form(self.env["purchase.order"])
+        po.partner_id = self.vendor
+        po.date_order = "2020-08-10"
+        with po.order_line.new() as po_line:
+            po_line.product_id = self.product_consu
+            po_line.product_qty = 1
+            self.assertEqual(po_line.price_unit, 10)
+            self.assertEqual(fields.Date.to_string(po_line.date_planned), "2020-08-20")
+            self.assertEqual(
+                fields.Date.to_string(po_line.supplier_date_planned), "2020-08-16"
+            )

--- a/vendor_transport_lead_time/views/product_supplierinfo.xml
+++ b/vendor_transport_lead_time/views/product_supplierinfo.xml
@@ -7,6 +7,9 @@
         <field name="model">product.supplierinfo</field>
         <field name="inherit_id" ref="product.product_supplierinfo_form_view" />
         <field name="arch" type="xml">
+            <field name="delay" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </field>
             <xpath expr="//field[@name='product_id']" position="after">
                 <label for="supplier_delay" />
                 <div>

--- a/vendor_transport_lead_time/views/purchase_order_line.xml
+++ b/vendor_transport_lead_time/views/purchase_order_line.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2020 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field name="name">purchase.order.form.inherit</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']/tree/field[@name='date_planned']"
+                position="after"
+            >
+                <field name="supplier_date_planned" optional="hide" />
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']/form//field[@name='date_planned']"
+                position="after"
+            >
+                <!-- widget="date" like 'date_planned' field -->
+                <field name="supplier_date_planned" widget="date" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
About the fix:

* move the constraint in a `@api.constrains` method
* able to create a seller (with 'create' method) without filling the `delay` field
* if we set `delay` when calling 'create', it takes precedence over other delay fields (inverse method is called)
* to make thing working, `delay` should not be required anymore
* do not override the `delay` user's label