### PR TITLE
[IMP] purchase_request: Speed up stock_move company constraint

### DIFF
--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -18,11 +18,13 @@ class PurchaseRequestAllocation(models.Model):
                                  comodel_name='res.company',
                                  readonly=True,
                                  related='purchase_request_line_id.request_id.'
-                                         'company_id'
+                                         'company_id',
+                                 store=True, index=True,
                                  )
     stock_move_id = fields.Many2one(string='Stock Move',
                                     comodel_name='stock.move',
                                     ondelete='cascade',
+                                    index=True,
                                     )
     purchase_line_id = fields.Many2one(
         string='Purchase Line',

--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -77,10 +77,18 @@ class StockMove(models.Model):
 
     @api.constrains('company_id')
     def _check_company_purchase_request(self):
-        if any(self.env['purchase.request.allocation'].search(
-                [('company_id', '!=', rec.company_id.id),
-                 ('stock_move_id', '=', rec.id)], limit=1)
-               for rec in self):
+        if not self.ids:
+            return
+        self.env.cr.execute("""
+            SELECT 1
+            FROM purchase_request_allocation pra
+            INNER JOIN stock_move sm
+               ON sm.id=pra.stock_move_id
+            WHERE pra.company_id != sm.company_id
+                AND sm.id IN %s
+            LIMIT 1
+        """, (tuple(self.ids),))
+        if self.env.cr.fetchone():
             raise ValidationError(
                 _('The company of the purchase request must match with '
                   'that of the location.'))

--- a/purchase_request/tests/test_purchase_request_allocation.py
+++ b/purchase_request/tests/test_purchase_request_allocation.py
@@ -280,3 +280,6 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
         self.assertEquals(len(purchase_request_line1.purchase_lines), 0)
         self.assertEquals(
             len(purchase_request_line1.purchase_request_allocation_ids), 0)
+
+    def test_empty_records_for_company_constraint(self):
+        self.assertFalse(self.env['stock.move']._check_company_purchase_request())


### PR DESCRIPTION
Stock move is a table that could increase a lot.
So, it's important avoid slow methods in the middle

The constraint method `stock_move._check_company_purchase_request`
compares `purchase_request_allocation.company_id` vs `stock_move.company_id`
to be sure they have the same value

`pra.company_id` was a related field to
`purchase_request_line_id.request_id.company_id`
without `store=True`
Then this constraint consume a lot of time getting all these iteration of records.
For that it was changed to `store=True` and an index was added to get it faster.

And the method was using a loop getting company record by record.
It is so slow too.
It was changed directly using a query since that the ORM doesn't support `JOIN`
And was added an index to `pra.stock_move_id` field to get `JOIN` faster