### PR TITLE
 [IMP][12.0] purchase_discount / purchase_triple_discount : add Apply button to mass update supplierinfos

### DIFF
--- a/purchase_discount/i18n/fr.po
+++ b/purchase_discount/i18n/fr.po
@@ -1,28 +1,29 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * purchase_discount
+#   * purchase_discount
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
-# Quentin THEURET <odoo@kerpeo.com>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 17:50+0000\n"
-"PO-Revision-Date: 2018-02-23 17:50+0000\n"
-"Last-Translator: Quentin THEURET <odoo@kerpeo.com>, 2018\n"
-"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
-"Language: fr\n"
+"POT-Creation-Date: 2021-06-10 19:58+0000\n"
+"PO-Revision-Date: 2021-06-10 19:58+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: purchase_discount
 #: model_terms:ir.ui.view,arch_db:purchase_discount.report_purchaseorder_document
 msgid "<strong>Disc. (%)</strong>"
 msgstr "<strong>Remise (%)</strong>"
+
+#. module: purchase_discount
+#: model_terms:ir.ui.view,arch_db:purchase_discount.res_partner_form_view
+msgid "Apply"
+msgstr "Appliquer"
 
 #. module: purchase_discount
 #: model:ir.model,name:purchase_discount.model_res_partner
@@ -33,7 +34,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:purchase_discount.field_res_partner__default_supplierinfo_discount
 #: model:ir.model.fields,field_description:purchase_discount.field_res_users__default_supplierinfo_discount
 msgid "Default Supplier Discount (%)"
-msgstr ""
+msgstr "Remise par défaut (%)"
 
 #. module: purchase_discount
 #: model:ir.model.fields,field_description:purchase_discount.field_product_supplierinfo__discount
@@ -53,15 +54,19 @@ msgid "Discount-related settings are managed on"
 msgstr ""
 
 #. module: purchase_discount
+#: model_terms:ir.ui.view,arch_db:purchase_discount.res_partner_form_view
+msgid "Do you want to apply this value (discount #1) to all supplier informations associated with this partner?"
+msgstr "Souhaitez vous appliquer cette valeur (Remise #1) à toutes les produits associés à ce fournisseur ?"
+
+#. module: purchase_discount
 #: model:ir.model,name:purchase_discount.model_account_invoice
 msgid "Invoice"
 msgstr "Facture"
 
 #. module: purchase_discount
 #: model:ir.model,name:purchase_discount.model_purchase_order
-#, fuzzy
 msgid "Purchase Order"
-msgstr "Commandes d'achat"
+msgstr "Commande fournisseur"
 
 #. module: purchase_discount
 #: model:ir.model,name:purchase_discount.model_purchase_order_line
@@ -70,34 +75,32 @@ msgstr "Ligne de commande d'achat"
 
 #. module: purchase_discount
 #: model:ir.model,name:purchase_discount.model_purchase_report
-#, fuzzy
 msgid "Purchase Report"
-msgstr "Commandes d'achat"
+msgstr "Rapport d'achat"
 
 #. module: purchase_discount
 #: model:ir.model,name:purchase_discount.model_stock_move
 msgid "Stock Move"
-msgstr ""
+msgstr "Mouvement de stock"
 
 #. module: purchase_discount
 #: model:ir.model,name:purchase_discount.model_stock_rule
 msgid "Stock Rule"
-msgstr ""
+msgstr "Règle de stock minimum"
 
 #. module: purchase_discount
 #: model:ir.model,name:purchase_discount.model_product_supplierinfo
 msgid "Supplier Pricelist"
-msgstr ""
+msgstr "Liste de prix du fournisseur"
 
 #. module: purchase_discount
 #: model:ir.model.fields,help:purchase_discount.field_res_partner__default_supplierinfo_discount
 #: model:ir.model.fields,help:purchase_discount.field_res_users__default_supplierinfo_discount
-msgid ""
-"This value will be used as the default one, for each new supplierinfo line "
-"depending on that supplier."
-msgstr ""
+msgid "This value will be used as the default one, for each new supplierinfo line depending on that supplier."
+msgstr "Cette valeur sera utilisée par défaut, pour chaque nouvelle information fournisseur créé."
 
 #. module: purchase_discount
 #: model_terms:ir.ui.view,arch_db:purchase_discount.res_partner_form_view
 msgid "the parent company"
