### PR TITLE
[12.0][FIX] purchase_work_acceptance - WA Reference on invoices

### DIFF
--- a/purchase_work_acceptance/models/account_invoice.py
+++ b/purchase_work_acceptance/models/account_invoice.py
@@ -14,18 +14,22 @@ class AccountInvoice(models.Model):
     wa_id = fields.Many2one(
         comodel_name='work.acceptance',
         string='WA Reference',
+        readonly=True,
         copy=False,
         domain=lambda self: [
             ('state', '=', 'accept'),
             ('purchase_id', '=', self._context.get('active_id'))],
         help='To control quantity and unit price of the vendor bill, to be '
-             'according to the quantity and unit price of the work acceptance.',
+             'according to the quantity and unit price of the work acceptance.'
     )
 
     @api.multi
     def _compute_require_wa(self):
-        self.require_wa = self.env.user.has_group(
-            'purchase_work_acceptance.group_enforce_wa_on_invoice')
+        for rec in self:
+            enforce_wa = self.env.user.has_group(
+                "purchase_work_acceptance.group_enforce_wa_on_invoice"
+            )
+            rec.require_wa = self.wa_id and enforce_wa
 
     def _prepare_invoice_line_from_po_line(self, line):
         res = super()._prepare_invoice_line_from_po_line(line)
@@ -69,6 +73,7 @@ class AccountInvoice(models.Model):
                         else:
                             invoice_line[line.product_id.id] = qty
                 if wa_line != invoice_line:
-                    raise ValidationError(_('You cannot validate a bill if '
-                                          'Quantity not equal accepted quantity'))
+                    raise ValidationError(_(
+                        'You cannot validate a bill if '
+                        'Quantity not equal accepted quantity'))
         return super().action_invoice_open()

--- a/purchase_work_acceptance/models/work_acceptance.py
+++ b/purchase_work_acceptance/models/work_acceptance.py
@@ -1,7 +1,8 @@
 # Copyright 2019 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class WorkAcceptance(models.Model):
@@ -129,6 +130,15 @@ class WorkAcceptance(models.Model):
 
     @api.multi
     def button_draft(self):
+        picking_obj = self.env["stock.picking"]
+        wa_ids = picking_obj.search([("wa_id", "in", self.ids)])
+        if wa_ids:
+            raise UserError(
+                _(
+                    "Unable set to draft this work acceptance. "
+                    "You must first cancel the related receipts."
+                )
+            )
         self.write({'state': 'draft'})
 
     @api.multi

--- a/purchase_work_acceptance/tests/test_purchase_work_acceptance.py
+++ b/purchase_work_acceptance/tests/test_purchase_work_acceptance.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import TransactionCase, Form
 
 
@@ -12,28 +12,125 @@ class TestPurchaseWorkAcceptance(TransactionCase):
         # Create Product
         self.service_product = self.env.ref('product.product_product_1')
         self.product_product = self.env.ref('product.product_product_6')
-        # Create Vendor
         self.res_partner = self.env.ref('base.res_partner_3')
-        # Create Employee
         self.employee = self.env.ref('base.user_demo')
-        # Create Date
+        self.main_company = self.env.ref("base.main_company")
         self.date_now = fields.Datetime.now()
