### PR TITLE
[13.0][IMP] purchase_stock_secondary_unit: Allow update secondary unit after a purchase order is confirmed

### DIFF
--- a/purchase_stock_secondary_unit/README.rst
+++ b/purchase_stock_secondary_unit/README.rst
@@ -69,6 +69,10 @@ Contributors
 
 * Alan Ramos <alan.ramos@jarsa.com.mx>
 
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+    * Sergio Teruel <sergio.teruel@tecnativa.com>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/purchase_stock_secondary_unit/__manifest__.py
+++ b/purchase_stock_secondary_unit/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Jarsa Sistemas
+# Copyright 2021 Tecnativa - Sergio Teruel
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     "name": "Purchase Stock Secondary Unit",

--- a/purchase_stock_secondary_unit/models/__init__.py
+++ b/purchase_stock_secondary_unit/models/__init__.py
@@ -2,3 +2,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import purchase_order_line
+from . import stock_move

--- a/purchase_stock_secondary_unit/models/purchase_order_line.py
+++ b/purchase_stock_secondary_unit/models/purchase_order_line.py
@@ -1,24 +1,44 @@
 # Copyright 2020 Jarsa Sistemas
+# Copyright 2021 Tecnativa - Sergio Teruel
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import models
 
 
-class PurchaseOrderline(models.Model):
+class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
+
+    def _get_secondary_uom_for_move(self, product_uom_qty):
+        if not self.secondary_uom_id:
+            return 0.0
+        move = self.env["stock.move"].new()
+        move.product_id = self.product_id
+        move.product_uom = self.product_uom
+        move.secondary_uom_id = self.secondary_uom_id
+        move.product_uom_qty = product_uom_qty
+        return move.secondary_uom_qty
 
     def _prepare_stock_moves(self, picking):
         res = super()._prepare_stock_moves(picking)
-        for move in res:
-            if move.get("purchase_line_id"):
-                purchase_line = self.env["purchase.order.line"].browse(
-                    move["purchase_line_id"]
-                )
-                if purchase_line.secondary_uom_id:
-                    move.update(
-                        {
-                            "secondary_uom_id": purchase_line.secondary_uom_id.id,
-                            "secondary_uom_qty": purchase_line.secondary_uom_qty,
-                        }
-                    )
+        # Ensure one method.
+        # Compute secondary unit values for stock moves.
+        # When a po line with stock moves has been updated the new moves only
+        # have the new quantity added so we always want compute the
+        # secondary unit.
+        if res:
+            product_uom_qty = res[0]["product_uom_qty"]
+            secondary_uom_qty = self._get_secondary_uom_for_move(product_uom_qty)
+            res[0].update(
+                {
+                    "secondary_uom_id": self.secondary_uom_id.id,
+                    "secondary_uom_qty": secondary_uom_qty,
+                }
+            )
         return res
+
+    def _create_or_update_picking(self):
+        # Inject a context to recompute secondary unit in stock moves after
+        # they have been assigned only for po lines updated and confirmed.
+        return super(
+            PurchaseOrderLine, self.with_context(secondary_uom_for_update_moves=True)
+        )._create_or_update_picking()

--- a/purchase_stock_secondary_unit/models/stock_move.py
+++ b/purchase_stock_secondary_unit/models/stock_move.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _action_assign(self):
+        res = super()._action_assign()
+        if self.env.context.get("secondary_uom_for_update_moves"):
+            for move in self:
+                move.secondary_uom_id = move.purchase_line_id.secondary_uom_id
+                move._compute_secondary_uom_qty()
+        return res

--- a/purchase_stock_secondary_unit/readme/CONTRIBUTORS.rst
+++ b/purchase_stock_secondary_unit/readme/CONTRIBUTORS.rst
@@ -1,1 +1,5 @@
 * Alan Ramos <alan.ramos@jarsa.com.mx>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+    * Sergio Teruel <sergio.teruel@tecnativa.com>

