### PR TITLE
[14.0][FIX] purchase_order_type, default type not set

### DIFF
--- a/purchase_order_type/models/purchase_order.py
+++ b/purchase_order_type/models/purchase_order.py
@@ -10,12 +10,6 @@ from odoo.addons.purchase.models.purchase import PurchaseOrder as Purchase
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
-    def _default_order_type(self):
-        return self.env["purchase.order.type"].search(
-            [("company_id", "in", [False, self.env.company.id])],
-            limit=1,
-        )
-
     order_type = fields.Many2one(
         comodel_name="purchase.order.type",
         readonly=False,
@@ -23,7 +17,6 @@ class PurchaseOrder(models.Model):
         string="Type",
         ondelete="restrict",
         domain="[('company_id', 'in', [False, company_id])]",
-        default=lambda self: self._default_order_type(),
     )
 
     @api.onchange("partner_id")
@@ -61,6 +54,12 @@ class PurchaseOrder(models.Model):
         ):
             raise ValidationError(_("Document's company and type's company mismatch"))
 
+    def _default_order_type(self):
+        return self.env["purchase.order.type"].search(
+            [("company_id", "in", [False, self.company_id.id])],
+            limit=1,
+        )
+
     @api.onchange("company_id")
     def _onchange_company(self):
-        self.order_type = False
+        self.order_type = self._default_order_type()

--- a/purchase_order_type/tests/test_purchase_order_type.py
+++ b/purchase_order_type/tests/test_purchase_order_type.py
@@ -72,12 +72,15 @@ class TestPurchaseOrderType(common.SavepointCase):
 
     def test_purchase_order_change_company(self):
         order = self.po_obj.new({"partner_id": self.partner1.id})
-        self.assertEqual(order.order_type, self.type1)
+        order.onchange_partner_id()
+        self.assertEqual(order.order_type, self.type2)
         order._onchange_company()
-        self.assertFalse(order.order_type)
+        self.assertEqual(order.order_type, order._default_order_type())
 
     def test_purchase_order_type_company_error(self):
-        order = self.po_obj.create({"partner_id": self.partner1.id})
+        order = self.po_obj.create(
+            {"partner_id": self.partner1.id, "order_type": self.type1.id}
+        )
         self.assertEqual(order.order_type, self.type1)
         self.assertEqual(order.company_id, self.type1.company_id)
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
The original _default_order_type() that set default order type no longer function because of the enhancement about multi-company https://github.com/OCA/purchase-workflow/blob/14.0/purchase_order_type/models/purchase_order.py#L65

(And since the default required field is not set, this also make test in other module red)

**Note:** this fix should back port to v13 too.

@ps-tubtim can you review please. Looks like company was from your commit - https://github.com/OCA/purchase-workflow/pull/898/commits/c4904605b934baa6ebb7be5affa3723cb985ba3e