### PR TITLE
[13.0][IMP] purchase_order_secondary_unit: Less code. Use product_secondary _unit mixin model from product-attribute repository.

### DIFF
--- a/purchase_order_secondary_unit/models/purchase_order.py
+++ b/purchase_order_secondary_unit/models/purchase_order.py
@@ -1,76 +1,39 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
-from odoo.tools.float_utils import float_compare, float_round
 
 
 class PurchaseOrderLine(models.Model):
-    _inherit = "purchase.order.line"
+    _inherit = ["purchase.order.line", "product.secondary.unit.mixin"]
+    _name = "purchase.order.line"
+    _secondary_unit_fields = {
+        "qty_field": "product_qty",
+        "uom_field": "product_uom",
+    }
 
-    secondary_uom_qty = fields.Float(
-        string="Secondary Qty", digits="Product Unit of Measure"
+    product_qty = fields.Float(
+        store=True, readonly=False, compute="_compute_product_qty", copy=True
     )
-    secondary_uom_id = fields.Many2one(
-        comodel_name="product.secondary.unit",
-        string="Secondary uom",
-        ondelete="restrict",
-    )
 
-    @api.onchange("secondary_uom_id", "secondary_uom_qty")
-    def _onchange_secondary_uom(self):
-        if not self.secondary_uom_id:
-            return
-        factor = self.secondary_uom_id.factor * self.product_uom.factor
-        qty = float_round(
-            self.secondary_uom_qty * factor,
-            precision_rounding=self.product_uom.rounding,
-        )
-        if (
-            float_compare(
-                self.product_qty, qty, precision_rounding=self.product_uom.rounding
-            )
-            != 0
-        ):
-            self.product_qty = qty
-
-    @api.onchange("product_qty")
-    def _onchange_product_qty_purchase_order_secondary_unit(self):
-        if not self.secondary_uom_id:
-            return
-        factor = self.secondary_uom_id.factor * self.product_uom.factor
-        qty = float_round(
-            self.product_qty / (factor or 1.0),
-            precision_rounding=self.secondary_uom_id.uom_id.rounding,
-        )
-        if (
-            float_compare(
-                self.secondary_uom_qty,
-                qty,
-                precision_rounding=self.secondary_uom_id.uom_id.rounding,
-            )
-            != 0
-        ):
-            self.secondary_uom_qty = qty
+    @api.depends("secondary_uom_qty", "secondary_uom_id")
+    def _compute_product_qty(self):
+        if hasattr(super(), "_compute_product_qty"):
+            super()._compute_product_qty()
+        self._compute_helper_target_field_qty()
 
     @api.onchange("product_uom")
-    def _onchange_product_uom_purchase_order_secondary_unit(self):
-        if not self.secondary_uom_id:
-            return
-        factor = self.product_uom.factor * self.secondary_uom_id.factor
-        qty = float_round(
-            self.product_qty / (factor or 1.0),
-            precision_rounding=self.product_uom.rounding,
-        )
-        if (
-            float_compare(
-                self.secondary_uom_qty,
-                qty,
-                precision_rounding=self.product_uom.rounding,
-            )
-            != 0
-        ):
-            self.secondary_uom_qty = qty
+    def onchange_product_uom_for_secondary(self):
+        self._onchange_helper_product_uom_for_secondary()
 
     @api.onchange("product_id")
-    def _onchange_product_id_purchase_order_secondary_unit(self):
+    def onchange_product_id(self):
+        """If default purchases secondary unit set on product, put on secondary
+        quantity 1 for being the default quantity. We override this method,
+        that is the one that sets by default 1 on the other quantity with that
+        purpose.
+        """
+        res = super().onchange_product_id()
         self.secondary_uom_id = self.product_id.purchase_secondary_uom_id
+        if self.secondary_uom_id:
+            self.secondary_uom_qty = 1.0
+        return res

--- a/purchase_order_secondary_unit/views/purchase_order_views.xml
+++ b/purchase_order_secondary_unit/views/purchase_order_views.xml
@@ -33,9 +33,9 @@
                 />
                 <field
                     name="secondary_uom_id"
-                    domain="[('product_tmpl_id.product_variant_ids', 'in', [product_id])]"
+                    domain="[('product_tmpl_id.product_variant_ids', 'in', product_id and [product_id] or [])]"
                     options="{'no_create': True}"
-                    attrs="{'readonly': ['|',('state', 'in', ('done', 'cancel')), ('product_id', '=', False)]}"
+                    attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
cc @Tecnativa TT27363
Also in this commit set secondary_uom as default is the product has informed a default purchase secondary uom for purchases.
ping @carlosdauden @chienandalu 

Depends on:

- [x] https://github.com/OCA/product-attribute/pull/773