-msgstr ""
+msgstr "la société parente"
+

--- a/purchase_discount/i18n/purchase_discount.pot
+++ b/purchase_discount/i18n/purchase_discount.pot
@@ -1,11 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* purchase_discount
+#   * purchase_discount
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-06-10 20:00+0000\n"
+"PO-Revision-Date: 2021-06-10 20:00+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,6 +18,11 @@ msgstr ""
 #. module: purchase_discount
 #: model_terms:ir.ui.view,arch_db:purchase_discount.report_purchaseorder_document
 msgid "<strong>Disc. (%)</strong>"
+msgstr ""
+
+#. module: purchase_discount
+#: model_terms:ir.ui.view,arch_db:purchase_discount.res_partner_form_view
+msgid "Apply"
 msgstr ""
 
 #. module: purchase_discount
@@ -44,6 +51,11 @@ msgstr ""
 #. module: purchase_discount
 #: model_terms:ir.ui.view,arch_db:purchase_discount.res_partner_form_view
 msgid "Discount-related settings are managed on"
+msgstr ""
+
+#. module: purchase_discount
+#: model_terms:ir.ui.view,arch_db:purchase_discount.res_partner_form_view
+msgid "Do you want to apply this value (discount #1) to all supplier informations associated with this partner?"
 msgstr ""
 
 #. module: purchase_discount

--- a/purchase_discount/models/res_partner.py
+++ b/purchase_discount/models/res_partner.py
@@ -16,3 +16,9 @@ class ResPartner(models.Model):
         " supplierinfo line depending on that supplier.",
         track_visibility="onchange",
     )
+
+    def button_apply_default_supplierinfo_discount(self):
+        for partner in self:
+            self.env["product.supplierinfo"].search(
+                [('name', '=', partner.id)]
+            ).write({"discount": partner.default_supplierinfo_discount})

--- a/purchase_discount/tests/test_product_supplierinfo_discount.py
+++ b/purchase_discount/tests/test_product_supplierinfo_discount.py
@@ -140,3 +140,13 @@ class TestProductSupplierinfoDiscount(common.SavepointCase):
             ('product_tmpl_id', '=', product.product_tmpl_id.id)])
         self.assertTrue(seller)
         self.assertEqual(seller.discount, 40)
+
+    def test_007_apply_supplierinfo_default_value(self):
+        all_supplierinfos = self.supplierinfo_model.search(
+            [('name', '=', self.partner_3.id)])
+        self.partner_3.default_supplierinfo_discount = 91
+        self.partner_3.button_apply_default_supplierinfo_discount()
+        self.assertEquals(
+            list(set(all_supplierinfos.mapped('discount'))), [91],
+            "Apply default supplierinfo discount should impact all the"
+            " existing supplierinfos.")

--- a/purchase_discount/views/res_partner_view.xml
+++ b/purchase_discount/views/res_partner_view.xml
@@ -5,8 +5,12 @@
          <field name="inherit_id" ref="base.view_partner_form"/>
          <field name="arch" type="xml">
             <xpath expr="//group[@name='purchase']" position="inside">
-                <field name="default_supplierinfo_discount"
-                        attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}"/>
+                <label for="default_supplierinfo_discount"
+                    attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}"/>
+                <div attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}">
+                    <field class="oe_inline" name="default_supplierinfo_discount"/>
+                    <button class="oe_inline oe_link" name="button_apply_default_supplierinfo_discount" type="object" string="Apply" confirm="Do you want to apply this value (discount #1) to all supplier informations associated with this partner?"/>
+                </div>
                 <div name="supplierinfo_discount_disabled" colspan="2"
                         attrs="{'invisible': ['|',('is_company', '=', True), ('parent_id', '=', False)]}">
                     <p>Discount-related settings are managed on <button name="open_commercial_entity" type="object" string="the parent company" class="oe_link"/></p>

--- a/purchase_triple_discount/i18n/fr.po
+++ b/purchase_triple_discount/i18n/fr.po
@@ -6,15 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-08 08:11+0000\n"
-"PO-Revision-Date: 2019-08-08 08:11+0000\n"
+"POT-Creation-Date: 2021-06-10 20:02+0000\n"
+"PO-Revision-Date: 2021-06-10 20:02+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: purchase_triple_discount
+#: model_terms:ir.ui.view,arch_db:purchase_triple_discount.res_partner_form_view
+msgid "Apply"
+msgstr "Appliquer"
 
 #. module: purchase_triple_discount
 #: model:ir.model,name:purchase_triple_discount.model_res_partner
