### PR TITLE
[12.0][FIX] purchase_order_product_recommendation: Add vendor for new line

### DIFF
--- a/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py
+++ b/purchase_order_product_recommendation/wizards/purchase_order_recommendation.py
@@ -376,5 +376,8 @@ class PurchaseOrderRecommendationLine(models.TransientModel):
         return {
             'order_id': self.wizard_id.order_id.id,
             'product_id': self.product_id.id,
+            # set this related field manually, as there's a glitch
+            # in ORM that doesn't set its initial value
+            'partner_id': self.partner_id.id,
             'sequence': sequence,
         }


### PR DESCRIPTION
If line.partner_id is not defined, unit price is catched from product instead of vendor pricelist.