### PR TITLE
[13.0][FIX] purchase propagate qty handle split moves

### DIFF
--- a/purchase_propagate_qty/models/__init__.py
+++ b/purchase_propagate_qty/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import purchase
+from . import stock_move

--- a/purchase_propagate_qty/models/purchase.py
+++ b/purchase_propagate_qty/models/purchase.py
@@ -3,8 +3,8 @@
 # Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
-from odoo.tools import float_is_zero
+from odoo import _, exceptions, models
+from odoo.tools import float_compare, float_is_zero
 
 
 class PurchaseOrderLine(models.Model):
@@ -20,11 +20,37 @@ class PurchaseOrderLine(models.Model):
         for line in self:
             if line.state != "purchase":
                 continue
-            for move in line.move_dest_ids | line.move_ids:
+            rounding = line.product_uom.rounding
+            for move in line.move_dest_ids:
                 if move.state in ("cancel", "done"):
                     continue
                 if move.product_id != line.product_id:
                     continue
                 move.product_uom_qty = line.product_uom_qty
-                if float_is_zero(move.product_uom_qty, line.product_uom.rounding):
+                if float_is_zero(move.product_uom_qty, precision_rounding=rounding):
                     move._action_cancel()
+            moves = line.move_ids
+            previous_qty = sum(moves.mapped("product_uom_qty"))
+            new_qty = line.product_uom_qty
+            # Do nothing is qty has been increased, since odoo handles this case
+            if new_qty >= previous_qty:
+                continue
+            # If qty has been decreased, cancel full moves if possible
+            moves = moves.filtered_domain(
+                [
+                    ("state", "not in", ("cancel", "done")),
+                    ("product_id", "=", line.product_id.id),
+                ]
+            ).sorted(lambda m: (m.product_uom_qty, m.quantity_done))
+            qty_to_remove = previous_qty - new_qty
+            removable_qty = moves._get_removable_qty()
+            if (
+                float_compare(qty_to_remove, removable_qty, precision_rounding=rounding)
+                == 1
+            ):
+                exception_text = _(
+                    "You cannot remove more that what remains to be done.\n"
+                    "Max removable quantity {}."
+                ).format(removable_qty)
+                raise exceptions.UserError(exception_text)
+            moves._deduce_qty(qty_to_remove, rounding)

--- a/purchase_propagate_qty/models/purchase.py
+++ b/purchase_propagate_qty/models/purchase.py
@@ -29,7 +29,7 @@ class PurchaseOrderLine(models.Model):
                 move.product_uom_qty = line.product_uom_qty
                 if float_is_zero(move.product_uom_qty, precision_rounding=rounding):
                     move._action_cancel()
-            moves = line.move_ids
+            moves = line.move_ids.filtered(lambda r: r.state not in ("cancel", "done"))
             previous_qty = sum(moves.mapped("product_uom_qty"))
             new_qty = line.product_uom_qty
             # Do nothing is qty has been increased, since odoo handles this case
@@ -49,7 +49,7 @@ class PurchaseOrderLine(models.Model):
                 == 1
             ):
                 exception_text = _(
-                    "You cannot remove more that what remains to be done.\n"
+                    "You cannot remove more that what remains to be done. "
                     "Max removable quantity {}."
                 ).format(removable_qty)
                 raise exceptions.UserError(exception_text)

--- a/purchase_propagate_qty/models/stock_move.py
+++ b/purchase_propagate_qty/models/stock_move.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import models
+from odoo.tools import float_compare, float_is_zero
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _deduce_qty(self, qty_to_remove, rounding):
+        """Deduce the provided qty with respect to done qties."""
+        self = self.with_context(do_not_unreserve=True)
+        for move in self:
+            if float_is_zero(qty_to_remove, precision_rounding=rounding):
+                break
+            # we cannot deduce more than the "not done" qty
+            removable_qty = move._get_removable_qty()
+            # If removable_qty <= qty_to_remove, deduce removable_qty
+            if (
+                float_compare(removable_qty, qty_to_remove, precision_rounding=rounding)
+                < 1
+            ):
+                move.product_uom_qty -= removable_qty
+                qty_to_remove -= removable_qty
+            # Else, deduce qty_to_remove from it
+            else:
+                move.product_uom_qty -= qty_to_remove
+                qty_to_remove = 0
+            # if new move product_uom_qty is 0, cancel it
+            if float_is_zero(move.product_uom_qty, precision_rounding=rounding):
+                move._action_cancel()
+
+    def _get_removable_qty(self):
+        assert (
+            len(set(self.mapped("product_uom"))) == 1
+        ), "moves doesn't share the same UoM"
+        return sum([move.product_uom_qty - move.quantity_done for move in self])

--- a/purchase_propagate_qty/models/stock_move.py
+++ b/purchase_propagate_qty/models/stock_move.py
@@ -32,7 +32,14 @@ class StockMove(models.Model):
                 move._action_cancel()
 
     def _get_removable_qty(self):
+        moves = self.filtered(
+            lambda move: move.location_dest_id.usage != "supplier"
+            and (
+                not move.origin_returned_move_id
+                or (move.origin_returned_move_id and move.to_refund)
+            )
+        )
         assert (
-            len(set(self.mapped("product_uom"))) == 1
+            len(set(moves.mapped("product_uom"))) == 1
         ), "moves doesn't share the same UoM"
-        return sum([move.product_uom_qty - move.quantity_done for move in self])
+        return sum([move.product_uom_qty - move.quantity_done for move in moves])