@@ -66,6 +70,16 @@ msgid "Discount 3 must be lower than 100%."
 msgstr "La remise 3 doit être inférieure à 100%."
 
 #. module: purchase_triple_discount
+#: model_terms:ir.ui.view,arch_db:purchase_triple_discount.res_partner_form_view
+msgid "Do you want to apply this value (discount #2) to all supplier informations associated with this partner?"
+msgstr "Souhaitez vous appliquer cette valeur (Remise #2) à toutes les produits associés à ce fournisseur ?"
+
+#. module: purchase_triple_discount
+#: model_terms:ir.ui.view,arch_db:purchase_triple_discount.res_partner_form_view
+msgid "Do you want to apply this value (discount #3) to all supplier informations associated with this partner?"
+msgstr "Souhaitez vous appliquer cette valeur (Remise #3) à toutes les produits associés à ce fournisseur ?"
+
+#. module: purchase_triple_discount
 #: model:ir.model,name:purchase_triple_discount.model_account_invoice
 msgid "Invoice"
 msgstr "Facture"
@@ -77,9 +91,8 @@ msgstr "Ligne de commande d'achat"
 
 #. module: purchase_triple_discount
 #: model:ir.model,name:purchase_triple_discount.model_purchase_report
-#, fuzzy
 msgid "Purchase Report"
-msgstr "Commande fournisseur"
+msgstr "Rapport d'achat"
 
 #. module: purchase_triple_discount
 #: model:ir.model,name:purchase_triple_discount.model_stock_rule
@@ -96,7 +109,7 @@ msgstr "Liste de prix du fournisseur"
 #: model:ir.model.fields,help:purchase_triple_discount.field_res_partner__default_supplierinfo_discount3
 #: model:ir.model.fields,help:purchase_triple_discount.field_res_users__default_supplierinfo_discount2
 #: model:ir.model.fields,help:purchase_triple_discount.field_res_users__default_supplierinfo_discount3
-msgid ""
-"This value will be used as the default one, for each new supplierinfo line "
-"depending on that supplier."
-msgstr ""
+msgid "This value will be used as the default one, for each new supplierinfo line depending on that supplier."
+msgstr "Cette valeur sera utilisée par défaut, pour chaque nouvelle information fournisseur créé."
+
+

--- a/purchase_triple_discount/i18n/purchase_triple_discount.pot
+++ b/purchase_triple_discount/i18n/purchase_triple_discount.pot
@@ -1,17 +1,24 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* purchase_triple_discount
+#   * purchase_triple_discount
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-06-10 20:01+0000\n"
+"PO-Revision-Date: 2021-06-10 20:01+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: purchase_triple_discount
+#: model_terms:ir.ui.view,arch_db:purchase_triple_discount.res_partner_form_view
+msgid "Apply"
+msgstr ""
 
 #. module: purchase_triple_discount
 #: model:ir.model,name:purchase_triple_discount.model_res_partner
@@ -60,6 +67,16 @@ msgstr ""
 #. module: purchase_triple_discount
 #: sql_constraint:purchase.order.line:0
 msgid "Discount 3 must be lower than 100%."
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model_terms:ir.ui.view,arch_db:purchase_triple_discount.res_partner_form_view
+msgid "Do you want to apply this value (discount #2) to all supplier informations associated with this partner?"
+msgstr ""
+
+#. module: purchase_triple_discount
+#: model_terms:ir.ui.view,arch_db:purchase_triple_discount.res_partner_form_view
+msgid "Do you want to apply this value (discount #3) to all supplier informations associated with this partner?"
 msgstr ""
 
 #. module: purchase_triple_discount

--- a/purchase_triple_discount/models/res_partner.py
+++ b/purchase_triple_discount/models/res_partner.py
@@ -19,3 +19,15 @@ class ResPartner(models.Model):
         help="This value will be used as the default one, for each new "
              "supplierinfo line depending on that supplier.",
     )
