### PR TITLE
[12.0][FIX] purchase_order_line_description: translated description

### DIFF
--- a/purchase_order_line_description/models/purchase_order_line.py
+++ b/purchase_order_line_description/models/purchase_order_line.py
@@ -13,9 +13,13 @@ class PurchaseOrderLine(models.Model):
         res = super(PurchaseOrderLine, self).onchange_product_id()
         if not self.product_id:
             return res
+        # TODO Use odoo.tools.misc.get_lang in v13+
+        translated_product = self.product_id.with_context(
+            lang=self.partner_id.lang or self.env.lang
+        )
         if (self.user_has_groups(
                 'purchase_order_line_description.'
                 'group_use_product_description_per_po_line') and
-                self.product_id.description_purchase):
-            self.name = self.product_id.description_purchase
+                translated_product.description_purchase):
+            self.name = translated_product.description_purchase
         return res

--- a/purchase_order_line_description/tests/test_purchase_order_line_description.py
+++ b/purchase_order_line_description/tests/test_purchase_order_line_description.py
@@ -46,3 +46,15 @@ class TestPurchaseOrderLineDescription(common.SavepointCase):
         self.order.order_line[0].sudo(self.test_user).onchange_product_id()
         self.assertEqual(
             self.product.description_purchase, self.order.order_line[0].name)
+
+    def test_translated_description(self):
+        """PO description rendered in supplier lang."""
+        self.env["res.lang"].load_lang("es_ES")
+        self.order.partner_id.lang = "es_ES"
+        self.product.with_context(
+            lang="es_ES"
+        ).description_purchase = "descripción para compras"
+        with common.Form(self.order.sudo(self.test_user)) as order:
+            with order.order_line.new() as line:
+                line.product_id = self.product
+                self.assertEqual(line.name, "descripción para compras")


### PR DESCRIPTION
Installing this module introduces a regression from Odoo core when the supplier speaks a different language than the user, setting the description on the user's lang instead.

@Tecnativa TT27390