--- a/purchase_stock_secondary_unit/static/description/index.html
+++ b/purchase_stock_secondary_unit/static/description/index.html
@@ -414,8 +414,16 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </div>
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<ul>
+<li><p class="first">Alan Ramos &lt;<a class="reference external" href="mailto:alan.ramos&#64;jarsa.com.mx">alan.ramos&#64;jarsa.com.mx</a>&gt;</p>
+</li>
+<li><p class="first"><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:</p>
+<blockquote>
 <ul class="simple">
-<li>Alan Ramos &lt;<a class="reference external" href="mailto:alan.ramos&#64;jarsa.com.mx">alan.ramos&#64;jarsa.com.mx</a>&gt;</li>
+<li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
+</ul>
+</blockquote>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/purchase_stock_secondary_unit/tests/test_purchase_stock_secondary_unit.py
+++ b/purchase_stock_secondary_unit/tests/test_purchase_stock_secondary_unit.py
@@ -1,78 +1,97 @@
 # Copyright 2020 Jarsa Sistemas
+# Copyright 2021 Tecnativa - Sergio Teruel
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+import logging
 
-from odoo import fields
-from odoo.tests import SavepointCase, tagged
+from odoo.tests import Form, SavepointCase
+
+_logger = logging.getLogger(__name__)
 
 
-@tagged("post_install", "-at_install")
-class TestPurchaseStockOrderSecondaryUnit(SavepointCase):
+class TestPurchaseStockSecondaryUnit(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # Active multiple units of measure security group for user
+        cls.env.user.groups_id = [(4, cls.env.ref("uom.group_uom").id)]
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.product_uom_kg = cls.env.ref("uom.product_uom_kgm")
         cls.product_uom_gram = cls.env.ref("uom.product_uom_gram")
         cls.product_uom_unit = cls.env.ref("uom.product_uom_unit")
-        cls.product = cls.env["product.product"].create(
-            {
-                "name": "test",
-                "type": "product",
-                "uom_id": cls.product_uom_kg.id,
-                "uom_po_id": cls.product_uom_kg.id,
-                "secondary_uom_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": "unit-700",
-                            "uom_id": cls.product_uom_unit.id,
-                            "factor": 0.7,
-                        },
-                    )
-                ],
-            }
-        )
-        StockQuant = cls.env["stock.quant"]
-        StockQuant.create(
-            {
-                "product_id": cls.product.id,
-                "location_id": cls.warehouse.lot_stock_id.id,
-                "quantity": 2000,
-            }
-        )
-        cls.secondary_unit = cls.env["product.secondary.unit"].search(
-            [("product_tmpl_id", "=", cls.product.product_tmpl_id.id)]
-        )
-        cls.product.purchase_secondary_uom_id = cls.secondary_unit.id
+        cls.ProductSecondaryUnit = cls.env["product.secondary.unit"]
         cls.partner = cls.env["res.partner"].create({"name": "test - partner"})
-        po = cls.env["purchase.order"].new(
-            {
-                "partner_id": cls.partner.id,
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": cls.product.name,
-                            "product_id": cls.product.id,
-                            "product_qty": 1,
-                            "product_uom": cls.product.uom_id.id,
-                            "price_unit": 1000.00,
-                            "date_planned": fields.Datetime.now(),
-                        },
-                    )
-                ],
-            }
-        )
+        with Form(cls.env["product.product"]) as product_form:
+            product_form.name = "Test"
+            product_form.type = "product"
+            with product_form.secondary_uom_ids.new() as secondary_uom:
+                secondary_uom.name = "box"
+                secondary_uom.uom_id = cls.product_uom_unit
+                secondary_uom.factor = 5.0
+        cls.product = product_form.save()
+        cls.secondary_product_uom = cls.product.secondary_uom_ids[:1]
+        po = cls.env["purchase.order"].new({"partner_id": cls.partner.id})
         po.onchange_partner_id()
