### PR TITLE
[FIX] purchase_isolated_rfq: Remove selection attribute on rfq_state as it is a related field

### DIFF
--- a/purchase_isolated_rfq/models/purchase_order.py
+++ b/purchase_isolated_rfq/models/purchase_order.py
@@ -25,12 +25,6 @@ class PurchaseOrder(models.Model):
         help="For RFQ, this field references to its Purchases Order",
     )
     rfq_state = fields.Selection(
-        selection=[
-            ("draft", "Draft"),
-            ("sent", "Mail Sent"),
-            ("cancel", "Cancelled"),
-            ("done", "Done"),
-        ],
         string="RFQ Status",
         readonly=True,
         related="state",


### PR DESCRIPTION
Fix to avoid Warning on runbot like below

```
2021-05-19 08:53:33,115 164 WARNING openerp_test odoo.fields: purchase.order.rfq_state: selection attribute will be ignored as the field is related
```

@kittiu @daylinglez 
@ForgeFlow