### PR TITLE
[FIX] purchase_discount: supplierinfo with no template

### DIFF
--- a/purchase_discount/models/product_supplierinfo.py
+++ b/purchase_discount/models/product_supplierinfo.py
@@ -32,7 +32,7 @@ class ProductSupplierInfo(models.Model):
         """ Insert discount (or others) from context from purchase.order's
         _add_supplier_to_product method """
         for vals in vals_list:
-            product_tmpl_id = vals['product_tmpl_id']
+            product_tmpl_id = vals.get('product_tmpl_id')
             po_line_map = self.env.context.get('po_line_map', {})
             if product_tmpl_id in po_line_map:
                 po_line = po_line_map[product_tmpl_id]


### PR DESCRIPTION
Actually, product_tmpl_id isn't a required field, so in theory a dummy
record could be created prior to assign it to a product template.

cc @Tecnativa TT23732

please review @victoralmau @carlosdauden 