### PR TITLE
[IMP] purchase_request: Setting default payment term from supplier

### DIFF
--- a/purchase_request/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request/tests/test_purchase_request_to_rfq.py
@@ -80,8 +80,9 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
         purchase_request.button_to_approve()
         purchase_request.button_approved()
 
+        supplier = self.env.ref('base.res_partner_12')
         vals = {
-            'supplier_id': self.env.ref('base.res_partner_12').id,
+            'supplier_id': supplier.id,
         }
         wiz_id = self.wiz.with_context(
             active_model="purchase.request.line",
@@ -99,6 +100,11 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
             purchase_request_line.purchase_lines.state,
             purchase_request_line.purchase_state,
             'Should have same state')
+        purchase_order = purchase_request_line.purchase_lines.order_id
+        self.assertEquals(
+            purchase_order.payment_term_id.id,
+            supplier.property_supplier_payment_term_id.id,
+            'Should have same supplier payment term')
 
     def test_bug_is_editable_multiple_lines(self):
         # Check that reading multiple lines is still possible

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -122,6 +122,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         data = {
             'origin': origin,
             'partner_id': self.supplier_id.id,
+            'payment_term_id': supplier.property_supplier_payment_term_id.id,
             'fiscal_position_id': supplier.property_account_position_id and
             supplier.property_account_position_id.id or False,
             'picking_type_id': picking_type.id,


### PR DESCRIPTION
When creating a RFQ from a PR the payment term should be copied from the default supplier payment term.