### PR TITLE
[13.0][IMP] procurement_purchase_no_grouping - add minimal type of grouping

### DIFF
--- a/procurement_purchase_no_grouping/models/product_category.py
+++ b/procurement_purchase_no_grouping/models/product_category.py
@@ -14,6 +14,7 @@ class ProductCategory(models.Model):
             ("line", "No line grouping"),
             ("order", "No order grouping"),
             ("product_category", "Product category grouping"),
+            ("minimal", "Minimal grouping"),
         ],
         string="Procured purchase grouping",
         default="standard",
@@ -29,5 +30,7 @@ class ProductCategory(models.Model):
         "grouping.\n"
         "* <empty>: If no value is selected, system-wide default will be used.\n"
         "* Product category grouping: This option groups products in the "
-        "same purchase order that belongs to the same product category.",
+        "same purchase order that belongs to the same product category.\n"
+        "* Minimal grouping: Will generate separate purchase order "
+        "per supplier for each procurement and will keep lines in them.",
     )

--- a/procurement_purchase_no_grouping/models/purchase_order.py
+++ b/procurement_purchase_no_grouping/models/purchase_order.py
@@ -20,7 +20,7 @@ class PurchaseOrderLine(models.Model):
         company_id,
         values,
     ):
-        if values.get("grouping") == "line":
+        if values.get("grouping") == "line" or values.get("grouping") == "minimal":
             return False
         return super()._find_candidate(
             product_id,

--- a/procurement_purchase_no_grouping/models/res_company.py
+++ b/procurement_purchase_no_grouping/models/res_company.py
@@ -13,11 +13,12 @@ class ResCompany(models.Model):
             ("line", "No line grouping"),
             ("order", "No order grouping"),
             ("product_category", "Product category grouping"),
+            ("minimal", "Minimal grouping"),
         ],
         string="Procured purchase grouping",
         default="standard",
-        help="Select the behaviour for grouping procured purchases for the "
-        "the products of this category:\n"
+        help="Select the default behaviour for grouping procured purchases "
+        "for the products (if no grouping is selected for categry):\n"
         "* Standard grouping: Procurements will generate "
         "purchase orders as always, grouping lines and orders when "
         "possible.\n"
@@ -26,7 +27,8 @@ class ResCompany(models.Model):
         "merged.\n"
         "* No order grouping: This option will prevent any kind of "
         "grouping.\n"
-        "* <empty>: If no value is selected, system-wide default will be used.\n"
         "* Product category grouping: This option groups products in the "
-        "same purchase order that belongs to the same product category.",
+        "same purchase order that belongs to the same product category.\n"
+        "* Minimal grouping: Will generate separate purchase order "
+        "per supplier for each procurement and will keep lines in them.",
     )

--- a/procurement_purchase_no_grouping/models/stock_rule.py
+++ b/procurement_purchase_no_grouping/models/stock_rule.py
@@ -19,6 +19,8 @@ class StockRule(models.Model):
             if not grouping:
                 grouping = self.env.company.procured_purchase_grouping
             procurement.values["grouping"] = grouping
+            if grouping == "minimal":
+                procurement.values["origin"] = procurement.origin
         return super()._run_buy(procurements)
 
     def _make_po_get_domain(self, company_id, values, partner):
@@ -42,4 +44,7 @@ class StockRule(models.Model):
                 domain += (("id", "=", -values["move_dest_ids"][:1].id),)
             # The minimum is imposed by PG int4 limit
             domain += (("id", "=", random.randint(-2147483648, 0)),)
+        elif values.get("grouping") == "minimal":
+            if values.get("origin"):
+                domain += (("origin", "=", values["origin"]),)
         return domain

--- a/procurement_purchase_no_grouping/readme/CONFIGURE.rst
+++ b/procurement_purchase_no_grouping/readme/CONFIGURE.rst
@@ -9,6 +9,7 @@ Go to each product category, and select one of these values in the field
 * *<empty>*: If you select nothing, default value set up in System
   settings will be applied.
 * *Product category grouping*: This option groups products in the same purchase order that belongs to the same product category.
+* *Minimal grouping*: Will generate separate purchase order per supplier for each procurement and will keep lines in them.
 
 System default behaviour can be set up in System settings / Purchase / Procurement
 Purchase Grouping


### PR DESCRIPTION
Following my question in #1209 I have created initial version that implements this kind of grouping:
1. I create SO1 with 3 Products P1(Supplier 1), P2(Supplier 1), P3(Supplier 2).
2. When I confirm I expect 2 PO to be created: PO1(Supplier 1)=[P1, P2] and PO2(Supplier 2)=[P3]
3. I create SO2 with the same content as SO1.
4. When I confirm it I'd expect to have PO3(Supplier 1)=[P1, P2] and PO4(Supplier 2)=[P3]

The idea is to have PO follow individual SO in the minimal way. If all the products are from single vendor, there only will be single PO for individual SO. If there are products from more suppliers in SO, as many POs as there are suppliers will be created.

I have also cleaned a bit of help in Purchase Settings where there was superficial value described that only makes sense for setting per Product Category.

@pedrobaeza would you please provide some comments/review? Especially - is there better way to get `origin` into `_make_po_get_domain` other than as I did inserting it in `_run_buy`? Also I couldn't come up with better name for that option than **minimal** Maybe **origin**? Thank you a lot.