### PR TITLE
[13.0] Refactor purchase_split_by_date (support new PO line or increased qty on a confirmed PO)

### DIFF
--- a/purchase_delivery_split_date/README.rst
+++ b/purchase_delivery_split_date/README.rst
@@ -32,12 +32,16 @@ Purchase Order Lines.
 
 Once the Purchase Order has been confirmed, subsequent changes made to the
 scheduled dates in the PO lines will produce a reorganization of the
-corresponding stock moves in the Incoming Shipments, creating/deleting new
-Incoming Shipments when needed, to ensure that each Incoming Shipment
-contains moves to be received in the same date.
+corresponding stock moves in the Incoming Shipments (**propagate_date on the
+purchase order line is not relevant anymore when this module is installed**),
+creating/deleting new Incoming Shipments when needed, to ensure that each
+Incoming Shipment contains moves to be received in the same date.
+
+Adding a new line on a confirmed PO will insert the new move in a picking with
+the corresponding date.
 
 This module is also designed for extensibility, so that you can define
-in other modules new criteria to split deliveries.
+in other modules new criteria to split incoming shipments.
 
 **Table of contents**
 
@@ -53,12 +57,18 @@ When a Purchase Order is confirmed, shipments will be grouped by same scheduled 
 Changelog
 =========
 
+13.0.1.1.0 (2021-08-17)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Refactor code to support addition of PO line on confirmed PO and better
+  support the change of date on a confirmed purchase order. Take care of
+  purchase order line 'propagate_date' field.
+
 12.0.2.0.0 (2020-04-10)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 * Improve the module: when changing the date on a purchase line, this will
   cause a split or a merge of the pickings, to keep 1 picking per date.
-
 
 11.0.1.0.0 (2018-09-16)
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -89,6 +99,7 @@ Authors
 * Numerigraphe
 * ForgeFlow
 * Camptocamp
+* BCIM
 
 Contributors
 ~~~~~~~~~~~~
@@ -100,6 +111,7 @@ Contributors
 * Lois Rilo <lois.rilo@forgeflow.com> (migration to v10)
 * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/purchase_delivery_split_date/__manifest__.py
+++ b/purchase_delivery_split_date/__manifest__.py
@@ -1,13 +1,14 @@
 # Copyright 2014-2016 Numérigraphe SARL
 # Copyright 2017 ForgeFlow, S.L.
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Purchase Delivery Split Date",
-    "version": "13.0.1.0.5",
+    "version": "13.0.1.1.0",
     "summary": "Allows Purchase Order you confirm to generate one Incoming "
     "Shipment for each expected date indicated in the Purchase Order Lines",
-    "author": "Numerigraphe, ForgeFlow, Camptocamp, Odoo Community Association (OCA)",
+    "author": "Numerigraphe, ForgeFlow, Camptocamp, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "category": "Purchase Management",
     "license": "AGPL-3",

--- a/purchase_delivery_split_date/models/__init__.py
+++ b/purchase_delivery_split_date/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import purchase
+from . import stock_picking

--- a/purchase_delivery_split_date/models/stock_picking.py
+++ b/purchase_delivery_split_date/models/stock_picking.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+
+from odoo import SUPERUSER_ID, fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def dt2date(self, datetime):
+        """Convert a datetime to date respecting tz"""
+        # TODO: extract the tz field on the warehouse from the module
+        # sale_cutoff_time_delivery in OCA/sale-workflow to make a generic module
+        # on which this module can depend on. At the moment, we take the tz of the
+        # SUPERUSER if defined. This is safer than the tz of the user
+        # (purchaser) that can be freely modified by the user.
+        if self.env.user.id != SUPERUSER_ID:
+            tz = self.env["res.users"].sudo().browse(SUPERUSER_ID).tz
+            if tz:
+                self = self.with_context(tz=tz)
+        return fields.Date.context_today(self, datetime)

--- a/purchase_delivery_split_date/readme/CONTRIBUTORS.rst
+++ b/purchase_delivery_split_date/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
 * Lois Rilo <lois.rilo@forgeflow.com> (migration to v10)
 * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/purchase_delivery_split_date/readme/DESCRIPTION.rst
+++ b/purchase_delivery_split_date/readme/DESCRIPTION.rst
@@ -5,9 +5,13 @@ Purchase Order Lines.
 
 Once the Purchase Order has been confirmed, subsequent changes made to the
 scheduled dates in the PO lines will produce a reorganization of the
