### PR TITLE
[13.0][FIX] purchase_delivery_split_date with tz

### DIFF
--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -17,7 +17,7 @@ class PurchaseOrderLine(models.Model):
         dictionary element with the field that you want to group by. This
         method is designed for extensibility, so that other modules can add
         additional keys or replace them by others."""
-        date = line.date_planned.date()
+        date = fields.Date.context_today(self.env.user, line.date_planned)
         # Split date value to obtain only the attributes year, month and day
         key = ({"date_planned": fields.Date.to_string(date)},)
         return key
@@ -96,6 +96,7 @@ class PurchaseOrder(models.Model):
             pickings_by_date = {}
             for pick in pickings:
                 pickings_by_date[pick.scheduled_date.date()] = pick
+
             order_lines = moves.mapped("purchase_line_id")
             date_groups = groupby(
                 order_lines, lambda l: l._get_group_keys(l.order_id, l)


### PR DESCRIPTION
If the date_planned is not set to the user timezone before grouping into
days. It can lead to having multiple picking when not needed.
Check unit test.