### PR TITLE
[13.0][FIX] purchase_order_secondary_unit, error selecting 2nd_uom when no product_id

### DIFF
--- a/purchase_order_secondary_unit/views/purchase_order_views.xml
+++ b/purchase_order_secondary_unit/views/purchase_order_views.xml
@@ -35,7 +35,7 @@
                     name="secondary_uom_id"
                     domain="[('product_tmpl_id.product_variant_ids', 'in', [product_id])]"
                     options="{'no_create': True}"
-                    attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}"
+                    attrs="{'readonly': ['|',('state', 'in', ('done', 'cancel')), ('product_id', '=', False)]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Fix -> https://github.com/OCA/purchase-workflow/issues/1053