### PR TITLE
[12.0][FIX] procurement_purchase_no_grouping: In product_category grouping need to separate in some purchase orders

### DIFF
--- a/procurement_purchase_no_grouping/models/stock_rule.py
+++ b/procurement_purchase_no_grouping/models/stock_rule.py
@@ -5,7 +5,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 import random
-
 from odoo import api, models
 
 
@@ -24,8 +23,9 @@ class StockRule(models.Model):
     def _make_po_get_domain(self, values, partner):
         domain = super()._make_po_get_domain(values, partner)
         if self.env.context.get('grouping', 'standard') == 'product_category':
-            if values.get("product_id"):
-                product = self.env["product.product"].browse(values["product_id"])
+            if values.get("supplier"):
+                suppinfo = values["supplier"]
+                product = suppinfo.product_id or suppinfo.product_tmpl_id
                 domain += (
                     ("order_line.product_id.categ_id", "=", product.categ_id.id),
                 )

--- a/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
+++ b/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
@@ -1,7 +1,6 @@
 # Copyright 2015-2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import fields
 from odoo.tests import common
 
 
@@ -15,117 +14,104 @@ class TestProcurementPurchaseNoGrouping(common.SavepointCase):
         cls.partner = cls.env['res.partner'].create({
             'name': 'Test partner',
         })
-        cls.product = cls.env['product.product'].create({
-            'name': 'Test product',
-            'categ_id': cls.category.id,
+        cls.product_1 = cls._create_product(
+            cls, 'Test product 1', cls.category, cls.partner
+        )
+        cls.product_2 = cls._create_product(
+            cls, 'Test product 2', cls.category, cls.partner
+        )
+        cls.location = cls.env.ref('stock.stock_location_stock')
+        cls.picking_type = cls.env.ref('stock.picking_type_in')
+        cls.origin = "Manual Replenishment"
+        cls.prev_orders = cls.env['purchase.order'].search([
+            ("origin", "=", cls.origin),
+        ])
+        cls.stock_location_route = cls.env.ref(
+            'purchase_stock.route_warehouse0_buy')
+        cls.stock_rule = cls.stock_location_route.rule_ids[0]
+
+    def _create_product(self, name, category, partner):
+        product = self.env['product.product'].create({
+            'name': name,
+            'categ_id': category.id,
             'seller_ids': [
                 (0, 0, {
-                    'name': cls.partner.id,
+                    'name': partner.id,
                     'min_qty': 1.0,
                 }),
             ]}
         )
-        # FIXME: Core doesn't find correctly supplier if this is not set
-        cls.product.seller_ids.product_id = cls.product.id
-        cls.location = cls.env.ref('stock.stock_location_stock')
-        cls.picking_type = cls.env.ref('stock.picking_type_in')
-        cls.origin = 'Test procurement_purchase_no_grouping'
-        cls.stock_location_route = cls.env.ref(
-            'purchase_stock.route_warehouse0_buy')
-        cls.stock_rule = cls.stock_location_route.rule_ids[0]
-        cls.values = {
-            # FIXME: Core doesn't find correctly supplier if not recordset
-            'company_id': cls.env.user.company_id,
-            'date_planned': fields.Datetime.now(),
-        }
+        return product
 
     def _run_procurement(self, product):
-        self.values['product_id'] = product.id
-        self.stock_rule._run_buy(
-            product, 1, product.uom_id, self.location, False,
-            self.origin, self.values,
-        )
+        wizard = self.env["product.replenish"].with_context(
+            default_product_id=product.id
+        ).create({})
+        wizard.launch_replenishment()
+
+    def _search_purchases(self):
+        return self.env['purchase.order'].search([
+            ("origin", "=", self.origin),
+            ("id", "not in", self.prev_orders.ids),
+        ])
 
     def test_procurement_grouped_purchase(self):
         self.category.procured_purchase_grouping = 'standard'
-        self._run_procurement(self.product)
-        self._run_procurement(self.product)
-        orders = self.env['purchase.order'].search([
-            ('origin', '=', self.origin),
-        ])
-        self.assertEqual(
-            len(orders), 1, 'Procured purchase orders are not the same',
-        )
-        self.assertEqual(
-            len(orders.order_line), 1,
-            'Procured purchase orders lines are not the same',
-        )
-
-    def test_procurement_no_grouping_line_purchase(self):
-        self.category.procured_purchase_grouping = 'line'
-        self._run_procurement(self.product)
-        self._run_procurement(self.product)
-        orders = self.env['purchase.order'].search([
-            ('origin', '=', self.origin),
-        ])
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        orders = self._search_purchases()
         self.assertEqual(
             len(orders), 1, 'Procured purchase orders are not the same',
         )
         self.assertEqual(
             len(orders.order_line), 2,
+            'Procured purchase orders lines are not the same',
+        )
+
+    def test_procurement_no_grouping_line_purchase(self):
+        self.category.procured_purchase_grouping = 'line'
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        orders = self._search_purchases()
+        self.assertEqual(
+            len(orders), 1, 'Procured purchase orders are not the same',
+        )
+        self.assertEqual(
+            len(orders.order_line), 3,
             'Procured purchase orders lines are the same',
         )
 
     def test_procurement_no_grouping_order_purchase(self):
         self.category.procured_purchase_grouping = 'order'
-        self._run_procurement(self.product)
-        self._run_procurement(self.product)
-        orders = self.env['purchase.order'].search([
-            ('origin', '=', self.origin),
-        ])
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        orders = self._search_purchases()
         self.assertEqual(
-            len(orders), 2, 'Procured purchase orders are the same',
+            len(orders), 3, 'Procured purchase orders are the same',
         )
         self.assertEqual(
-            len(orders.mapped('order_line')), 2,
+            len(orders.mapped('order_line')), 3,
             'Procured purchase orders lines are the same',
         )
 
-    def test_procurement_products_category_grouped_order_purchase(self):
+    def test_procurement_products_same_category(self):
         self.category.procured_purchase_grouping = 'product_category'
-        self._run_procurement(self.product)
-        product2 = self.product.copy()
-        product2.write({
-            'seller_ids': [
-                (0, 0, {
-                    'name': self.partner.id,
-                    'min_qty': 1.0,
-                })
-            ]
-        })
-        self._run_procurement(product2)
-        orders = self.env['purchase.order'].search([
-            ('origin', '=', self.origin),
-        ])
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self._search_purchases()
         self.assertEqual(len(orders), 1)
         self.assertEqual(len(orders.mapped('order_line')), 2)
 
-    def test_procurement_products_distinct_category_grouped_order_purchase(self):
+    def test_procurement_products_distinct_category(self):
         self.category.procured_purchase_grouping = 'product_category'
         category2 = self.category.copy()
-        self._run_procurement(self.product)
-        product2 = self.product.copy()
-        product2.write({
-            'categ_id': category2.id,
-            'seller_ids': [
-                (0, 0, {
-                    'name': self.partner.id,
-                    'min_qty': 1.0,
-                })
-            ]
-        })
-        self._run_procurement(product2)
-        orders = self.env['purchase.order'].search([
-            ('origin', '=', self.origin),
-        ])
+        self._run_procurement(self.product_1)
+        self.product_2.categ_id = category2.id
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self._search_purchases()
         self.assertEqual(len(orders), 2)


### PR DESCRIPTION
Some test indicate that product_category grouping don't work fine (https://github.com/OCA/purchase-workflow/blob/12.0/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py#L110)

In product_category grouping need to separate in some purchase orders.

In 13.0: https://github.com/OCA/purchase-workflow/pull/1081

Please @pedrobaeza and @carlosdauden review it.

@Tecnativa TT27393