### PR TITLE
[FIX] Convert invoice amount to expense currency

### DIFF
--- a/purchase_landed_cost/wizard/import_invoice_line.py
+++ b/purchase_landed_cost/wizard/import_invoice_line.py
@@ -26,7 +26,7 @@ class ImportInvoiceLine(models.TransientModel):
         self.ensure_one()
         dist_id = self.env.context['active_id']
         distribution = self.env['purchase.cost.distribution'].browse(dist_id)
-        currency_from = self.invoice_line.company_id.currency_id
+        currency_from = self.invoice_line.currency_id
         amount = self.invoice_line.price_subtotal
         currency_to = distribution.currency_id
         company = distribution.company_id or self.env.user.company_id


### PR DESCRIPTION
Invoice currency is NOT being used to convert to landed cost currency.
Currently it takes company currency and converts to landed cost currency, so if invoice is in different currency, amount is wrong.