+        # Enable and Config WA
+        self.env["res.config.settings"].create(
+            {"group_enable_wa_on_po": True}
+        ).execute()
+
+    def _create_purchase_order(self, qty):
+        purchase_order = self.env["purchase.order"].create({
+            "partner_id": self.res_partner.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product_product.id,
+                        "product_uom": self.product_product.uom_id.id,
+                        "name": self.product_product.name,
+                        "price_unit": self.product_product.standard_price,
+                        "date_planned": self.date_now,
+                        "product_qty": qty
+                    },
+                )
+            ]
+        })
+        return purchase_order
+
+    def _create_multi_purchase_order(self, qty, multi):
+        purchase_order = self.env["purchase.order"].create(
+            {
+                "partner_id": self.res_partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_product.id,
+                            "product_uom": self.product_product.uom_id.id,
+                            "name": self.product_product.name,
+                            "price_unit": self.product_product.standard_price,
+                            "date_planned": self.date_now,
+                            "product_qty": qty,
+                        },
+                    )
+                    for x in range(multi)
+                ],
+            }
+        )
+        return purchase_order
+
+    def _create_work_acceptance(self, qty, po=False):
+        work_acceptance = self.env["work.acceptance"].create(
+            {
+                "purchase_id": po and po.id or False,
+                "partner_id": self.res_partner.id,
+                "responsible_id": self.employee.id,
+                "date_due": self.date_now,
+                "date_receive": self.date_now,
+                "company_id": self.main_company.id,
+                "wa_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "purchase_line_id": po and po.order_line[0].id
+                            or False,
+                            "product_id": po
+                            and po.order_line[0].product_id.id
+                            or self.service_product.id,
+                            "name": po
+                            and po.order_line[0].name
+                            or self.service_product.name,
+                            "price_unit": po
+                            and po.order_line[0].price_unit
+                            or self.service_product.standard_price,
+                            "product_uom": po
+                            and po.order_line[0].product_uom.id
+                            or self.service_product.uom_id.id,
+                            "product_qty": qty,
+                        },
+                    )
+                ],
+            }
+        )
+        return work_acceptance
+
+    def _create_multi_work_acceptance(self, qty, purchase_order, multi):
+        work_acceptance = self.env["work.acceptance"].create(
+            {
+                "purchase_id": purchase_order.id,
+                "partner_id": self.res_partner.id,
+                "responsible_id": self.employee.id,
+                "date_due": self.date_now,
+                "date_receive": self.date_now,
+                "company_id": self.main_company.id,
+                "wa_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "purchase_line_id": purchase_order.order_line[x].id,
+                            "product_id": purchase_order.order_line[x].product_id.id,
+                            "name": purchase_order.order_line[x].name,
+                            "price_unit": purchase_order.order_line[x].price_unit,
+                            "product_uom": purchase_order.order_line[x].product_uom.id,
+                            "product_qty": qty,
+                        },
+                    )
+                    for x in range(multi)
+                ],
+            }
+        )
+        return work_acceptance
 
     def test_00_wa_button(self):
-        work_acceptance = self.env['work.acceptance'].create({
-            'partner_id': self.res_partner.id,
-            'responsible_id': self.employee.id,
-            'date_due': self.date_now,
-            'date_receive': self.date_now,
-            'company_id': self.env.ref('base.main_company').id,
-            'wa_line_ids': [
-                (0, 0, {'product_id': self.service_product.id,
-                        'name': self.service_product.name,
-                        'price_unit': self.service_product.standard_price,
-                        'product_qty': 3.0,
-                        'product_uom': self.service_product.uom_id.id,
-                        })]
-        })
+        qty = 3.0
+        work_acceptance = self._create_work_acceptance(qty)
         work_acceptance.button_accept()
         self.assertEqual(work_acceptance.state, 'accept')
         work_acceptance.button_cancel()
@@ -43,68 +140,42 @@ class TestPurchaseWorkAcceptance(TransactionCase):
 
     def test_01_action_view_wa(self):
         # Create Purchase Order
-        purchase_order = self.env['purchase.order'].create({
-            'partner_id': self.res_partner.id,
-            'order_line': [
-                (0, 0, {'product_id': self.service_product.id,
-                        'product_uom': self.service_product.uom_id.id,
-                        'name': self.service_product.name,
-                        'price_unit': self.service_product.standard_price,
-                        'date_planned': self.date_now,
-                        'product_qty': 42.0})]})
+        qty = 42.0
+        purchase_order = self._create_purchase_order(qty)
         purchase_order.button_confirm()
-        self.assertEqual(purchase_order.state, 'purchase')
+        self.assertEqual(purchase_order.state, "purchase")
 
         res = purchase_order.with_context(create_wa=True).action_view_wa()
-        ctx = res.get('context')
-        work_acceptance = Form(self.env['work.acceptance'].with_context(ctx))
-        self.assertEqual(work_acceptance.state, 'draft')
+        ctx = res.get("context")
+        work_acceptance = Form(self.env["work.acceptance"].with_context(ctx))
+        self.assertEqual(work_acceptance.state, "draft")
 
     def test_02_flow_product(self):
         # Create Purchase Order
