### PR TITLE
[IMP] purchase_order_product_recommendation: min with for numeric step cells

### DIFF
--- a/purchase_order_product_recommendation/__manifest__.py
+++ b/purchase_order_product_recommendation/__manifest__.py
@@ -15,6 +15,7 @@
     ],
     "data": [
         "wizards/purchase_order_recommendation_view.xml",
+        "views/assets.xml",
         "views/purchase_order_view.xml",
     ],
 }

--- a/purchase_order_product_recommendation/static/src/scss/purchase_order_product_recommendation.scss
+++ b/purchase_order_product_recommendation/static/src/scss/purchase_order_product_recommendation.scss
@@ -1,0 +1,3 @@
+.o_list_view td.o_numeric_step_cell {
+    min-width: 120px;
+}

--- a/purchase_order_product_recommendation/views/assets.xml
+++ b/purchase_order_product_recommendation/views/assets.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="assets_backend" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <link rel="stylesheet" type="text/scss" href="/purchase_order_product_recommendation/static/src/scss/purchase_order_product_recommendation.scss"></link>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
cc @Tecnativa TT25581

A min width is set for the wizard list field labeled 'Qty'. If the wizard list has many columns and the field has a very small width, editing it with the numeric_step widget is very difficult.

![image](https://user-images.githubusercontent.com/38267832/101992383-bf6cef80-3c80-11eb-9364-c3246427ca80.png)
