### PR TITLE
[12.0][FIX] purchase_allowed_product: Add use_only_supplied_product to invoice form

### DIFF
--- a/purchase_allowed_product/views/account_invoice_view.xml
+++ b/purchase_allowed_product/views/account_invoice_view.xml
@@ -17,6 +17,15 @@
             </xpath>
         </field>
     </record>
+    <record model="ir.ui.view" id="account_invoice_form_supplied_product">
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_form" />
+        <field name="arch" type="xml">
+            <field name="invoice_line_ids" position="before">
+                <field name="use_only_supplied_product" invisible="1" />
+            </field>
+        </field>
+    </record>
     <record model="ir.ui.view" id="invoice_line_form_supplied_product">
         <field name="model">account.invoice.line</field>
         <field name="inherit_id" ref="account.view_invoice_line_form" />


### PR DESCRIPTION
Fixing https://github.com/OCA/purchase-workflow/issues/1083

Due to the context being added to https://github.com/OCA/purchase-workflow/blob/bc3b5bd2b5e2f34c6f2b88a995333819f2b3d0c7/purchase_allowed_product/views/account_invoice_view.xml#L20-L28

Both vendor bill and customer invoice need to have the `use_only_supplied_product` in the form otherwise there will be a js error.