### PR TITLE
[14.0][FIX] purchase_work_acceptance_evaluation, editable evalulation when no state required

### DIFF
--- a/purchase_work_acceptance_evaluation/models/work_acceptance.py
+++ b/purchase_work_acceptance_evaluation/models/work_acceptance.py
@@ -67,4 +67,8 @@ class WorkAcceptanceEvaluationResult(models.Model):
     @api.depends("case_id")
     def _compute_editable(self):
         for rec in self:
-            rec.editable = rec.wa_id.state == rec.case_id.state_required
+            rec.editable = (
+                True
+                if not rec.case_id.state_required
+                else rec.wa_id.state == rec.case_id.state_required
+            )


### PR DESCRIPTION
Score should be editable also, when Evaluation Criteria not set state_required.

![image](https://user-images.githubusercontent.com/1973598/123736095-b1a05400-d8ca-11eb-93df-d3ac8457a172.png)
