### PR TITLE
[13.0][FIX] purchase_order_uninvoiced_amount: Allow amount_uninvoiced negative

### DIFF
--- a/purchase_order_uninvoiced_amount/models/purchase_order.py
+++ b/purchase_order_uninvoiced_amount/models/purchase_order.py
@@ -1,10 +1,10 @@
 # Copyright 2020 Tecnativa - Manuel Calero
 # Copyright 2020 Tecnativa - Pedro M. Baeza
 # Copyright 2020 Tecnativa - João Marques
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
-from odoo.tools.float_utils import float_compare
 
 
 class PurchaseOrder(models.Model):
@@ -28,9 +28,6 @@ class PurchaseOrder(models.Model):
                     qty = line.product_qty - line.qty_invoiced
                 else:
                     qty = line.qty_received - line.qty_invoiced
-                rounding = line.product_uom.rounding
-                if float_compare(qty, 0.0, precision_rounding=rounding) <= 0:
-                    qty = 0.0
                 # we use this way for being compatible with purchase_discount
                 price_unit = (
                     line.product_qty

--- a/purchase_order_uninvoiced_amount/readme/CONTRIBUTORS.rst
+++ b/purchase_order_uninvoiced_amount/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
   * João Marques
   * Pedro M. Baeza
   * Ernesto Tejeda
+  * Víctor Martínez

--- a/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
+++ b/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Tecnativa - Manuel Calero
 # Copyright 2020 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import fields
@@ -131,3 +132,12 @@ class TestPurchaseOrderUninvoiceAmount(SavepointCase):
         self.assertEquals(purchase.amount_uninvoiced, 400)
         self._create_invoice_from_purchase(purchase)
         self.assertEquals(purchase.amount_uninvoiced, 0)
+
+    def test_create_purchase_receive_and_invoice_more_qty(self):
+        purchase = self._create_purchase(10, 10)
+        self.assertEquals(purchase.amount_uninvoiced, 1000)
+        invoice = self._create_invoice_from_purchase(purchase)
+        with Form(invoice) as invoice_form:
+            with invoice_form.invoice_line_ids.edit(0) as line_form:
+                line_form.quantity = 20
+        self.assertEquals(purchase.amount_uninvoiced, -1000)


### PR DESCRIPTION
Steps to reproduce:

- Create a purchase order with quantity 10
- Receive 10 units
- Create an invoice and define 20 units
`amount_uninvoiced` is 0 but it should be negative (-100 € for example)

In 12.0 happen same.

Please @pedrobaeza and @ernestotejeda can you review it?

@Tecnativa TT28185