### PR TITLE
[12.0][IMP] purchase_order_uninvoiced_amount: the amount depends on the invoice policy of the products.

### DIFF
--- a/purchase_order_uninvoiced_amount/README.rst
+++ b/purchase_order_uninvoiced_amount/README.rst
@@ -56,6 +56,7 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * Manuel Calero
+  * Ernesto Tejeda
 
 Maintainers
 ~~~~~~~~~~~

--- a/purchase_order_uninvoiced_amount/models/purchase_order.py
+++ b/purchase_order_uninvoiced_amount/models/purchase_order.py
@@ -3,23 +3,40 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
+from odoo.tools.float_utils import float_compare
 
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
-    @api.depends('order_line.qty_invoiced')
+    @api.depends(
+        "order_line.product_qty",
+        "order_line.qty_invoiced",
+        "order_line.qty_received",
+        "order_line.product_id",
+        "order_line.product_uom",
+        "order_line.price_unit",
+    )
     def _compute_amount_uninvoiced(self):
         for order in self:
-            amount_uninvoiced = order.amount_untaxed
-            for line in order.order_line.filtered("qty_invoiced"):
+            amount_uninvoiced = 0
+            for line in order.order_line:
+                # The qty to invoice depends on the invoicing policy of
+                # the product
+                if line.product_id.purchase_method == 'purchase':
+                    qty = line.product_qty - line.qty_invoiced
+                else:
+                    qty = line.qty_received - line.qty_invoiced
+                rounding = line.product_uom.rounding
+                if float_compare(qty, 0.0, precision_rounding=rounding) <= 0:
+                    qty = 0.0
                 # we use this way for being compatible with purchase_discount
                 price_unit = (
                     line.product_qty and
                     line.price_subtotal / line.product_qty or
                     line.price_unit
                 )
-                amount_uninvoiced -= line.qty_invoiced * price_unit
+                amount_uninvoiced += qty * price_unit
             order.update({
                 'amount_uninvoiced': order.currency_id.round(amount_uninvoiced),
             })

--- a/purchase_order_uninvoiced_amount/readme/CONTRIBUTORS.rst
+++ b/purchase_order_uninvoiced_amount/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * Manuel Calero
+  * Ernesto Tejeda

--- a/purchase_order_uninvoiced_amount/static/description/index.html
+++ b/purchase_order_uninvoiced_amount/static/description/index.html
@@ -402,6 +402,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Manuel Calero</li>
+<li>Ernesto Tejeda</li>
 </ul>
 </li>
 </ul>

--- a/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
+++ b/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
@@ -49,6 +49,7 @@ class TestPurchaseOrderUninvoiceAmount(SavepointCase):
             'type': 'consu',
             'categ_id': self.product_category.id,
             'description_sale': 'Test Description Sale',
+            'purchase_method': 'receive',
         })
 
     def _create_purchase(self, product_qty=1, product_received=1):
@@ -89,17 +90,17 @@ class TestPurchaseOrderUninvoiceAmount(SavepointCase):
         self.assertEquals(purchase.amount_uninvoiced, purchase.amount_untaxed,
                           "The purchase amount uninvoiced must be the amount untaxed")
 
-    def test_create_purchase_and_invoiced_without_units(self):
+    def test_create_purchase_and_no_receive(self):
         purchase = self._create_purchase(2, 0)
-        self._create_invoice_from_purchase(purchase)
-        self.assertEquals(purchase.amount_uninvoiced, 200,
-                          "The purchase amount uninvoiced must be 200")
+        self.assertEquals(purchase.amount_uninvoiced, 0,
+                          "The purchase amount uninvoiced must be 0")
 
-    def test_create_purchase_and_invoiced_with_half_units(self):
-        purchase = self._create_purchase(2, 1)
-        self._create_invoice_from_purchase(purchase)
-        self.assertEquals(purchase.amount_uninvoiced, 100,
-                          "The purchase amount uninvoiced must be 100")
+    def test_create_purchase_and_invoiced_a_part(self):
+        purchase = self._create_purchase(10, 5)
+        self.assertEquals(purchase.amount_uninvoiced, 500)
+        invoice = self._create_invoice_from_purchase(purchase)
+        invoice.invoice_line_ids.quantity = 3
+        self.assertEquals(purchase.amount_uninvoiced, 200)
 
     def test_create_purchase_create_and_invoiced_with_all_units(self):
         purchase = self._create_purchase(2, 2)
@@ -109,4 +110,14 @@ class TestPurchaseOrderUninvoiceAmount(SavepointCase):
 
     def test_create_purchase_qty_0(self):
         purchase = self._create_purchase(0, 0)
+        self.assertEquals(purchase.amount_uninvoiced, 0)
+
+    def test_on_ordered_quantities_policy(self):
+        self.product_1.purchase_method = "purchase"
+        purchase = self._create_purchase(10, 0)
+        self.assertEquals(purchase.amount_uninvoiced, 1000)
+        invoice = self._create_invoice_from_purchase(purchase)
+        invoice.invoice_line_ids.quantity = 6
+        self.assertEquals(purchase.amount_uninvoiced, 400)
+        self._create_invoice_from_purchase(purchase)
         self.assertEquals(purchase.amount_uninvoiced, 0)


### PR DESCRIPTION
cc @Tecnativa TT27317

Take into account the 'Control Policy' of the products to compute the uninvoiced amount.