### PR TITLE
[FIX] purchase_discount: access error

### DIFF
--- a/purchase_discount/models/stock_move.py
+++ b/purchase_discount/models/stock_move.py
@@ -16,7 +16,7 @@ class StockMove(models.Model):
         is not merged.
         """
         price_unit = False
-        po_line = self.purchase_line_id
+        po_line = self.purchase_line_id.sudo()
         if po_line and self.product_id == po_line.product_id:
             price = po_line._get_discounted_price_unit()
             if price != po_line.price_unit:


### PR DESCRIPTION
On certain situations this compute could be triggered by non purchase
users (e.g: Inventory users) so we'll get an access error on it.

cc @Tecnativa TT29910

please review @carlosdauden @pedrobaeza 