### PR TITLE
[8.0][FIX] purchase_order_reorder_lines: Add purchase_partial_invoicing depends to prevent error in tests

### DIFF
--- a/purchase_order_reorder_lines/tests/test_invoice_on_lines.py
+++ b/purchase_order_reorder_lines/tests/test_invoice_on_lines.py
@@ -27,6 +27,8 @@ from openerp.tools.safe_eval import safe_eval
 
 class testPurchasePartialInvoicing(common.TransactionCase):
 
+    post_install = True
+
     def setUp(self):
         super(testPurchasePartialInvoicing, self).setUp()
         self.context = self.env['res.users'].context_get()


### PR DESCRIPTION
Add `purchase_partial_invoicing` depends to prevent error in tests.

Please @joao-p-marques can you review it?

@Tecnativa TT28516