### PR TITLE
UPD travis to recent config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,32 @@
+language: python
 sudo: false
 cache: pip
 
+python:
+  - "2.7"
+
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
 
-language: python
-
-python:
-  - "2.7"
-
 env:
   global:
-  - VERSION="8.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
-  - TRANSIFEX_USER='transbot@odoo-community.org'
-  - secure: "XoIYWXq+aT6EiA2DWYjLyqRnYafnvqoXvs1mHzIRi3y4d/YARm1jwouReyDzn8Wd9GLdedQ7rffVZg0sXMiErEyRC+4e7ax5bd3+YFvHALZTdC4PoprJKQDiLMc5hcdlXRpS8hKTx32Jr/DmJdhX0jjaJ05tXV3ibTwdzP5VA9k="
+  - VERSION="8.0" TESTS="0" LINT_CHECK="0" MAKEPOT="0"
+
   matrix:
   - LINT_CHECK="1"
-  - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="framework_agreement"
+  - MAKEPOT="1"
   - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="framework_agreement"
-  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="purchase_rfq_bid_workflow"
   - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="purchase_rfq_bid_workflow"
-  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="purchase_requisition_auto_rfq"
   - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="purchase_requisition_auto_rfq"
-  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="purchase_requisition_multicurrency,purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq_bid_selection"
   - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="purchase_requisition_multicurrency,purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq_bid_selection"
-  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="purchase_requisition_delivery_address,purchase_delivery_address,purchase_origin_address,framework_agreement,purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection,purchase_requisition_multicurrency"
   - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="purchase_requisition_delivery_address,purchase_delivery_address,purchase_origin_address,framework_agreement,purchase_rfq_bid_workflow,purchase_requisition_bid_selection,purchase_requisition_auto_rfq,purchase_requisition_auto_rfq_bid_selection,purchase_requisition_multicurrency"
 
-virtualenv:
-  system_site_packages: true
-
 install:
-  - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
 


### PR DESCRIPTION
This branch use transifex.
This PR fix that

On a such old version, we only need OCB.

Copy/paste from sale-workflow 8.0