### PR TITLE
[13.0][FIX] purchase_delivery_split_date crash with notes and sections with corfirmation 

### DIFF
--- a/purchase_delivery_split_date/README.rst
+++ b/purchase_delivery_split_date/README.rst
@@ -100,6 +100,7 @@ Contributors
 * Lois Rilo <lois.rilo@forgeflow.com> (migration to v10)
 * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* Mallory Marcot <contact@mallory-marcot.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -37,7 +37,9 @@ class PurchaseOrderLine(models.Model):
         """Group the receptions in one picking per group key"""
         moves = self.env["stock.move"]
         # Group the order lines by group key
-        order_lines = sorted(self, key=lambda l: l.date_planned)
+        order_lines = sorted(
+            self.filtered(lambda l: not l.display_type), key=lambda l: l.date_planned
+        )
         date_groups = groupby(
             order_lines, lambda l: self._get_group_keys(l.order_id, l, picking=picking)
         )


### PR DESCRIPTION
Hello,

It should fix:
#1040
#1039