### PR TITLE
[14.0][IMP] purchase_invoice_plan, misc improvements

### DIFF
--- a/purchase_invoice_plan/tests/test_purchase_invoice_plan.py
+++ b/purchase_invoice_plan/tests/test_purchase_invoice_plan.py
@@ -71,6 +71,10 @@ class TestPurchaseInvoicePlan(TransactionCase):
             p.num_installment = 5
         purchase_plan = p.save()
         purchase_plan.with_context(ctx).purchase_create_invoice_plan()
+        # Change plan, so that the 1st installment is 1000 and 5th is 3000
+        self.assertEqual(len(self.test_po_product.invoice_plan_ids), 5)
+        self.test_po_product.invoice_plan_ids[0].amount = 1000
+        self.test_po_product.invoice_plan_ids[4].amount = 3000
         self.test_po_product.button_confirm()
         self.assertEqual(self.test_po_product.state, "purchase")
         # Receive all products
@@ -79,6 +83,10 @@ class TestPurchaseInvoicePlan(TransactionCase):
         receive._action_done()
         purchase_create = self.env["purchase.make.planned.invoice"].create({})
         purchase_create.with_context(ctx).create_invoices_by_plan()
+        self.assertEqual(
+            self.test_po_product.amount_total,
+            sum(self.test_po_product.invoice_ids.mapped("amount_total")),
+        )
 
     def test_unlink_invoice_plan(self):
         ctx = {

--- a/purchase_invoice_plan/views/purchase_view.xml
+++ b/purchase_invoice_plan/views/purchase_view.xml
@@ -7,11 +7,11 @@
                 <field name="installment" />
                 <field name="plan_date" />
                 <field name="invoice_type" />
-                <field name="percent" sum="Percent" />
-                <field name="amount" optional="hide" sum="Amount" />
+                <field name="percent" optional="show" />
+                <field name="amount" optional="show" />
                 <field name="to_invoice" />
                 <field name="invoiced" />
-                <field name="invoice_ids" />
+                <field name="invoice_ids" optional="hide" widget="many2many_tags" />
             </tree>
         </field>
     </record>
@@ -87,6 +87,10 @@
                         context="{'tree_view_ref': 'view_purchase_invoice_plan_tree'}"
                         attrs="{'invisible': [('invoice_plan_ids', '=', [])], 'readonly': [('invoice_count', '>', 0)]}"
                     />
+                    <group class="oe_subtotal_footer oe_right">
+                        <field name="ip_total_percent" />
+                        <field name="ip_total_amount" />
+                    </group>
                 </page>
             </xpath>
         </field>
@@ -167,10 +171,11 @@
                 <field name="installment" />
                 <field name="plan_date" />
                 <field name="invoice_type" />
-                <field name="percent" sum="Percent" />
-                <field name="amount" optional="hide" sum="Amount" />
+                <field name="percent" optional="show" sum="Percent" />
+                <field name="amount" optional="show" sum="Amount" />
                 <field name="to_invoice" />
                 <field name="invoiced" />
+                <field name="invoice_ids" widget="many2many_tags" />
             </tree>
         </field>
     </record>

--- a/purchase_invoice_plan/views/purchase_view.xml
+++ b/purchase_invoice_plan/views/purchase_view.xml
@@ -7,9 +7,11 @@
                 <field name="installment" />
                 <field name="plan_date" />
                 <field name="invoice_type" />
-                <field name="percent" />
+                <field name="percent" sum="Percent" />
+                <field name="amount" optional="hide" sum="Amount" />
                 <field name="to_invoice" />
                 <field name="invoiced" />
+                <field name="invoice_ids" />
             </tree>
         </field>
     </record>
@@ -27,6 +29,7 @@
                     <group>
                         <field name="invoice_type" />
                         <field name="percent" />
+                        <field name="amount" />
                         <field name="invoiced" />
                     </group>
                 </group>
@@ -164,7 +167,8 @@
                 <field name="installment" />
                 <field name="plan_date" />
                 <field name="invoice_type" />
-                <field name="percent" />
+                <field name="percent" sum="Percent" />
+                <field name="amount" optional="hide" sum="Amount" />
                 <field name="to_invoice" />
                 <field name="invoiced" />
             </tree>

--- a/purchase_invoice_plan/wizard/purchase_make_planned_invoice.py
+++ b/purchase_invoice_plan/wizard/purchase_make_planned_invoice.py
@@ -17,5 +17,5 @@ class PurchaseAdvancePaymentInv(models.TransientModel):
             or purchase.invoice_plan_ids.filtered("to_invoice")
         )
         for plan in invoice_plans.sorted("installment"):
-            purchase.with_context(invoice_plan_id=plan.id).action_invoice_create()
+            purchase.with_context(invoice_plan_id=plan.id).action_create_invoice()
         return {"type": "ir.actions.act_window_close"}

--- a/purchase_invoice_plan/wizard/purchase_make_planned_invoice.py
+++ b/purchase_invoice_plan/wizard/purchase_make_planned_invoice.py
@@ -17,5 +17,7 @@ class PurchaseAdvancePaymentInv(models.TransientModel):
             or purchase.invoice_plan_ids.filtered("to_invoice")
         )
         for plan in invoice_plans.sorted("installment"):
-            purchase.with_context(invoice_plan_id=plan.id).action_create_invoice()
+            purchase.sudo().with_context(
+                invoice_plan_id=plan.id
+            ).action_create_invoice()
         return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
Improvement:

* When create invoice by invoice plan, to better handle the last invoice (handle decimals)
* Make a hook method (to be extended with purchase_invoice_plan_deposit)
* Use function account_create_invoice (in v14) instead of module own account_invoice_create (removed)
* Add amount in invoice plan, as helper to calculate percent
* Add sum invoice plan total, and percent