### PR TITLE
[14.0][IMP] purchase_invoice_plan, misc improvements to be more accurate.

### DIFF
--- a/purchase_invoice_plan/__manifest__.py
+++ b/purchase_invoice_plan/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["purchase_open_qty", "purchase_stock"],
     "data": [
         "security/ir.model.access.csv",
+        "data/purchase_data.xml",
         "wizard/purchase_create_invoice_plan_view.xml",
         "wizard/purchase_make_planned_invoice_view.xml",
         "views/purchase_view.xml",

--- a/purchase_invoice_plan/data/purchase_data.xml
+++ b/purchase_invoice_plan/data/purchase_data.xml
@@ -1,0 +1,6 @@
+<odoo noupdate="1">
+    <record id="decimal_price" model="decimal.precision" forcecreate="True">
+        <field name="name">Purchase Invoice Plan Percent</field>
+        <field name="digits">6</field>
+    </record>
+</odoo>

--- a/purchase_invoice_plan/views/purchase_view.xml
+++ b/purchase_invoice_plan/views/purchase_view.xml
@@ -4,11 +4,29 @@
         <field name="model">purchase.invoice.plan</field>
         <field name="arch" type="xml">
             <tree editable="bottom">
-                <field name="installment" />
-                <field name="plan_date" />
-                <field name="invoice_type" />
-                <field name="percent" optional="show" />
-                <field name="amount" optional="show" />
+                <field name="no_edit" invisible="1" />
+                <field
+                    name="installment"
+                    attrs="{'readonly': [('no_edit', '=', True)]}"
+                />
+                <field
+                    name="plan_date"
+                    attrs="{'readonly': [('no_edit', '=', True)]}"
+                />
+                <field
+                    name="invoice_type"
+                    attrs="{'readonly': [('no_edit', '=', True)]}"
+                />
+                <field
+                    name="percent"
+                    optional="show"
+                    attrs="{'readonly': [('no_edit', '=', True)]}"
+                />
+                <field
+                    name="amount"
+                    optional="show"
+                    attrs="{'readonly': [('no_edit', '=', True)]}"
+                />
                 <field name="to_invoice" />
                 <field name="invoiced" />
                 <field name="invoice_ids" optional="hide" widget="many2many_tags" />
@@ -85,7 +103,7 @@
                     <field
                         name="invoice_plan_ids"
                         context="{'tree_view_ref': 'view_purchase_invoice_plan_tree'}"
-                        attrs="{'invisible': [('invoice_plan_ids', '=', [])], 'readonly': [('invoice_count', '>', 0)]}"
+                        attrs="{'invisible': [('invoice_plan_ids', '=', [])]}"
                     />
                     <group class="oe_subtotal_footer oe_right">
                         <field name="ip_total_percent" />


### PR DESCRIPTION
For invoice plan to be more flexible and accurate, following improvement are added,

1. Ensure that, only unused invoice plan are editable.
2. Validate that, total plan percent = 100
3. Add decimal prec "Purchase Invoice Plan Percent" to gain more accuracy of computed amount. (now, default perent prec = 6 digits, this is much need for big amount with lots of installments).