### PR TITLE
[10.0][FIX] purchase_request_to_rfq: incorrect domain, location_id does not exist in purchase order line

### DIFF
--- a/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq/wizard/purchase_request_line_make_purchase_order.py
@@ -198,11 +198,6 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         if not item.product_id:
             order_line_data = [x for x in order_line_data if x[0] != "name"]
             order_line_data.append(('name', '=', item.name))
-        if item.line_id.procurement_id and \
-                item.line_id.procurement_id.location_id:
-            order_line_data.append(
-                ('location_id', '=',
-                 item.line_id.procurement_id.location_id.id))
         return order_line_data
 
     @api.multi


### PR DESCRIPTION
This was legacy from previous versions. But the bug was hidden until this other fix was merged: https://github.com/OCA/purchase-workflow/pull/1138

This is aligned to next versions of the module where that domain does not exist at all.

@ForgeFlow