### PR TITLE
[12.0][IMP] purchase_order_uninvoiced_amount: Be compatible with purchase_discount

### DIFF
--- a/purchase_order_uninvoiced_amount/models/purchase_order.py
+++ b/purchase_order_uninvoiced_amount/models/purchase_order.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Tecnativa - Manuel Calero
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
@@ -11,10 +12,14 @@ class PurchaseOrder(models.Model):
     def _compute_amount_uninvoiced(self):
         for order in self:
             amount_uninvoiced = order.amount_untaxed
-
-            for line in order.order_line.filtered(lambda x: (x.qty_invoiced != 0)):
-                amount_uninvoiced -= line.qty_invoiced * line.price_unit
-
+            for line in order.order_line.filtered("qty_invoiced"):
+                # we use this way for being compatible with purchase_discount
+                price_unit = (
+                    line.product_qty and
+                    line.price_subtotal / line.product_qty or
+                    line.price_unit
+                )
+                amount_uninvoiced -= line.qty_invoiced * price_unit
             order.update({
                 'amount_uninvoiced': order.currency_id.round(amount_uninvoiced),
             })

--- a/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
+++ b/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Tecnativa - Manuel Calero
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo.tests.common import SavepointCase
@@ -105,3 +106,7 @@ class TestPurchaseOrderUninvoiceAmount(SavepointCase):
         self._create_invoice_from_purchase(purchase)
         self.assertEquals(purchase.amount_uninvoiced, 0,
                           "The purchase amount uninvoiced must be 0")
+
+    def test_create_purchase_qty_0(self):
+        purchase = self._create_purchase(0, 0)
+        self.assertEquals(purchase.amount_uninvoiced, 0)


### PR DESCRIPTION
If we use such module, the final price is not the PO line price unit, so we need to extract the unit price from the subtotal divided by the quantity instead for getting a proper result on both cases.

@Tecnativa TT25368