### PR TITLE
[FIX] purchase_delivery_split_date: Access rights issue

### DIFF
--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -68,7 +68,7 @@ class PurchaseOrderLine(models.Model):
             # If a picking is provided, clone it for each key for modularity
             if picking:
                 copy_vals = self._first_picking_copy_vals(key, lines)
-                picking = first_picking.copy(copy_vals)
+                picking = first_picking.sudo().copy(copy_vals)
             po_lines = self.env["purchase.order.line"]
             for line in list(lines):
                 po_lines += line
@@ -110,14 +110,14 @@ class PurchaseOrder(models.Model):
                         if move.picking_id.scheduled_date.date() != date_key:
                             if date_key not in pickings_by_date:
                                 copy_vals = line._first_picking_copy_vals(key, line)
-                                new_picking = move.picking_id.copy(copy_vals)
+                                new_picking = move.picking_id.sudo().copy(copy_vals)
                                 pickings_by_date[date_key] = new_picking
                             move._do_unreserve()
                             move.picking_id = pickings_by_date[date_key]
                             move.date_deadline = date_key
             for picking in pickings_by_date.values():
                 if len(picking.move_lines) == 0:
-                    picking.write({"state": "cancel"})
+                    picking.sudo().write({"state": "cancel"})
 
 
 class StockPicking(models.Model):


### PR DESCRIPTION
This error occurs when an automated action is setup for model=stock.picking with trigger=On update.
Also, there is an open picking and change the date in purchase.order form view and save the record.

```
File "/odoo/src/addons/purchase_stock/models/purchase.py", line 74, in write
res = super(PurchaseOrder, self).write(vals)
File "/odoo/src/addons/purchase_requisition/models/purchase.py", line 101, in write
result = super(PurchaseOrder, self).write(vals)
File "/odoo/src/addons/purchase/models/purchase.py", line 204, in write
res = super().write(vals)
File "/odoo/src/addons/mail/models/mail_thread.py", line 322, in write
result = super(MailThread, self).write(values)
File "/odoo/src/addons/mail/models/mail_activity.py", line 788, in write
return super(MailActivityMixin, self).write(vals)
File "/odoo/external-src/connector/component_event/models/base.py", line 109, in write
result = super(Base, self).write(vals)
File "/odoo/src/odoo/models.py", line 3665, in write
field.write(self, vals[fname])
File "/odoo/src/odoo/fields.py", line 3046, in write
return self.write_batch([(records, value)])
File "/odoo/src/odoo/fields.py", line 3067, in write_batch
return self.write_real(records_commands_list, create)
File "/odoo/src/odoo/fields.py", line 3218, in write_real
comodel.browse(command[1]).write(command[2])
File "/odoo/external-src/purchase-workflow/purchase_delivery_split_date/models/purchase.py", line 81, in write
self.mapped("order_id")._check_split_pickings()
File "/odoo/external-src/purchase-workflow/purchase_delivery_split_date/models/purchase.py", line 113, in _check_split_pickings
new_picking = move.picking_id.copy(copy_vals)
File "/odoo/src/odoo/models.py", line 4662, in copy
new = self.with_context(lang=None).create(vals)
File "<decorator-gen-331>", line 2, in create
File "/odoo/src/odoo/api.py", line 323, in _model_create_single
return create(self, arg)
File "/odoo/src/addons/stock_picking_batch/models/stock_picking.py", line 18, in create
res = super().create(vals)
File "<decorator-gen-274>", line 2, in create
File "/odoo/src/odoo/api.py", line 323, in _model_create_single
return create(self, arg)
File "/odoo/src/addons/stock/models/stock_picking.py", line 668, in create
res.with_context(mail_notrack=True).write({'scheduled_date': scheduled_date})
File "/odoo/src/addons/base_automation/models/base_automation.py", line 341, in write
for old_vals in (records.read(list(vals)) if vals else [])
File "/odoo/src/odoo/models.py", line 3020, in read
self._read(stored_fields)
File "/odoo/src/odoo/models.py", line 3182, in _read
raise self.env['ir.rule']._make_access_error('read', forbidden)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
File "/odoo/src/odoo/http.py", line 640, in _handle_exception
return super(JsonRequest, self)._handle_exception(exception)
File "/odoo/src/odoo/http.py", line 316, in _handle_exception
raise exception.with_traceback(None) from new_cause
odoo.exceptions.AccessError: Due to security restrictions, you are not allowed to access 'Transfer' (stock.picking) records.

Records: PA/IN/02535 (id=79215)
User: Admin Sodexis (id=5687)

This restriction is due to the following rules:

Contact your administrator to request access if necessary.
```

cc: @SodexisTeam 