### PR TITLE
[12.0][FIX] purchase_picking_state: `show_purchase` unused in 12.0

### DIFF
--- a/purchase_picking_state/views/purchase_view.xml
+++ b/purchase_picking_state/views/purchase_view.xml
@@ -16,7 +16,7 @@
 		<field name="inherit_id" ref="purchase.purchase_order_tree" />
 		<field name="arch" type="xml">
 			<field name="state" position="after">
-				<field name="picking_state" invisible="not context.get('show_purchase', False)" />
+				<field name="picking_state" attrs="{'invisible':[('picking_state','=', 'draft')]}" />
 			</field>
 		</field>
 	</record>


### PR DESCRIPTION
In [10.0](https://github.com/OCA/OCB/blob/10.0/addons/purchase/views/purchase_views.xml#L433) & [11.0](https://github.com/OCA/OCB/blob/11.0/addons/purchase/views/purchase_views.xml#L444), context information such as the `show_purchase` value was set on the `purchase_form_action` Window Action.

However, in [12.0](https://github.com/OCA/OCB/blob/12.0/addons/purchase/views/purchase_views.xml#L416), `context` is now empty and `show_purchase` is nowhere to be found, resulting in `picking_state` never appearing on the `purchase_order_tree` Tree View.

This PR removes the use of `show_purchase`.

Note: an alternative would be to reuse `{ 'show_purchase': True}` in the `purchase_form_action` Window Action.