### PR TITLE
[13.0][IMP] procurement_purchase_no_grouping: Add product_category in procured_purchase_grouping field

### DIFF
--- a/procurement_purchase_no_grouping/i18n/es.po
+++ b/procurement_purchase_no_grouping/i18n/es.po
@@ -8,15 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-24 07:53+0000\n"
-"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"POT-Creation-Date: 2021-02-02 12:31+0000\n"
+"PO-Revision-Date: 2021-02-02 13:38+0100\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.3\n"
 
 #. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
@@ -31,31 +32,31 @@ msgstr ""
 #. module: procurement_purchase_no_grouping
 #: model:ir.model,name:procurement_purchase_no_grouping.model_res_company
 msgid "Companies"
-msgstr ""
+msgstr "Compañías"
 
 #. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
 msgid "Grouping"
-msgstr ""
+msgstr "Agrupación"
 
 #. module: procurement_purchase_no_grouping
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__product_category__procured_purchase_grouping__line
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__res_company__procured_purchase_grouping__line
 msgid "No line grouping"
-msgstr ""
+msgstr "Sin agrupación de líneas"
 
 #. module: procurement_purchase_no_grouping
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__product_category__procured_purchase_grouping__order
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__res_company__procured_purchase_grouping__order
 msgid "No order grouping"
-msgstr ""
+msgstr "Sin agrupación de pedidos"
 
 #. module: procurement_purchase_no_grouping
 #: model:ir.model.fields,field_description:procurement_purchase_no_grouping.field_product_category__procured_purchase_grouping
 #: model:ir.model.fields,field_description:procurement_purchase_no_grouping.field_res_company__procured_purchase_grouping
 #: model:ir.model.fields,field_description:procurement_purchase_no_grouping.field_res_config_settings__procured_purchase_grouping
 msgid "Procured purchase grouping"
-msgstr ""
+msgstr "Agrupación de la compra abastecida"
 
 #. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
@@ -70,12 +71,18 @@ msgstr ""
 #. module: procurement_purchase_no_grouping
 #: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
 msgid "Product Category"
-msgstr ""
+msgstr "Categoría de producto"
+
+#. module: procurement_purchase_no_grouping
+#: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__product_category__procured_purchase_grouping__product_category
+#: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__res_company__procured_purchase_grouping__product_category
+msgid "Product category grouping"
+msgstr "Agrupación por categoría de producto"
 
 #. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
 msgid "Purchase"
-msgstr ""
+msgstr "Compra"
 
 #. module: procurement_purchase_no_grouping
 #: model:ir.model,name:procurement_purchase_no_grouping.model_purchase_order_line
@@ -92,7 +99,9 @@ msgid ""
 "* No line grouping: If there are any open purchase order for the same "
 "supplier, it will be reused, but lines won't be merged.\n"
 "* No order grouping: This option will prevent any kind of grouping.\n"
-"* <empty>: If no value is selected, system-wide default will be used."
+"* <empty>: If no value is selected, system-wide default will be used.\n"
+"* Product category grouping: This option groups products in the same "
+"purchase order that belongs to the same product category."
 msgstr ""
 
 #. module: procurement_purchase_no_grouping
@@ -105,24 +114,26 @@ msgid ""
 "grouping lines and orders when possible.\n"
 "* No line grouping: If there are any open purchase order for the same "
 "supplier, it will be reused, but lines won't be merged.\n"
-"* No order grouping: This option will prevent any kind of grouping."
+"* No order grouping: This option will prevent any kind of grouping.\n"
+"* <empty>: If no value is selected, system-wide default will be used.\n"
+"* Product category grouping: This option groups products in the same "
+"purchase order that belongs to the same product category."
 msgstr ""
 
 #. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
 msgid "Set the default procurement purchase grouping type"
 msgstr ""
+"Establecer el tipo de agrupación de compras de aprovisionamiento "
+"predeterminado "
 
 #. module: procurement_purchase_no_grouping
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__product_category__procured_purchase_grouping__standard
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__res_company__procured_purchase_grouping__standard
 msgid "Standard grouping"
-msgstr ""
+msgstr "Agrupación estándar"
 
 #. module: procurement_purchase_no_grouping
 #: model:ir.model,name:procurement_purchase_no_grouping.model_stock_rule
 msgid "Stock Rule"
-msgstr ""
-
-#~ msgid "Purchase Order"
-#~ msgstr "Orden de Compra"
+msgstr "Regla de inventario"

