### PR TITLE
[13.0] [IMP] purchase_request: index on created_purchase_request_line_id

### DIFF
--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -14,6 +14,7 @@ class StockMove(models.Model):
         ondelete="set null",
         readonly=True,
         copy=False,
+        index=True,
     )
 
     purchase_request_allocation_ids = fields.One2many(


### PR DESCRIPTION
Avoid:
`LOG:  duration: 567.259 ms  statement: SELECT "stock_move".id FROM "stock_move" WHERE ("stock_move"."created_purchase_request_line_id" in (103989)) ORDER BY "stock_move"."sequence" ,"stock_move"."id"`