### PR TITLE
[13.0][FIX] procurement_purchase_no_grouping: In product_category grouping need to separate in some purchase orders

### DIFF
--- a/procurement_purchase_no_grouping/i18n/es.po
+++ b/procurement_purchase_no_grouping/i18n/es.po
@@ -8,15 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-24 07:53+0000\n"
-"PO-Revision-Date: 2017-11-24 07:53+0000\n"
+"POT-Creation-Date: 2021-01-19 13:00+0000\n"
+"PO-Revision-Date: 2021-01-20 10:03+0100\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.3\n"
 
 #. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
@@ -42,20 +43,20 @@ msgstr ""
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__product_category__procured_purchase_grouping__line
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__res_company__procured_purchase_grouping__line
 msgid "No line grouping"
-msgstr ""
+msgstr "Sin agrupación de líneas"
 
 #. module: procurement_purchase_no_grouping
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__product_category__procured_purchase_grouping__order
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__res_company__procured_purchase_grouping__order
 msgid "No order grouping"
-msgstr ""
+msgstr "Sin agrupación de pedidos"
 
 #. module: procurement_purchase_no_grouping
 #: model:ir.model.fields,field_description:procurement_purchase_no_grouping.field_product_category__procured_purchase_grouping
 #: model:ir.model.fields,field_description:procurement_purchase_no_grouping.field_res_company__procured_purchase_grouping
 #: model:ir.model.fields,field_description:procurement_purchase_no_grouping.field_res_config_settings__procured_purchase_grouping
 msgid "Procured purchase grouping"
-msgstr ""
+msgstr "Agrupación de la compra abastecida"
 
 #. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
@@ -70,7 +71,12 @@ msgstr ""
 #. module: procurement_purchase_no_grouping
 #: model:ir.model,name:procurement_purchase_no_grouping.model_product_category
 msgid "Product Category"
-msgstr ""
+msgstr "Categoría de producto"
+
+#. module: procurement_purchase_no_grouping
+#: selection:product.category,procured_purchase_grouping:0
+msgid "Product category grouping"
+msgstr "Agrupación por categoría de producto"
 
 #. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
@@ -106,7 +112,19 @@ msgid ""
 "* No line grouping: If there are any open purchase order for the same "
 "supplier, it will be reused, but lines won't be merged.\n"
 "* No order grouping: This option will prevent any kind of grouping."
+"* Product category grouping: This option groups products in the same "
+"purchase order that belongs to the same product category."
 msgstr ""
+"Seleccione el comportamiento para agrupar las compras adquiridas para los "
+"productos de esta categoría:\n"
+"* Agrupación estándar (predeterminada): Las adquisiciones generarán órdenes "
+"de compra como siempre, agrupando líneas y órdenes cuando sea posible.\n"
+"* Sin agrupación de líneas: si hay alguna orden de compra abierta para el "
+"mismo proveedor, se reutilizará, pero las líneas no se fusionarán.\n"
+"* Sin agrupación de pedidos: esta opción evitará cualquier tipo de "
+"agrupación.\n"
+"* Agrupación por categoría de producto: esta opción agrupa productos en la "
+"misma orden de compra que pertenece a la misma categoría de producto."
 
 #. module: procurement_purchase_no_grouping
 #: model_terms:ir.ui.view,arch_db:procurement_purchase_no_grouping.res_config_settings_view_form_procurement_purchase_grouping
@@ -117,12 +135,12 @@ msgstr ""
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__product_category__procured_purchase_grouping__standard
 #: model:ir.model.fields.selection,name:procurement_purchase_no_grouping.selection__res_company__procured_purchase_grouping__standard
 msgid "Standard grouping"
-msgstr ""
+msgstr "Agrupación estándar"
 
 #. module: procurement_purchase_no_grouping
 #: model:ir.model,name:procurement_purchase_no_grouping.model_stock_rule
 msgid "Stock Rule"
-msgstr ""
+msgstr "Regla de inventario"
 
 #~ msgid "Purchase Order"
 #~ msgstr "Orden de Compra"

--- a/procurement_purchase_no_grouping/i18n/procurement_purchase_no_grouping.pot
+++ b/procurement_purchase_no_grouping/i18n/procurement_purchase_no_grouping.pot
@@ -6,7 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"Last-Translator: \n"
+"POT-Creation-Date: 2021-01-19 13:00+0000\n"
+"PO-Revision-Date: 2021-01-19 13:00+0000\n"
+"Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -81,17 +83,8 @@ msgid ""
 "* Standard grouping (default): Procurements will generate purchase orders as always, grouping lines and orders when possible.\n"
 "* No line grouping: If there are any open purchase order for the same supplier, it will be reused, but lines won't be merged.\n"
 "* No order grouping: This option will prevent any kind of grouping.\n"
+"* Product category grouping: This option groups products in the same purchase order that belongs to the same product category."
 "* <empty>: If no value is selected, system-wide default will be used."
