### PR TITLE
[13.0]  purchase_delivery_split_date: fix move assign after split

### DIFF
--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -106,6 +106,7 @@ class PurchaseOrder(models.Model):
                             move._do_unreserve()
                             move.picking_id = pickings_by_date[date_key]
                             move.date_expected = date_key
+                            move._action_assign()
             for picking in pickings_by_date.values():
                 if len(picking.move_lines) == 0:
                     picking.write({"state": "cancel"})


### PR DESCRIPTION
### Context
When a confirmed PO line has its scheduled date changed, the related stock move is moved to another picking.
Before the move is assigned to another picking, it is unreserved. However, after the change of picking_id and setting the new date, it is not reserved back again which is causing the reception to not be ready.