### PR TITLE
[13.0][FIX] purchase_order_product_recommendation: Fix tests

### DIFF
--- a/purchase_order_product_recommendation/tests/test_recommendation.py
+++ b/purchase_order_product_recommendation/tests/test_recommendation.py
@@ -237,9 +237,9 @@ class RecommendationCaseTests(RecommendationCase):
         line_prod_3 = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_3)
         self.assertEqual(line_prod_3.times_delivered, 1)
         self.assertEqual(line_prod_3.units_delivered, 13)
-        self.assertEqual(line_prod_3.units_included, 9)
-        self.assertEqual(line_prod_3.units_available, 4)
-        self.assertEqual(line_prod_3.units_virtual_available, 4)
+        self.assertEqual(line_prod_3.units_included, 8)
+        self.assertEqual(line_prod_3.units_available, 5)
+        self.assertEqual(line_prod_3.units_virtual_available, 5)
 
     def test_action_accept(self):
         """Open wizard when there are PO Lines and click on Accept"""


### PR DESCRIPTION
cc @Tecnativa TT29377

After commit odoo/odoo@4625f3d
the warehouse is taken into account when computing the quantities.

As we are limiting the test by warehouse, the final value should be updated to the new
correctly computed.

Please @sergio-teruel @carlosdauden review this.