-corresponding stock moves in the Incoming Shipments, creating/deleting new
-Incoming Shipments when needed, to ensure that each Incoming Shipment
-contains moves to be received in the same date.
+corresponding stock moves in the Incoming Shipments (**propagate_date on the
+purchase order line is not relevant anymore when this module is installed**),
+creating/deleting new Incoming Shipments when needed, to ensure that each
+Incoming Shipment contains moves to be received in the same date.
+
+Adding a new line on a confirmed PO will insert the new move in a picking with
+the corresponding date.
 
 This module is also designed for extensibility, so that you can define
-in other modules new criteria to split deliveries.
+in other modules new criteria to split incoming shipments.

--- a/purchase_delivery_split_date/readme/HISTORY.rst
+++ b/purchase_delivery_split_date/readme/HISTORY.rst
@@ -1,9 +1,14 @@
+13.0.1.1.0 (2021-08-17)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Refactor code to support addition of PO line on confirmed PO and better
+  support the change of date on a confirmed purchase order.
+
 12.0.2.0.0 (2020-04-10)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 * Improve the module: when changing the date on a purchase line, this will
   cause a split or a merge of the pickings, to keep 1 picking per date.
-
 
 11.0.1.0.0 (2018-09-16)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/purchase_delivery_split_date/tests/test_purchase_delivery.py
+++ b/purchase_delivery_split_date/tests/test_purchase_delivery.py
@@ -1,5 +1,6 @@
 # Copyright 2014-2016 Numérigraphe SARL
 # Copyright 2017 ForgeFlow, S.L.
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests.common import TransactionCase
@@ -22,6 +23,7 @@ class TestDeliverySingle(TransactionCase):
         )
 
         # Two dates which we can use to test the features:
+        self.date_in_the_past = "2014-12-12"
         self.date_sooner = "2015-01-01"
         self.date_later = "2015-12-13"
         self.date_3rd = "2015-12-31"
@@ -39,6 +41,7 @@ class TestDeliverySingle(TransactionCase):
                             "name": p1.name,
                             "price_unit": p1.standard_price,
                             "date_planned": self.date_sooner,
+                            "propagate_date": True,
                             "product_qty": 42.0,
                         },
                     ),
@@ -51,6 +54,7 @@ class TestDeliverySingle(TransactionCase):
                             "name": p2.name,
                             "price_unit": p2.standard_price,
                             "date_planned": self.date_sooner,
+                            "propagate_date": True,
                             "product_qty": 12.0,
                         },
                     ),
@@ -63,6 +67,7 @@ class TestDeliverySingle(TransactionCase):
                             "name": p1.name,
                             "price_unit": p1.standard_price,
                             "date_planned": self.date_sooner,
+                            "propagate_date": True,
                             "product_qty": 1.0,
                         },
                     ),
@@ -120,9 +125,7 @@ class TestDeliverySingle(TransactionCase):
     def test_purchase_line_date_change(self):
         self.po.order_line[0].date_planned = self.date_later
         self.po.button_confirm()
-        moves = self.env["stock.move"].search(
-            [("purchase_line_id", "=", self.po.order_line[0].id)]
-        )
+        moves = self.po.order_line[0].move_ids
         line = self.po.order_line[0]
         line.write({"date_planned": self.date_3rd})
         self.assertEqual(moves.date_expected.strftime("%Y-%m-%d"), self.date_3rd)