--- a/procurement_purchase_no_grouping/i18n/procurement_purchase_no_grouping.pot
+++ b/procurement_purchase_no_grouping/i18n/procurement_purchase_no_grouping.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-02-02 12:31+0000\n"
+"PO-Revision-Date: 2021-02-02 12:31+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -65,6 +67,12 @@ msgid "Product Category"
 msgstr ""
 
 #. module: procurement_purchase_no_grouping
+#: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__product_category__procured_purchase_grouping__product_category
+#: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__res_company__procured_purchase_grouping__product_category
+msgid "Product category grouping"
+msgstr ""
+
+#. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
 msgid "Purchase"
 msgstr ""
@@ -81,7 +89,8 @@ msgid ""
 "* Standard grouping (default): Procurements will generate purchase orders as always, grouping lines and orders when possible.\n"
 "* No line grouping: If there are any open purchase order for the same supplier, it will be reused, but lines won't be merged.\n"
 "* No order grouping: This option will prevent any kind of grouping.\n"
-"* <empty>: If no value is selected, system-wide default will be used."
+"* <empty>: If no value is selected, system-wide default will be used.\n"
+"* Product category grouping: This option groups products in the same purchase order that belongs to the same product category."
 msgstr ""
 
 #. module: procurement_purchase_no_grouping
@@ -91,7 +100,9 @@ msgid ""
 "Select the behaviour for grouping procured purchases for the the products of this category:\n"
 "* Standard grouping: Procurements will generate purchase orders as always, grouping lines and orders when possible.\n"
 "* No line grouping: If there are any open purchase order for the same supplier, it will be reused, but lines won't be merged.\n"
-"* No order grouping: This option will prevent any kind of grouping."
+"* No order grouping: This option will prevent any kind of grouping.\n"
+"* <empty>: If no value is selected, system-wide default will be used.\n"
+"* Product category grouping: This option groups products in the same purchase order that belongs to the same product category."
 msgstr ""
 
 #. module: procurement_purchase_no_grouping

--- a/procurement_purchase_no_grouping/models/product_category.py
+++ b/procurement_purchase_no_grouping/models/product_category.py
@@ -1,5 +1,5 @@
 # Copyright 2015 AvanzOsc (http://www.avanzosc.es)
-# Copyright 2015-2016 - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2015-2016 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields, models
@@ -13,8 +13,10 @@ class ProductCategory(models.Model):
             ("standard", "Standard grouping"),
             ("line", "No line grouping"),
             ("order", "No order grouping"),
+            ("product_category", "Product category grouping"),
         ],
         string="Procured purchase grouping",
+        default="standard",
         help="Select the behaviour for grouping procured purchases for the "
         "the products of this category:\n"
         "* Standard grouping (default): Procurements will generate "
@@ -25,5 +27,7 @@ class ProductCategory(models.Model):
         "merged.\n"
         "* No order grouping: This option will prevent any kind of "
         "grouping.\n"
-        "* <empty>: If no value is selected, system-wide default will be used.",
+        "* <empty>: If no value is selected, system-wide default will be used.\n"
+        "* Product category grouping: This option groups products in the "
+        "same purchase order that belongs to the same product category.",
     )

--- a/procurement_purchase_no_grouping/models/res_company.py
+++ b/procurement_purchase_no_grouping/models/res_company.py
@@ -12,6 +12,7 @@ class ResCompany(models.Model):
             ("standard", "Standard grouping"),
             ("line", "No line grouping"),
             ("order", "No order grouping"),
+            ("product_category", "Product category grouping"),
         ],
         string="Procured purchase grouping",
         default="standard",
@@ -24,5 +25,8 @@ class ResCompany(models.Model):
         "the same supplier, it will be reused, but lines won't be "
         "merged.\n"
         "* No order grouping: This option will prevent any kind of "
-        "grouping.",
+        "grouping.\n"
+        "* <empty>: If no value is selected, system-wide default will be used.\n"
+        "* Product category grouping: This option groups products in the "
+        "same purchase order that belongs to the same product category.",
     )

--- a/procurement_purchase_no_grouping/models/stock_rule.py
+++ b/procurement_purchase_no_grouping/models/stock_rule.py
@@ -2,6 +2,7 @@
 # Copyright 2015-2016 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Tecnativa - Carlos Dauden
 # Copyright 2020 Radovan Skolnik
