### PR TITLE
[12.0][IMP] purchase_order_line_packaging_qty: default without warning

### DIFF
--- a/purchase_order_line_packaging_qty/models/product_product.py
+++ b/purchase_order_line_packaging_qty/models/product_product.py
@@ -9,4 +9,5 @@ class ProductPackaging(models.Model):
     default_packaging = fields.Many2one(
         comodel_name='product.packaging',
         string="Default Product Packaging",
+        company_dependent=True,
     )

--- a/purchase_order_line_packaging_qty/models/purchase_order_line.py
+++ b/purchase_order_line_packaging_qty/models/purchase_order_line.py
@@ -33,8 +33,6 @@ class PurchaseOrderLine(models.Model):
                 or pol.product_packaging.qty == 0
             ):
                 pol.product_packaging_qty = 0
-                if pol.product_id and pol.product_id.default_packaging:
-                    pol.product_packaging = pol.product_id.default_packaging.id
                 continue
             # Consider UOM
             if pol.product_id.uom_id != pol.product_uom:
@@ -118,4 +116,13 @@ class PurchaseOrderLine(models.Model):
         if res and res[0]:
             res[0]["product_packaging"] = self.product_packaging.id
             res[0]["product_packaging_qty"] = self.product_packaging_qty
+        return res
+
+    @api.onchange('product_id')
+    def onchange_product_id(self):
+        res = super(PurchaseOrderLine, self).onchange_product_id()
+        for pol in self:
+            if pol.product_id and pol.product_id.default_packaging:
+                pol.product_packaging = pol.product_id.default_packaging.id
+                pol._onchange_product_packaging()
         return res

--- a/purchase_order_line_packaging_qty/views/product_product.xml
+++ b/purchase_order_line_packaging_qty/views/product_product.xml
@@ -4,8 +4,7 @@
     <record model="ir.ui.view" id="product_product_form_view">
         <field name="name">product.product.form (in product_form_sale_link)</field>
         <field name="model">product.product</field>
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
-        <field name="inherit_id" ref="sale.product_form_view_sale_order_button"/>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='packaging_ids']" position="after">
                 <group name="main">


### PR DESCRIPTION
When the default packaging is set in the purchase order line, a notification appears saying the quantity of the default packaging. It is better not to display the notification to accelerate the process of generating the PO.
Also change the inherited view to product.product view, avoid inheritance from sale.
@HviorForgeFlow 