-        cls.order = cls.env["purchase.order"].create(po._convert_to_write(po._cache))
-
-    def test_stock_move_line_secondary_unit(self):
-        self.order.order_line.write(
-            {"secondary_uom_id": self.secondary_unit.id, "secondary_uom_qty": 5}
+        cls.purchase_order = cls.env["purchase.order"].create(
+            po._convert_to_write(po._cache)
         )
-        self.order.order_line._onchange_secondary_uom()
-        self.order.button_confirm()
-        picking = self.order.picking_ids
-        self.assertEqual(picking.move_line_ids.secondary_uom_qty, 5.0)
+        with Form(cls.purchase_order) as po_form:
+            po_form.partner_id = cls.partner
+            with po_form.order_line.new() as line:
+                line.product_id = cls.product
+                line.secondary_uom_id = cls.secondary_product_uom
+                line.secondary_uom_qty = 2.0
+        cls.purchase_order = po_form.save()
+
+    def test_confirm_purchase_order_without_secondary_uom(self):
+        with Form(self.purchase_order) as po_form:
+            with po_form.order_line.edit(0) as line:
+                line.secondary_uom_id = self.ProductSecondaryUnit.browse()
+                line.secondary_uom_qty = 0.0
+        self.purchase_order.button_confirm()
+        picking = self.purchase_order.picking_ids
+        self.assertEqual(picking.move_lines.secondary_uom_qty, 0.0)
+        self.assertFalse(picking.move_lines.secondary_uom_id)
+        self.assertEqual(picking.move_lines.product_uom_qty, 10.0)
+
+    def test_confirm_new_purchase_order(self):
+        self.purchase_order.button_confirm()
+        picking = self.purchase_order.picking_ids
+        self.assertEqual(picking.move_lines.secondary_uom_qty, 2.0)
+        self.assertEqual(
+            picking.move_lines.secondary_uom_id, self.secondary_product_uom
+        )
+        self.assertEqual(picking.move_lines.product_uom_qty, 10.0)
+
+    def test_update_confirmed_purchase_order(self):
+        self.purchase_order.button_confirm()
+        with Form(self.purchase_order) as po_form:
+            with po_form.order_line.edit(0) as line:
+                line.secondary_uom_qty = 5.0
+        picking = self.purchase_order.picking_ids
+        self.assertEqual(picking.move_lines.secondary_uom_qty, 5.0)
+        self.assertEqual(
+            picking.move_lines.secondary_uom_id, self.secondary_product_uom
+        )
+        self.assertEqual(picking.move_lines.product_uom_qty, 25.0)
+
+    def test_update_confirmed_purchase_order_with_move_validated(self):
+        self.purchase_order.button_confirm()
+        picking = self.purchase_order.picking_ids
+        picking.action_assign()
+        picking.move_line_ids.qty_done = picking.move_lines.product_uom_qty
+        picking.action_done()
+        with Form(self.purchase_order) as po_form:
+            with po_form.order_line.edit(0) as line:
+                line.secondary_uom_qty = 5.0
+        picking = self.purchase_order.picking_ids.filtered(lambda p: p.state != "done")
+        self.assertEqual(picking.move_lines.secondary_uom_qty, 3.0)
+        self.assertEqual(
+            picking.move_lines.secondary_uom_id, self.secondary_product_uom
+        )
+        self.assertEqual(picking.move_lines.product_uom_qty, 15.0)
+        # Assigned move line
+        self.assertEqual(picking.move_line_ids.secondary_uom_qty, 3.0)
+        self.assertEqual(
+            picking.move_line_ids.secondary_uom_id, self.secondary_product_uom
+        )
+        self.assertEqual(picking.move_line_ids.product_uom_qty, 15.0)


### PR DESCRIPTION
cc @Tecnativa TT27362
ping @carlosdauden @chienandalu @alan196 

Depends on:

- [x] https://github.com/OCA/stock-logistics-warehouse/pull/1053