### PR TITLE
[14.0][IMP] purchase_request, auto sequence only when saved

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -56,8 +56,11 @@ class PurchaseRequest(models.Model):
     name = fields.Char(
         string="Request Reference",
         required=True,
-        default=_get_default_name,
+        default=lambda self: _("New"),
         track_visibility="onchange",
+    )
+    is_name_editable = fields.Boolean(
+        default=lambda self: self.env.user.has_group("base.group_no_one"),
     )
     origin = fields.Char(string="Source Document")
     date_start = fields.Date(
@@ -225,6 +228,8 @@ class PurchaseRequest(models.Model):
 
     @api.model
     def create(self, vals):
+        if vals.get("name", _("New")) == _("New"):
+            vals["name"] = self._get_default_name()
         request = super(PurchaseRequest, self).create(vals)
         if vals.get("assigned_to"):
             partner_id = self._get_partner_id(request)

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -102,10 +102,11 @@
                     </div>
                     <h1>
                         <field name="is_editable" attrs="{'invisible': True}" />
+                        <field name="is_name_editable" invisible="1" />
                         <field
                             name="name"
                             class="oe_inline"
-                            attrs="{'readonly': [('is_editable','=', False)]}"
+                            attrs="{'readonly': [('is_name_editable','=', False)]}"
                         />
                     </h1>
                     <group>


### PR DESCRIPTION
This PR change behavior when create new Purchase Request. Instead of immediately run the number, it now only run number when user click "Save".

**New Record**

![image](https://user-images.githubusercontent.com/1973598/108819333-4e857480-75ed-11eb-866f-0036458a35b6.png)

**Saved Record (but still editable)**

![image](https://user-images.githubusercontent.com/1973598/108819344-50e7ce80-75ed-11eb-9913-b852a662beac.png)

**Note:**

* Keeping inline with current behavior which use `is_editable` to determine if the `name` is editable during draft. But this means, user can change name to anything.
* Personally, I prefer to make the name field readonly at all time. WDTY?