### PR TITLE
[13.0][FIX] purchase_delivery_split pickings same date

### DIFF
--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -107,7 +107,10 @@ class PurchaseOrder(models.Model):
                     for move in line.move_ids:
                         if move.state in ("cancel", "done"):
                             continue
-                        if move.picking_id.scheduled_date.date() != date_key:
+                        if (
+                            move.picking_id.scheduled_date.date() != date_key
+                            or pickings_by_date[date_key] != move.picking_id
+                        ):
                             if date_key not in pickings_by_date:
                                 copy_vals = line._first_picking_copy_vals(key, line)
                                 new_picking = move.picking_id.copy(copy_vals)
@@ -116,7 +119,7 @@ class PurchaseOrder(models.Model):
                             move.picking_id = pickings_by_date[date_key]
                             move.date_expected = date_key
                             move._action_assign()
-            for picking in pickings_by_date.values():
+            for picking in pickings:
                 if len(picking.move_lines) == 0:
                     picking.write({"state": "cancel"})
 

--- a/purchase_delivery_split_date/tests/test_purchase_delivery.py
+++ b/purchase_delivery_split_date/tests/test_purchase_delivery.py
@@ -127,6 +127,24 @@ class TestDeliverySingle(TransactionCase):
         line.write({"date_planned": self.date_3rd})
         self.assertEqual(moves.date_expected.strftime("%Y-%m-%d"), self.date_3rd)
 
+    def test_group_multiple_picking_same_date(self):
+        """Check multiple picking with same planned date are also merged
+
+        This can happen if another module changes the picking planned date
+        before the _check_split_pickings is being called from the write method.
+         """
+        self.po.order_line[0].date_planned = self.date_later
+        self.po.button_confirm()
+        moves = self.env["stock.move"].search(
+            [("purchase_line_id", "in", self.po.order_line.ids)]
+        )
+        pickings = moves.mapped("picking_id")
+        self.assertEqual(len(pickings), 2)
+        pickings[1].scheduled_date = pickings[0].scheduled_date
+        self.po.order_line[0].date_planned = self.date_sooner
+        self.assertEqual(len(moves.mapped("picking_id")), 1)
+        self.assertEqual(len(pickings.filtered(lambda r: r.state == "cancel")), 1)
+
     def test_purchase_line_date_change_split_picking(self):
         self.po.button_confirm()
         line1 = self.po.order_line[0]


### PR DESCRIPTION
When there is multiple pickings with the same planned date on entering
the function `_check_split_pickings` the moves are not grouped in one
picking.
This can happen if the picking planned date is changed by another module
on the call to super in the write method.

This resolve that issue.