### PR TITLE
[13.0][IMP] purchase_order_supplierinfo_update: Fix random test failure

### DIFF
--- a/purchase_order_supplierinfo_update/tests/test_purchase_order_supplierinfo_update.py
+++ b/purchase_order_supplierinfo_update/tests/test_purchase_order_supplierinfo_update.py
@@ -1,6 +1,9 @@
 # Copyright 2021 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields
 from odoo.tests import Form, SavepointCase
 
 
@@ -48,6 +51,8 @@ class TestPurchaseOrderSupplierinfoUpdate(SavepointCase):
         # Create first purchase
         po_form_1 = Form(self.env["purchase.order"])
         po_form_1.partner_id = self.supplier
+        now = fields.Datetime.now()
+        po_form_1.date_order = now - relativedelta(days=1)
         with po_form_1.order_line.new() as po_line_form:
             po_line_form.product_id = self.product
             po_line_form.taxes_id.clear()


### PR DESCRIPTION
When 2 purchase orders are created by the test at the same time can have same date order and this condition:
https://github.com/OCA/purchase-workflow/blob/d30f00b3d646c9d969561d25e3bd9612aed4dc2a/purchase_order_supplierinfo_update/models/purchase_order.py#L33-L40
causes the price to be updated here:
https://github.com/OCA/purchase-workflow/blob/d30f00b3d646c9d969561d25e3bd9612aed4dc2a/purchase_order_supplierinfo_update/tests/test_purchase_order_supplierinfo_update.py#L74
and this assert fails:
https://github.com/OCA/purchase-workflow/blob/d30f00b3d646c9d969561d25e3bd9612aed4dc2a/purchase_order_supplierinfo_update/tests/test_purchase_order_supplierinfo_update.py#L75


@Tecnativa