+# Copyright 2020 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 import random
@@ -29,7 +30,14 @@ class StockRule(models.Model):
         lines confirmation).
         """
         domain = super()._make_po_get_domain(company_id, values, partner)
-        if values.get("grouping") == "order":
+        if values.get("grouping") == "product_category":
+            if values.get("supplier"):
+                suppinfo = values["supplier"]
+                product = suppinfo.product_id or suppinfo.product_tmpl_id
+                domain += (
+                    ("order_line.product_id.categ_id", "=", product.categ_id.id),
+                )
+        elif values.get("grouping") == "order":
             if values.get("move_dest_ids"):
                 domain += (("id", "=", -values["move_dest_ids"][:1].id),)
             # The minimum is imposed by PG int4 limit

--- a/procurement_purchase_no_grouping/readme/CONFIGURE.rst
+++ b/procurement_purchase_no_grouping/readme/CONFIGURE.rst
@@ -8,6 +8,7 @@ Go to each product category, and select one of these values in the field
 * *No order grouping*: This option will prevent any kind of grouping.
 * *<empty>*: If you select nothing, default value set up in System
   settings will be applied.
+* *Product category grouping*: This option groups products in the same purchase order that belongs to the same product category.
 
 System default behaviour can be set up in System settings / Purchase / Procurement
 Purchase Grouping

--- a/procurement_purchase_no_grouping/readme/CONTRIBUTORS.rst
+++ b/procurement_purchase_no_grouping/readme/CONTRIBUTORS.rst
@@ -4,6 +4,7 @@
   * Sergio Teruel
   * Carlos Dauden
   * Alexandre Díaz
+  * Víctor Martínez
 
 * Ana Juaristi <ajuaristo@gmail.com>
 * Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
+++ b/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
@@ -1,4 +1,5 @@
-# Copyright 2015-2017 - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2015-2017 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields
@@ -11,18 +12,18 @@ class TestProcurementPurchaseNoGrouping(common.SavepointCase):
         super(TestProcurementPurchaseNoGrouping, cls).setUpClass()
         cls.category = cls.env["product.category"].create({"name": "Test category"})
         cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
-        cls.product = cls.env["product.product"].create(
-            {
-                "name": "Test product",
-                "categ_id": cls.category.id,
-                "seller_ids": [(0, 0, {"name": cls.partner.id, "min_qty": 1.0})],
-            }
+        cls.product_1 = cls._create_product(
+            cls, "Test product 1", cls.category, cls.partner
         )
-        # FIXME: Core doesn't find correctly supplier if this is not set
-        cls.product.seller_ids.product_id = cls.product.id
+        cls.product_2 = cls._create_product(
+            cls, "Test product 2", cls.category, cls.partner
+        )
         cls.location = cls.env.ref("stock.stock_location_stock")
         cls.picking_type = cls.env.ref("stock.picking_type_in")
-        cls.origin = "Test procurement_purchase_no_grouping"
+        cls.origin = "Manual Replenishment"
+        cls.prev_orders = cls.env["purchase.order"].search(
+            [("origin", "=", cls.origin)]
+        )
         cls.stock_location_route = cls.env.ref("purchase_stock.route_warehouse0_buy")
         cls.stock_rule = cls.stock_location_route.rule_ids[0]
         cls.values = {
@@ -31,12 +32,22 @@ class TestProcurementPurchaseNoGrouping(common.SavepointCase):
             "date_planned": fields.Datetime.now(),
         }
 
-    def _run_procurement(self):
+    def _create_product(self, name, category, partner):
+        product = self.env["product.product"].create(
+            {
+                "name": name,
+                "categ_id": category.id,
+                "seller_ids": [(0, 0, {"name": partner.id, "min_qty": 1.0})],
+            }
+        )
+        return product
+
+    def _run_procurement(self, product):
         procurement_group_obj = self.env["procurement.group"]
         procurement = procurement_group_obj.Procurement(
-            self.product,
+            product,
             1,
-            self.product.uom_id,
+            product.uom_id,
             self.location,
             False,
             self.origin,
@@ -51,69 +62,126 @@ class TestProcurementPurchaseNoGrouping(common.SavepointCase):
     def _set_system_grouping(self, grouping):
         self.env.company.procured_purchase_grouping = grouping
 
+    def _search_purchases(self):
+        return self.env["purchase.order"].search(
+            [("origin", "=", self.origin), ("id", "not in", self.prev_orders.ids)]
+        )
+
     def test_procurement_grouped_purchase(self):
         self.category.procured_purchase_grouping = "standard"
-        self._run_procurement()
-        self._run_procurement()
-        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
-        self.assertEqual(len(orders), 1, "Procured purchase orders are not the same")
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        orders = self._search_purchases()
         self.assertEqual(
-            len(orders.order_line), 1, "Procured purchase orders lines are not the same"
+            len(orders), 1, "Procured purchase orders are not the same",
         )
-
-    def test_procurement_no_grouping_line_purchase(self):
-        self.category.procured_purchase_grouping = "line"
-        self._run_procurement()
-        self._run_procurement()
-        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
-        self.assertEqual(len(orders), 1, "Procured purchase orders are not the same")
         self.assertEqual(
-            len(orders.order_line), 2, "Procured purchase orders lines are the same"
-        )
-
-    def test_procurement_no_grouping_order_purchase(self):
-        self.category.procured_purchase_grouping = "order"
-        self._run_procurement()
-        self._run_procurement()
-        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
-        self.assertEqual(len(orders), 2, "Procured purchase orders are the same")
-        self.assertEqual(
-            len(orders.mapped("order_line")),
+            len(orders.order_line),
             2,
-            "Procured purchase orders lines are the same",
+            "Procured purchase orders lines are not the same",
         )
 
     def test_procurement_system_grouped_purchase(self):
         self.category.procured_purchase_grouping = None
         self._set_system_grouping("standard")
-        self._run_procurement()
-        self._run_procurement()
-        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        orders = self._search_purchases()
         self.assertEqual(len(orders), 1, "Procured purchase orders are not the same")
         self.assertEqual(
-            len(orders.order_line), 1, "Procured purchase orders lines are not the same"
+            len(orders.order_line), 2, "Procured purchase orders lines are the same",
+        )
+
+    def test_procurement_no_grouping_line_purchase(self):
+        self.category.procured_purchase_grouping = "line"
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        orders = self._search_purchases()
+        self.assertEqual(len(orders), 1, "Procured purchase orders are not the same")
+        self.assertEqual(
+            len(orders.order_line), 3, "Procured purchase orders lines are the same"
         )
 
     def test_procurement_system_no_grouping_line_purchase(self):
         self.category.procured_purchase_grouping = None
         self._set_system_grouping("line")
-        self._run_procurement()
-        self._run_procurement()
-        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        orders = self._search_purchases()
         self.assertEqual(len(orders), 1, "Procured purchase orders are not the same")
         self.assertEqual(
-            len(orders.order_line), 2, "Procured purchase orders lines are the same"
+            len(orders.order_line), 3, "Procured purchase orders lines are the same"
+        )
+
+    def test_procurement_no_grouping_order_purchase(self):
+        self.category.procured_purchase_grouping = "order"
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        orders = self._search_purchases()
+        self.assertEqual(
+            len(orders), 3, "Procured purchase orders are the same",
+        )
+        self.assertEqual(
+            len(orders.mapped("order_line")),
+            3,
+            "Procured purchase orders lines are the same",
         )
 
     def test_procurement_system_no_grouping_order_purchase(self):
         self.category.procured_purchase_grouping = None
         self._set_system_grouping("order")
-        self._run_procurement()
-        self._run_procurement()
-        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
-        self.assertEqual(len(orders), 2, "Procured purchase orders are the same")
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        orders = self._search_purchases()
+        self.assertEqual(len(orders), 3, "Procured purchase orders are the same")
         self.assertEqual(
             len(orders.mapped("order_line")),
-            2,
+            3,
             "Procured purchase orders lines are the same",
         )
+
+    def test_procurement_products_same_category(self):
+        self.category.procured_purchase_grouping = "product_category"
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self._search_purchases()
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(len(orders.mapped("order_line")), 2)
+
+    def test_procurement_system_products_same_category(self):
+        self.category.procured_purchase_grouping = None
+        self._set_system_grouping("product_category")
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self._search_purchases()
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(len(orders.mapped("order_line")), 2)
+
+    def test_procurement_products_distinct_category(self):
+        self.category.procured_purchase_grouping = "product_category"
+        category2 = self.category.copy()
+        self._run_procurement(self.product_1)
+        self.product_2.categ_id = category2.id
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self._search_purchases()
+        self.assertEqual(len(orders), 2)
+
+    def test_procurement_system_products_distinct_category(self):
+        self.category.procured_purchase_grouping = None
+        self._set_system_grouping("product_category")
+        category2 = self.category.copy()
+        self._run_procurement(self.product_1)
+        self.product_2.categ_id = category2.id
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self._search_purchases()
+        self.assertEqual(len(orders), 2)


### PR DESCRIPTION
Add product_category in `procured_purchase_grouping` field

Related to 12.0: https://github.com/OCA/purchase-workflow/pull/1052

@Tecnativa TT27393