### PR TITLE
[IMP] purchase_request: Speed up stock_move company constraint

### DIFF
--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -21,6 +21,8 @@ class PurchaseRequestAllocation(models.Model):
         comodel_name="res.company",
         readonly=True,
         related="purchase_request_line_id.request_id.company_id",
+        store=True,
+        index=True,
     )
     stock_move_id = fields.Many2one(
         string="Stock Move", comodel_name="stock.move", ondelete="cascade", index=True,

--- a/purchase_request/tests/test_purchase_request_allocation.py
+++ b/purchase_request/tests/test_purchase_request_allocation.py
@@ -348,3 +348,6 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
         }
         purchase_request_line1 = self.purchase_request_line.create(vals)
         purchase_request_line1.onchange_product_id()
+
+    def test_empty_records_for_company_constraint(self):
+        self.assertFalse(self.env["stock.move"]._check_company_purchase_request())


### PR DESCRIPTION
Stock move is a table that could increase a lot.
So, it's important avoid slow methods in the middle

The constraint method `stock_move._check_company_purchase_request`
compares `purchase_request_allocation.company_id` vs `stock_move.company_id`
to be sure they have the same value

`pra.company_id` was a related field to
`purchase_request_line_id.request_id.company_id`
without `store=True`
Then this constraint consume a lot of time getting all these iteration of records.
For that it was changed to `store=True` and an index was added to get it faster.

And the method was using a loop getting company record by record.
It is so slow too.
It was changed directly using a query since that the ORM doesn't support `JOIN`
And was added an index to `pra.stock_move_id` field to get `JOIN` faster

FWP https://github.com/OCA/purchase-workflow/pull/978