### PR TITLE
[14.0][IMP] purchase_request, add total estimated cost on PR head

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -149,6 +149,17 @@ class PurchaseRequest(models.Model):
     purchase_count = fields.Integer(
         string="Purchases count", compute="_compute_purchase_count", readonly=True
     )
+    currency_id = fields.Many2one(related="company_id.currency_id", readonly=True)
+    estimated_cost = fields.Monetary(
+        compute="_compute_estimated_cost",
+        string="Total Estimated Cost",
+        store=True,
+    )
+
+    @api.depends("line_ids", "line_ids.estimated_cost")
+    def _compute_estimated_cost(self):
+        for rec in self:
+            rec.estimated_cost = sum(rec.line_ids.mapped("estimated_cost"))
 
     @api.depends("line_ids")
     def _compute_purchase_count(self):

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -293,6 +293,20 @@
                                     </sheet>
                                 </form>
                             </field>
+                            <group class="oe_subtotal_footer oe_right">
+                                <field name="currency_id" invisible="1" />
+                                <div class="oe_subtotal_footer_separator oe_inline">
+                                    <label for="estimated_cost" />
+                                </div>
+                                <field
+                                    name="estimated_cost"
+                                    nolabel="1"
+                                    class="oe_subtotal_footer_separator"
+                                    widget="monetary"
+                                    options="{'currency_field': 'currency_id'}"
+                                />
+                            </group>
+
                         </page>
                     </notebook>
                 </sheet>
@@ -325,6 +339,8 @@
                 />
                 <field name="activity_ids" widget="list_activity" optional="show" />
                 <field name="origin" />
+                <field name="currency_id" invisible="1" />
+                <field name="estimated_cost" optional="hide" />
                 <field
                     name="state"
                     widget="badge"


### PR DESCRIPTION
Adding a compute total `estimated_cost` on PR header.

For couple of projects already that we have to add this field in custom module. I think it is good time to move it here.