-msgstr ""
-
-#. module: procurement_purchase_no_grouping
-#: model:ir.model.fields,help:procurement_purchase_no_grouping.field_res_company__procured_purchase_grouping
-#: model:ir.model.fields,help:procurement_purchase_no_grouping.field_res_config_settings__procured_purchase_grouping
-msgid ""
-"Select the behaviour for grouping procured purchases for the the products of this category:\n"
-"* Standard grouping: Procurements will generate purchase orders as always, grouping lines and orders when possible.\n"
-"* No line grouping: If there are any open purchase order for the same supplier, it will be reused, but lines won't be merged.\n"
-"* No order grouping: This option will prevent any kind of grouping."
 msgstr ""
 
 #. module: procurement_purchase_no_grouping

--- a/procurement_purchase_no_grouping/models/product_category.py
+++ b/procurement_purchase_no_grouping/models/product_category.py
@@ -1,5 +1,5 @@
 # Copyright 2015 AvanzOsc (http://www.avanzosc.es)
-# Copyright 2015-2016 - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2015-2016 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields, models
@@ -13,6 +13,7 @@ class ProductCategory(models.Model):
             ("standard", "Standard grouping"),
             ("line", "No line grouping"),
             ("order", "No order grouping"),
+            ("product_category", "Product category grouping"),
         ],
         string="Procured purchase grouping",
         help="Select the behaviour for grouping procured purchases for the "
@@ -25,5 +26,7 @@ class ProductCategory(models.Model):
         "merged.\n"
         "* No order grouping: This option will prevent any kind of "
         "grouping.\n"
+        "* Product category grouping: This option groups products in the "
+        "same purchase order that belongs to the same product category.\n"
         "* <empty>: If no value is selected, system-wide default will be used.",
     )

--- a/procurement_purchase_no_grouping/models/res_company.py
+++ b/procurement_purchase_no_grouping/models/res_company.py
@@ -12,6 +12,7 @@ class ResCompany(models.Model):
             ("standard", "Standard grouping"),
             ("line", "No line grouping"),
             ("order", "No order grouping"),
+            ("product_category", "Product category grouping"),
         ],
         string="Procured purchase grouping",
         default="standard",
@@ -24,5 +25,7 @@ class ResCompany(models.Model):
         "the same supplier, it will be reused, but lines won't be "
         "merged.\n"
         "* No order grouping: This option will prevent any kind of "
-        "grouping.",
+        "grouping.\n"
+        "* Product category grouping: This option groups products in the "
+        "same purchase order that belongs to the same product category.",
     )

--- a/procurement_purchase_no_grouping/readme/CONFIGURE.rst
+++ b/procurement_purchase_no_grouping/readme/CONFIGURE.rst
@@ -6,6 +6,7 @@ Go to each product category, and select one of these values in the field
 * *No line grouping*: With this value, if there are any open purchase order
   for the same supplier, it will be reused, but lines won't be merged.
 * *No order grouping*: This option will prevent any kind of grouping.
+* *Product category grouping*: This option groups products in the same purchase order that belongs to the same product category.
 * *<empty>*: If you select nothing, default value set up in System
   settings will be applied.
 

--- a/procurement_purchase_no_grouping/readme/CONTRIBUTORS.rst
+++ b/procurement_purchase_no_grouping/readme/CONTRIBUTORS.rst
@@ -4,6 +4,7 @@
   * Sergio Teruel
   * Carlos Dauden
   * Alexandre Díaz
+  * Víctor Martínez
 
 * Ana Juaristi <ajuaristo@gmail.com>
 * Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
+++ b/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
@@ -1,4 +1,5 @@
-# Copyright 2015-2017 - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2015-2017 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Matínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields
@@ -11,15 +12,12 @@ class TestProcurementPurchaseNoGrouping(common.SavepointCase):
         super(TestProcurementPurchaseNoGrouping, cls).setUpClass()
         cls.category = cls.env["product.category"].create({"name": "Test category"})
         cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
-        cls.product = cls.env["product.product"].create(
-            {
-                "name": "Test product",
-                "categ_id": cls.category.id,
-                "seller_ids": [(0, 0, {"name": cls.partner.id, "min_qty": 1.0})],
-            }
+        cls.product_1 = cls._create_product(
+            cls, "Test product 1", cls.category, cls.partner
         )
-        # FIXME: Core doesn't find correctly supplier if this is not set
-        cls.product.seller_ids.product_id = cls.product.id
+        cls.product_2 = cls._create_product(
+            cls, "Test product 2", cls.category, cls.partner
+        )
         cls.location = cls.env.ref("stock.stock_location_stock")
         cls.picking_type = cls.env.ref("stock.picking_type_in")
         cls.origin = "Test procurement_purchase_no_grouping"
@@ -31,12 +29,24 @@ class TestProcurementPurchaseNoGrouping(common.SavepointCase):
             "date_planned": fields.Datetime.now(),
         }
 