--- a/purchase_propagate_qty/tests/test_purchase_delivery.py
+++ b/purchase_propagate_qty/tests/test_purchase_delivery.py
@@ -18,7 +18,7 @@ class TestQtyUpdate(SavepointCase):
         cls.product_model = cls.env["product.product"]
 
         # Create products:
-        p1 = cls.product1 = cls.product_model.create(
+        cls.p1 = cls.product1 = cls.product_model.create(
             {"name": "Test Product 1", "type": "product", "default_code": "PROD1"}
         )
         p2 = cls.product2 = cls.product_model.create(
@@ -34,12 +34,12 @@ class TestQtyUpdate(SavepointCase):
                         0,
                         0,
                         {
-                            "product_id": p1.id,
-                            "product_uom": p1.uom_id.id,
-                            "name": p1.name,
-                            "price_unit": p1.standard_price,
+                            "product_id": cls.p1.id,
+                            "product_uom": cls.p1.uom_id.id,
+                            "name": cls.p1.name,
                             "date_planned": cls.date_planned,
                             "product_qty": 42.0,
+                            "price_unit": 10.0,
                         },
                     ),
                     (
@@ -49,21 +49,21 @@ class TestQtyUpdate(SavepointCase):
                             "product_id": p2.id,
                             "product_uom": p2.uom_id.id,
                             "name": p2.name,
-                            "price_unit": p2.standard_price,
                             "date_planned": cls.date_planned,
                             "product_qty": 12.0,
+                            "price_unit": 10.0,
                         },
                     ),
                     (
                         0,
                         0,
                         {
-                            "product_id": p1.id,
-                            "product_uom": p1.uom_id.id,
-                            "name": p1.name,
-                            "price_unit": p1.standard_price,
+                            "product_id": cls.p1.id,
+                            "product_uom": cls.p1.uom_id.id,
+                            "name": cls.p1.name,
                             "date_planned": cls.date_planned,
                             "product_qty": 1.0,
+                            "price_unit": 10.0,
                         },
                     ),
                 ],
@@ -94,3 +94,60 @@ class TestQtyUpdate(SavepointCase):
         line1.write({"product_qty": 0})
         self.assertEqual(move1.product_uom_qty, 0)
         self.assertEqual(move1.state, "cancel")
+
+    def test_purchase_line_split_move(self):
+        line1 = self.po.order_line[0]
+        move1 = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
+        self.assertEqual(len(move1), 1)
+        # change price so when qty is updated, price is as well, an triggers the split
+        self.assertEqual(self.p1.seller_ids.price, 10.0)
+        self.p1.seller_ids.price = 9.0
+        line1._onchange_quantity()
+        line1.write({"product_qty": 64})
+        moves = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
+        self.assertEqual(len(moves), 2)
+        self.assertEqual(moves.mapped("product_uom_qty"), [42.0, 22.0])
+        # Then, decrease 11
+        line1.write({"product_qty": 53})
+        self.assertEqual(moves.mapped("product_uom_qty"), [42.0, 11.0])
+        # Again, decrease 11
+        line1.write({"product_qty": 42})
+        self.assertEqual(moves.mapped("product_uom_qty"), [42.0, 0.0])
+        active_move = moves.filtered(lambda m: m.state != "cancel")
+        inactive_move = moves.filtered(lambda m: m.state == "cancel")
+        self.assertEqual(active_move.product_uom_qty, 42)
+        self.assertEqual(inactive_move.product_uom_qty, 0)
+
+    def test_purchase_line_split_move_w_reserved_qty(self):
+        line1 = self.po.order_line[0]
+        move1 = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
+        self.assertEqual(len(move1), 1)
+        # change price so when qty is updated, price is as well, an triggers the split
+        self.assertEqual(self.p1.seller_ids.price, 10.0)
+        self.p1.seller_ids.price = 9.0
+        line1._onchange_quantity()
+        # Increase qty by 22, move1 should be split
+        line1.write({"product_qty": 64})
+        moves = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
+        move2 = moves - move1
+        # reserve 12 qty
+        move2.quantity_done = 12
+        self.assertEqual(move2._get_removable_qty(), 10)
+        line1.write({"product_qty": 60})
+        self.assertEqual(moves.mapped("product_uom_qty"), [42.0, 18.0])
+        # We cannot remove more than 10 on move2, deduce the max from it,
+        # then deduce from move1
+        line1.write({"product_qty": 50})
+        self.assertEqual(moves.mapped("product_uom_qty"), [38.0, 12.0])
+        # We should not be able to set a qty < to 12, since 12 products are reserved
+        exception_regex = (
+            r"You cannot remove more that what remains to be done.\n"
+            r"Max removable quantity 38.0."
+        )
+        with self.assertRaisesRegex(UserError, exception_regex):
+            line1.write({"product_qty": 11})
+        # with 12, move1 should be cancelled
+        line1.write({"product_qty": 12})
+        self.assertEqual(move1.product_uom_qty, 0.0)
+        self.assertEqual(move1.state, "cancel")
+        self.assertEqual(move2.product_uom_qty, 12.0)


### PR DESCRIPTION
based on https://github.com/OCA/purchase-workflow/pull/1172, to be merged first.

In some cases (to be defined), odoo creates multiple moves for a single purchase order line.
Since the purchase_propagate_qty propagates the new purchased qty to all moves, we get two moves with a same quantity, which is the same as the one on the purchase line.

e.g 
 - user adds 10 to a purchase line with qty 100 -> new qty 110
 - for some reason, odoo creates a new move with qty 10 -> 2 moves with qties 100 and 10
 - purchase_propagate_qty does what it's meant to, propagates 110 onto the moves -> two moves with 110

This PR fixes this behaviour