### PR TITLE
[13.0][FIX] purchase_delivery_split_date

### DIFF
--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -74,6 +74,12 @@ class PurchaseOrderLine(models.Model):
             self.mapped("order_id")._check_split_pickings()
         return res
 
+    def create(self, values):
+        line = super().create(values)
+        if line.order_id.state == "purchase":
+            line.order_id._check_split_pickings()
+        return line
+
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"


### PR DESCRIPTION
On an order already confirmed, if a scheduled date is changed on an
existing line, the move is correctly assign to the picking.
But if a line is added with it is not the case, this changes fixes that.