### PR TITLE
[10.0][FIX] purchase_request_to_rfq: domain on existing purchase order lines

### DIFF
--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -196,8 +196,9 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                             item.line_id.analytic_account_id.id or False),
                            ]
         if not item.product_id:
+            order_line_data = [x for x in order_line_data if x[0] != "name"]
             order_line_data.append(('name', '=', item.name))
-        if not item.line_id.procurement_id and \
+        if item.line_id.procurement_id and \
                 item.line_id.procurement_id.location_id:
             order_line_data.append(
                 ('location_id', '=',


### PR DESCRIPTION
Two corner cases not well solved:
* no product in the purchase request line: then use the name, but remove the domain on the product
* if there is a procurement location then we check if there is a procurement, the condition is incorrect.