-        purchase_order = self.env['purchase.order'].create({
-            'partner_id': self.res_partner.id,
-            'order_line': [
-                (0, 0, {'product_id': self.product_product.id,
-                        'product_uom': self.product_product.uom_id.id,
-                        'name': self.product_product.name,
-                        'price_unit': self.product_product.standard_price,
-                        'date_planned': self.date_now,
-                        'product_qty': 42.0})]
-        })
+        qty = 42.0
+        purchase_order = self._create_purchase_order(qty)
         purchase_order.button_confirm()
-        self.assertEqual(purchase_order.state, 'purchase')
+        self.assertEqual(purchase_order.state, "purchase")
         self.assertEqual(purchase_order.picking_count, 1)
         # Create Work Acceptance
-        work_acceptance = self.env['work.acceptance'].create({
-            'purchase_id': purchase_order.id,
-            'partner_id': self.res_partner.id,
-            'responsible_id': self.employee.id,
-            'date_due': self.date_now,
-            'date_receive': self.date_now,
-            'company_id': self.env.ref('base.main_company').id,
-            'wa_line_ids': [
-                (0, 0, {'purchase_line_id': purchase_order.order_line[0].id,
-                        'product_id': purchase_order.order_line[0].product_id.id,
-                        'name': purchase_order.order_line[0].name,
-                        'price_unit': purchase_order.order_line[0].price_unit,
-                        'product_uom': purchase_order.order_line[0].product_uom.id,
-                        'product_qty': 42.0})]
-        })
+        work_acceptance = self._create_work_acceptance(qty, purchase_order)
         work_acceptance.button_accept()
-        self.assertEqual(work_acceptance.state, 'accept')
+        self.assertEqual(work_acceptance.state, "accept")
         self.assertEqual(purchase_order.wa_count, 1)
         # Received Products
         picking = purchase_order.picking_ids[0]
         self.assertEqual(len(picking.move_ids_without_package), 1)
-        picking.wa_id = work_acceptance
-        picking._onchange_wa_id()
-
+        with Form(picking) as p:
+            p.wa_id = work_acceptance
+        p.save()
         with self.assertRaises(ValidationError):
             picking.move_ids_without_package[0].quantity_done = 30.0
             picking.button_validate()
         picking.move_ids_without_package[0].quantity_done = 42.0
         picking.button_validate()
+        # Can't set to draft wa when you validate picking
+        with self.assertRaises(UserError):
+            work_acceptance.button_draft()
         # Create Vendor Bill
         invoice = self.env['account.invoice'].create({
             'partner_id': self.res_partner.id,
@@ -121,35 +192,13 @@ class TestPurchaseWorkAcceptance(TransactionCase):
         invoice.action_invoice_open()
 
     def test_03_flow_service(self):
+        qty = 30.0
         # Create Purchase Order
-        purchase_order = self.env['purchase.order'].create({
-            'partner_id': self.res_partner.id,
-            'order_line': [
-                (0, 0, {'product_id': self.service_product.id,
-                        'product_uom': self.service_product.uom_id.id,
-                        'name': self.service_product.name,
-                        'price_unit': self.service_product.standard_price,
-                        'date_planned': self.date_now,
-                        'product_qty': 30.0})]
-        })
+        purchase_order = self._create_purchase_order(qty)
         purchase_order.button_confirm()
         self.assertEqual(purchase_order.state, 'purchase')
         # Create Work Acceptance
-        work_acceptance = self.env['work.acceptance'].create({
-            'purchase_id': purchase_order.id,
-            'partner_id': self.res_partner.id,
-            'responsible_id': self.employee.id,
-            'date_due': self.date_now,
-            'date_receive': self.date_now,
-            'company_id': self.env.ref('base.main_company').id,
-            'wa_line_ids': [
-                (0, 0, {'purchase_line_id': purchase_order.order_line[0].id,
-                        'product_id': purchase_order.order_line[0].product_id.id,
-                        'name': purchase_order.order_line[0].name,
-                        'price_unit': purchase_order.order_line[0].price_unit,
-                        'product_uom': purchase_order.order_line[0].product_uom.id,
-                        'product_qty': 30.0})]
-        })
+        work_acceptance = self._create_work_acceptance(qty, purchase_order)
         work_acceptance.button_accept()
         self.assertEqual(work_acceptance.state, 'accept')
         self.assertEqual(purchase_order.wa_count, 1)
@@ -166,6 +215,77 @@ class TestPurchaseWorkAcceptance(TransactionCase):
             'type': 'in_invoice',
         })
         invoice.wa_id = work_acceptance