@@ -135,12 +138,9 @@ class TestDeliverySingle(TransactionCase):
          """
         self.po.order_line[0].date_planned = self.date_later
         self.po.button_confirm()
-        moves = self.env["stock.move"].search(
-            [("purchase_line_id", "in", self.po.order_line.ids)]
-        )
+        moves = self.po.order_line.move_ids
         pickings = moves.mapped("picking_id")
         self.assertEqual(len(pickings), 2)
-        pickings[1].scheduled_date = pickings[0].scheduled_date
         self.po.order_line[0].date_planned = self.date_sooner
         self.assertEqual(len(moves.mapped("picking_id")), 1)
         self.assertEqual(len(pickings.filtered(lambda r: r.state == "cancel")), 1)
@@ -149,8 +149,8 @@ class TestDeliverySingle(TransactionCase):
         self.po.button_confirm()
         line1 = self.po.order_line[0]
         line2 = self.po.order_line[1]
-        move1 = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
-        move2 = self.env["stock.move"].search([("purchase_line_id", "=", line2.id)])
+        move1 = line1.move_ids
+        move2 = line2.move_ids
 
         line1.write({"date_planned": self.date_later})
         self.assertEquals(
@@ -169,6 +169,49 @@ class TestDeliverySingle(TransactionCase):
             "both moves must be in the same picking",
         )
 
+    def test_purchase_line_qty_change_merge_moves(self):
+        self.po.order_line[0].date_planned = self.date_later
+        self.po.button_confirm()
+        self.assertEquals(
+            len(self.po.picking_ids),
+            2,
+            "There must be 2 pickings when PO lines have 2 different dates",
+        )
+        # Increase qty of first PO line
+        self.po.order_line[0].product_qty += 10
+        self.assertEquals(
+            len(self.po.picking_ids),
+            2,
+            "There must be 2 pickings when PO lines have 2 different dates",
+        )
+        self.assertEquals(
+            len(self.po.order_line[0].move_ids),
+            1,
+            "There must be 1 move per PO line when qty is increased",
+        )
+        self.assertEquals(
+            len(self.po.order_line[1].move_ids),
+            1,
+            "There must be 1 move per PO line when qty is increased",
+        )
+        # Increase qty of second PO line
+        self.po.order_line[1].product_qty += 10
+        self.assertEquals(
+            len(self.po.picking_ids),
+            2,
+            "There must be 2 pickings when PO lines have 2 different dates",
+        )
+        self.assertEquals(
+            len(self.po.order_line[0].move_ids),
+            1,
+            "There must be 1 move per PO line when qty is increased",
+        )
+        self.assertEquals(
+            len(self.po.order_line[1].move_ids),
+            1,
+            "There must be 1 move per PO line when qty is increased",
+        )
+
     def test_purchase_line_created_afer_confirm(self):
         """Check new line created when order is confirmed.
 
@@ -180,9 +223,7 @@ class TestDeliverySingle(TransactionCase):
         self.po.button_confirm()
         self.assertEqual(self.po.state, "purchase")
         new_date = "2016-01-30"
-        moves_before = self.env["stock.move"].search(
-            [("purchase_line_id", "in", self.po.order_line.ids)]
-        )
+        moves_before = self.po.order_line.move_ids
         self.assertEqual(len(moves_before.mapped("picking_id")), 1)
         self.po.order_line = [
             (
@@ -198,16 +239,13 @@ class TestDeliverySingle(TransactionCase):
                 },
             ),
         ]
-        moves_after = self.env["stock.move"].search(
-            [("purchase_line_id", "in", self.po.order_line.ids)]
-        )
+        moves_after = self.po.order_line.move_ids
         self.assertEqual(len(moves_after.mapped("picking_id")), 2)
 
     def test_purchase_line_date_change_tz_aware(self):
         """Check that the grouping  is time zone aware.
 
         Datetime are always stored in utc in the database.
-
         """
         self.po.order_line[2].unlink()
         self.po.button_confirm()
@@ -226,4 +264,11 @@ class TestDeliverySingle(TransactionCase):
         self.assertEquals(len(self.po.picking_ids), 2)
         # No time difference so will be another day (2 pickings)
         line2.write({"date_planned": "2021-05-04 23:00:00"})
+        self.assertEquals(len(self.po.picking_ids), 2)
+
+    def test_set_planned_date_in_the_past(self):
+        """Check changing the scheduled date of one line in the past."""
+        self.po.button_confirm()
+        self.assertEquals(len(self.po.picking_ids), 1)
+        self.po.order_line[0].date_planned = self.date_in_the_past
         self.assertEquals(len(self.po.picking_ids), 2)

--- a/purchase_location_by_line/README.rst
+++ b/purchase_location_by_line/README.rst
@@ -62,6 +62,7 @@ Contributors
 * Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
 * Hizbul Bahar <hizbul25@gmail.com>
 * Harald Panten <harald.panten@sygel.es>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/purchase_location_by_line/__manifest__.py