-    def _run_procurement(self):
+    def _create_product(self, name, category, partner):
+        product = self.env["product.product"].create(
+            {
+                "name": name,
+                "categ_id": category.id,
+                "seller_ids": [(0, 0, {"name": partner.id, "min_qty": 1.0})],
+            }
+        )
+        # FIXME: Core doesn't find correctly supplier if this is not set
+        product.seller_ids.product_id = product.id
+        return product
+
+    def _run_procurement(self, product):
         procurement_group_obj = self.env["procurement.group"]
         procurement = procurement_group_obj.Procurement(
-            self.product,
+            product,
             1,
-            self.product.uom_id,
+            product.uom_id,
             self.location,
             False,
             self.origin,
@@ -53,67 +63,113 @@ class TestProcurementPurchaseNoGrouping(common.SavepointCase):
 
     def test_procurement_grouped_purchase(self):
         self.category.procured_purchase_grouping = "standard"
-        self._run_procurement()
-        self._run_procurement()
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
         orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
         self.assertEqual(len(orders), 1, "Procured purchase orders are not the same")
         self.assertEqual(
-            len(orders.order_line), 1, "Procured purchase orders lines are not the same"
+            len(orders.order_line), 2, "Procured purchase orders lines are not the same"
         )
 
     def test_procurement_no_grouping_line_purchase(self):
         self.category.procured_purchase_grouping = "line"
-        self._run_procurement()
-        self._run_procurement()
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
         orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
         self.assertEqual(len(orders), 1, "Procured purchase orders are not the same")
         self.assertEqual(
-            len(orders.order_line), 2, "Procured purchase orders lines are the same"
+            len(orders.order_line), 3, "Procured purchase orders lines are the same"
         )
 
     def test_procurement_no_grouping_order_purchase(self):
         self.category.procured_purchase_grouping = "order"
-        self._run_procurement()
-        self._run_procurement()
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
         orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
-        self.assertEqual(len(orders), 2, "Procured purchase orders are the same")
+        self.assertEqual(len(orders), 3, "Procured purchase orders are the same")
         self.assertEqual(
             len(orders.mapped("order_line")),
-            2,
+            3,
             "Procured purchase orders lines are the same",
         )
 
     def test_procurement_system_grouped_purchase(self):
         self.category.procured_purchase_grouping = None
         self._set_system_grouping("standard")
-        self._run_procurement()
-        self._run_procurement()
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
         orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
         self.assertEqual(len(orders), 1, "Procured purchase orders are not the same")
         self.assertEqual(
-            len(orders.order_line), 1, "Procured purchase orders lines are not the same"
+            len(orders.order_line), 2, "Procured purchase orders lines are not the same"
         )
 
     def test_procurement_system_no_grouping_line_purchase(self):
         self.category.procured_purchase_grouping = None
         self._set_system_grouping("line")
-        self._run_procurement()
-        self._run_procurement()
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
         orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
         self.assertEqual(len(orders), 1, "Procured purchase orders are not the same")
         self.assertEqual(
-            len(orders.order_line), 2, "Procured purchase orders lines are the same"
+            len(orders.order_line), 3, "Procured purchase orders lines are the same"
         )
 
     def test_procurement_system_no_grouping_order_purchase(self):
         self.category.procured_purchase_grouping = None
         self._set_system_grouping("order")
-        self._run_procurement()
-        self._run_procurement()
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
         orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
-        self.assertEqual(len(orders), 2, "Procured purchase orders are the same")
+        self.assertEqual(len(orders), 3, "Procured purchase orders are the same")
         self.assertEqual(
             len(orders.mapped("order_line")),
-            2,
+            3,
             "Procured purchase orders lines are the same",
         )
+
+    def test_procurement_products_category_grouped_order_purchase(self):
+        self.category.procured_purchase_grouping = "product_category"
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(len(orders.mapped("order_line")), 2)
+
+    def test_procurement_system_products_category_grouped_order_purchase(self):
+        self.category.procured_purchase_grouping = None
+        self._set_system_grouping("product_category")
+        self._run_procurement(self.product_1)
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(len(orders.mapped("order_line")), 2)
+
+    def test_procurement_products_distinct_category_grouped_order_purchase(self):
+        self.category.procured_purchase_grouping = "product_category"
+        category2 = self.category.copy({"procured_purchase_grouping": "standard"})
+        self._run_procurement(self.product_1)
+        self.product_2.categ_id = category2.id
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
+        self.assertEqual(len(orders), 2)
+
+    def test_procurement_system_products_distinct_category_grouped_order_purchase(self):
+        self.category.procured_purchase_grouping = None
+        self._set_system_grouping("product_category")
+        category2 = self.category.copy({"procured_purchase_grouping": "standard"})
+        self._run_procurement(self.product_1)
+        self.product_2.categ_id = category2.id
+        self._run_procurement(self.product_2)
+        self._run_procurement(self.product_1)
+        orders = self.env["purchase.order"].search([("origin", "=", self.origin)])
+        self.assertEqual(len(orders), 2)


### PR DESCRIPTION
- [ ] Pending rebase 13.0 when https://github.com/OCA/purchase-workflow/pull/1077 is merged.

Some test indicate that product_category grouping don't work fine (https://github.com/OCA/purchase-workflow/blob/12.0/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py#L131)

In product_category grouping need to separate in some purchase orders.

In 12.0: https://github.com/OCA/purchase-workflow/pull/1080

@Tecnativa TT27393