### PR TITLE
[14.0][IMP] purchase_open_qty, field optional='hide'

### DIFF
--- a/purchase_open_qty/views/purchase_view.xml
+++ b/purchase_open_qty/views/purchase_view.xml
@@ -12,12 +12,14 @@
                 <field
                     name="qty_to_receive"
                     attrs="{'column_invisible': [('parent.state', 'not in', ('purchase', 'done'))]}"
+                    optional="hide"
                 />
             </field>
             <field name="qty_invoiced" position="before">
                 <field
                     name="qty_to_invoice"
                     attrs="{'column_invisible': [('parent.state', 'not in', ('purchase', 'done'))]}"
+                    optional="hide"
                 />
             </field>
         </field>


### PR DESCRIPTION
Just make the Qty to Receive and Qty to Bill fields, optional hidden, to save some space.

Can be FFW

![image](https://user-images.githubusercontent.com/1973598/123209651-20586880-d4eb-11eb-90d2-71fe335d324a.png)
