### PR TITLE
[12.0][FIX] subcontracted_service: check if purchase_ok

### DIFF
--- a/subcontracted_service/i18n/subcontracted_service.pot
+++ b/subcontracted_service/i18n/subcontracted_service.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-03-10 10:21+0000\n"
+"PO-Revision-Date: 2021-03-10 10:21+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -30,6 +32,7 @@ msgid "Subcontracted Service"
 msgstr ""
 
 #. module: subcontracted_service
+#: model_terms:ir.ui.view,arch_db:subcontracted_service.product_template_subcontracted_service_view_form
 #: model_terms:ir.ui.view,arch_db:subcontracted_service.view_warehouse
 msgid "Subcontracting"
 msgstr ""

--- a/subcontracted_service/models/procurement.py
+++ b/subcontracted_service/models/procurement.py
@@ -11,8 +11,8 @@ class ProcurementGroup(models.Model):
     @api.model
     def _is_subcontracted_service(self, product_id):
         return (product_id.type == 'service' and
-                product_id.property_subcontracted_service or
-                False)
+                product_id.property_subcontracted_service and
+                product_id.purchase_ok or False)
 
     @api.model
     def _get_rule(self, product_id, location_id, values):

--- a/subcontracted_service/views/product_template.xml
+++ b/subcontracted_service/views/product_template.xml
@@ -6,8 +6,10 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='type']" position="after">
-                <field name="property_subcontracted_service" attrs="{'invisible': [('type', '!=', 'service')]}"/>
+            <xpath expr="//group[@name='bill']" position="before">
+                <group string="Subcontracting" attrs="{'invisible': [('type','!=','service')]}">
+                    <field name="property_subcontracted_service"/>
+                </group>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
`property_subcontracted_service` is a purchase only option so:

- Move it from general info page to purchase page (that way it will be hidden when `purchase_ok` is not set)
- Check for `purchase_ok` to validate `_is_subcontracted_service`