+++ b/purchase_location_by_line/__manifest__.py
@@ -1,12 +1,12 @@
-# © 2016 ForgeFlow S.L.
-#   (<http://www.forgeflow.com>)
-# © 2018 Hizbul Bahar <hizbul25@gmail.com>
+# Copyright 2016 ForgeFlow S.L. (<http://www.forgeflow.com>)
+# Copyright 2018 Hizbul Bahar <hizbul25@gmail.com>
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Purchase Location by Line",
     "summary": "Allows to define a specific destination location on each PO line",
-    "version": "13.0.1.0.0",
+    "version": "13.0.2.0.0",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "category": "Purchase Management",

--- a/purchase_location_by_line/models/purchase.py
+++ b/purchase_location_by_line/models/purchase.py
@@ -1,9 +1,9 @@
-# © 2016 ForgeFlow S.L.
-#   (<http://www.forgeflow.com>)
-# © 2018 Hizbul Bahar <hizbul25@gmail.com>
+# Copyright 2016 ForgeFlow S.L. (<http://www.forgeflow.com>)
+# Copyright 2018 Hizbul Bahar <hizbul25@gmail.com>
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class PurchaseOrderLine(models.Model):
@@ -15,44 +15,22 @@ class PurchaseOrderLine(models.Model):
         domain=[("usage", "in", ["internal", "transit"])],
     )
 
-    @api.model
-    def _first_picking_copy_vals(self, key, lines):
-        """The data to be copied to new pickings is updated with data from the
-        grouping key.  This method is designed for extensibility, so that
-        other modules can store more data based on new keys."""
-        vals = super(PurchaseOrderLine, self)._first_picking_copy_vals(key, lines)
-        for key_element in key:
-            if "location_dest_id" in key_element.keys():
-                vals["location_dest_id"] = key_element["location_dest_id"].id
-        return vals
-
-    @api.model
-    def _get_group_keys(self, order, line, picking=False):
-        """Define the key that will be used to group. The key should be
-        defined as a tuple of dictionaries, with each element containing a
-        dictionary element with the field that you want to group by. This
-        method is designed for extensibility, so that other modules can add
-        additional keys or replace them by others."""
-        key = super(PurchaseOrderLine, self)._get_group_keys(
-            order, line, picking=picking
+    def _is_valid_picking(self, picking):
+        res = super()._is_valid_picking(picking)
+        if not res:
+            return res
+        location = self.location_dest_id or self.env["stock.location"].browse(
+            self.order_id._get_destination_location()
         )
-        default_picking_location_id = line.order_id._get_destination_location()
-        default_picking_location = self.env["stock.location"].browse(
-            default_picking_location_id
-        )
-        location = line.location_dest_id or default_picking_location
-        return key + ({"location_dest_id": location},)
+        return picking.location_dest_id == location
 
-    def _create_stock_moves(self, picking):
-        res = super(PurchaseOrderLine, self)._create_stock_moves(picking)
-        for line in self:
-            default_picking_location_id = line.order_id._get_destination_location()
-            default_picking_location = self.env["stock.location"].browse(
-                default_picking_location_id
+    def _prepare_stock_moves(self, picking):
+        # When the first move of the picking is prepared, ensure the
+        # destination of the picking to make it a valid candidate
+        if not picking.move_lines:
+            location = self.location_dest_id or self.env["stock.location"].browse(
+                self.order_id._get_destination_location()
             )
-            location = line.location_dest_id or default_picking_location
-            if location:
-                line.move_ids.filtered(lambda m: m.state != "done").write(
-                    {"location_dest_id": location.id}
-                )
-        return res
+            if picking.location_dest_id != location:
+                picking.location_dest_id = location
+        return super()._prepare_stock_moves(picking)

--- a/purchase_location_by_line/readme/CONTRIBUTORS.rst
+++ b/purchase_location_by_line/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
 * Hizbul Bahar <hizbul25@gmail.com>
 * Harald Panten <harald.panten@sygel.es>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>


### PR DESCRIPTION
Support new PO line or increased qty on a confirmed PO. Instead of changing _create_stock_moves that is called only when the PO is confirmed, modify _prepare_stock_move to properly ensure the move is directly inserted in the right picking.

Improve PO line date change to properly insert move in the right picking and ensure to have one picking per date.

Improve date comparison taking care of the timezone.

Be compliant with ~~propagate_date and (after discussing with @jgrandguillaume, we better do not care of that feature as it is currently in previous versions)~~ display_type from odoo standard. 

cc @sebalix @jgrandguillaume @gurneyalex @LoisRForgeFlow @JordiBForgeFlow 