+
+    def button_apply_default_supplierinfo_discount2(self):
+        for partner in self:
+            self.env["product.supplierinfo"].search(
+                [('name', '=', partner.id)]
+            ).write({"discount2": partner.default_supplierinfo_discount2})
+
+    def button_apply_default_supplierinfo_discount3(self):
+        for partner in self:
+            self.env["product.supplierinfo"].search(
+                [('name', '=', partner.id)]
+            ).write({"discount3": partner.default_supplierinfo_discount3})

--- a/purchase_triple_discount/readme/USAGE.rst
+++ b/purchase_triple_discount/readme/USAGE.rst
@@ -22,3 +22,6 @@ Unit price: 600.00 ->
   and third discounts.
 * A default second or third discount can be set in every vendor
   *Sale & Purchases* tab.
+
+You can mass update all the supplierinfo discount values, going to **Purchase > Vendors**,
+open a supplier, and click on the button "Apply" near the according "Default Supplier Discount (%)" field.

--- a/purchase_triple_discount/tests/test_purchase_discount.py
+++ b/purchase_triple_discount/tests/test_purchase_discount.py
@@ -216,3 +216,20 @@ class TestPurchaseOrder(common.SavepointCase):
         self.assertEqual(rec.discount2, 50)
         self.assertEqual(rec.discount3, 20)
         self.assertEqual(rec.price_total, 240)
+
+    def test_09_apply_supplierinfo_default_value(self):
+        all_supplierinfos = self.supplierinfo_obj.search(
+            [('name', '=', self.partner2.id)])
+        self.partner2.default_supplierinfo_discount2 = 92
+        self.partner2.button_apply_default_supplierinfo_discount2()
+        self.assertEquals(
+            list(set(all_supplierinfos.mapped('discount2'))), [92],
+            "Apply default supplierinfo discount 2 should impact all the"
+            " existing supplierinfos.")
+
+        self.partner2.default_supplierinfo_discount3 = 93
+        self.partner2.button_apply_default_supplierinfo_discount3()
+        self.assertEquals(
+            list(set(all_supplierinfos.mapped('discount3'))), [93],
+            "Apply default supplierinfo discount 3 should impact all the"
+            " existing supplierinfos.")

--- a/purchase_triple_discount/views/res_partner_view.xml
+++ b/purchase_triple_discount/views/res_partner_view.xml
@@ -4,12 +4,20 @@
          <field name="model">res.partner</field>
          <field name="inherit_id" ref="purchase_discount.res_partner_form_view"/>
          <field name="arch" type="xml">
-            <field name="default_supplierinfo_discount" position="after">
-                <field name="default_supplierinfo_discount2"
-                        attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}"/>
-                <field name="default_supplierinfo_discount3"
-                        attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}"/>
-            </field>
+            <xpath expr="//field[@name='default_supplierinfo_discount']/.." position="after">
+                <label for="default_supplierinfo_discount2"
+                    attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}"/>
+                <div attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}">
+                    <field class="oe_inline" name="default_supplierinfo_discount2"/>
+                    <button class="oe_inline oe_link" name="button_apply_default_supplierinfo_discount2" type="object" string="Apply" confirm="Do you want to apply this value (discount #2) to all supplier informations associated with this partner?"/>
+                </div>
+                <label for="default_supplierinfo_discount3"
+                    attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}"/>
+                <div attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}">
+                    <field class="oe_inline" name="default_supplierinfo_discount3"/>
+                    <button class="oe_inline oe_link" name="button_apply_default_supplierinfo_discount3" type="object" string="Apply" confirm="Do you want to apply this value (discount #3) to all supplier informations associated with this partner?"/>
+                </div>
+            </xpath>
          </field>
      </record>
 


### PR DESCRIPTION
**Impact ``purchase_discount`` and ``purchase_triple_discount``**

- add new buttons "Apply" in the partner form view, near default supplierinfo value. (1 / 2 / 3) 

![image](https://user-images.githubusercontent.com/3407482/119333358-10e6c500-bc8a-11eb-8831-a5bc84bb1463.png)


- add a warning message, when clicking on them. If confirmed, all the supplierinfo will be updated.

![image](https://user-images.githubusercontent.com/3407482/119333431-222fd180-bc8a-11eb-8ff2-6a265806c9d4.png)

- add tests

- update ``usage.rst`` files.

**Merge process** : ``/minor``

CC : @quentinDupont #GRAPOCA (apps/deck/#/board/144/card/1552)