### PR TITLE
[14.0][FIX] Change action_confirm to button_confirm

### DIFF
--- a/purchase_invoice_plan/models/purchase.py
+++ b/purchase_invoice_plan/models/purchase.py
@@ -61,10 +61,10 @@ class PurchaseOrder(models.Model):
                         _("Please fill percentage for all invoice plan lines")
                     )
 
-    def action_confirm(self):
+    def button_confirm(self):
         if self.filtered(lambda r: r.use_invoice_plan and not r.invoice_plan_ids):
             raise UserError(_("Use Invoice Plan selected, but no plan created"))
-        return super().action_confirm()
+        return super().button_confirm()
 
     def create_invoice_plan(
         self, num_installment, installment_date, interval, interval_type


### PR DESCRIPTION
I didn't found action_confirm function in purchase.order model, This error `Use Invoice Plan selected, but no plan created` should check when click Confirm Order button.

cc: @kittiu 