+        invoice.purchase_order_change()
+        self.assertEqual(invoice.state, 'draft')
+        invoice.action_invoice_open()
+
+    def test_04_enable_config_flow(self):
+        qty = 2.0
+        # Create Purchase Order
+        purchase_order = self._create_purchase_order(qty)
+        purchase_order.button_confirm()
+        # Create Work Acceptance
+        work_acceptance = self._create_work_acceptance(qty, purchase_order)
+        work_acceptance.button_accept()
+        res = purchase_order.with_context(create_bill=True).action_view_invoice()
+        self.assertEqual(res.get("res_model"), "account.invoice")
+        # enable wa on invoice
+        self.env["res.config.settings"].create(
+            {"group_enable_wa_on_invoice": True}
+        ).execute()
+        # Create Vendor Bill
+        purchase_order.with_context(create_bill=True).action_view_invoice()
+        wizard = self.env['select.work.acceptance.wizard'].create({
+            'wa_id': work_acceptance.id,
+        })
+        wizard.button_create_vendor_bill()
+        invoice = self.env['account.invoice'].create({
+            'partner_id': self.res_partner.id,
+            'purchase_id': purchase_order.id,
+            'account_id': self.res_partner.property_account_payable_id.id,
+            'type': 'in_invoice',
+        })
+        invoice.wa_id = work_acceptance
+        invoice.purchase_order_change()
+        self.assertEqual(invoice.state, 'draft')
+        invoice.action_invoice_open()
+
+    def test_05_create_multi_lines(self):
+        qty = 5.0
+        # Create Purchase Order
+        purchase_order = self._create_multi_purchase_order(qty, multi=2)
+        purchase_order.button_confirm()
+        # Create Work Acceptance
+        work_acceptance = work_acceptance = self._create_multi_work_acceptance(
+            qty, purchase_order, multi=2
+        )
+        work_acceptance.button_accept()
+        # Received Products
+        picking = purchase_order.picking_ids[0]
+        self.assertEqual(len(picking.move_ids_without_package), 2)
+        with Form(picking) as p:
+            p.wa_id = work_acceptance
+        p.save()
+        picking.button_validate()
+        # enable and enforce wa on invoice
+        self.env["res.config.settings"].create(
+            {"group_enable_wa_on_invoice": True, "group_enforce_wa_on_invoice": True}
+        ).execute()
+        # Create Vendor Bill
+        purchase_order.with_context(create_bill=True).action_view_invoice()
+        wizard = self.env['select.work.acceptance.wizard'].create({
+            'wa_id': work_acceptance.id,
+        })
+        wizard.button_create_vendor_bill()
+        invoice = self.env['account.invoice'].create({
+            'partner_id': self.res_partner.id,
+            'purchase_id': purchase_order.id,
+            'account_id': self.res_partner.property_account_payable_id.id,
+            'type': 'in_invoice',
+        })
+        invoice.wa_id = work_acceptance
+        invoice._compute_require_wa()
+        self.assertEqual(invoice.require_wa, True)
         invoice.purchase_order_change()
         self.assertEqual(invoice.state, 'draft')
         invoice.action_invoice_open()

--- a/purchase_work_acceptance/views/account_invoice_views.xml
+++ b/purchase_work_acceptance/views/account_invoice_views.xml
@@ -12,7 +12,6 @@
                        options="{'no_create': True}"
                        groups="purchase_work_acceptance.group_enable_wa_on_invoice"
                        attrs="{'required': [('require_wa','=', True)],
-                               'readonly':[('state', '!=' , 'draft')],
                                'invisible': [('id', '=', False)]}"
                        />
             </xpath>


### PR DESCRIPTION
Update code from https://github.com/OCA/purchase-workflow/pull/957

- Fix Button `set to draft` in WA can't do it when WA related with Receipts
- Fix display `WA Reference` on invoice and readonly
- Improved test script