### PR TITLE
[14.0][FIX] purchase_work_acceptance: Set invoice date manually on tests

### DIFF
--- a/purchase_work_acceptance/tests/test_purchase_work_acceptance.py
+++ b/purchase_work_acceptance/tests/test_purchase_work_acceptance.py
@@ -191,6 +191,7 @@ class TestPurchaseWorkAcceptance(TransactionCase):
             invoice.action_post()  # Warn when quantity not equal to WA
         invoice_line.quantity = qty
         self.assertEqual(invoice.state, "draft")
+        invoice.invoice_date = invoice.date
         invoice.action_post()
         self.assertEqual(invoice.state, "posted")
 
@@ -213,6 +214,7 @@ class TestPurchaseWorkAcceptance(TransactionCase):
         invoice = f.save()
         invoice.wa_id = work_acceptance
         self.assertEqual(invoice.state, "draft")
+        invoice.invoice_date = invoice.date
         invoice.action_post()
         self.assertEqual(invoice.state, "posted")
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/fcaa54939e9a4f0dd5e47cd0ccffe7aa24bd451c invoice_date should be set manually, this Pr aims to correct test adding this field manually.

@ForgeFlow @kittiu @ps-tubtim 