### PR TITLE
[12.0][ADD] sale_purchase_service_grouping

### DIFF
--- a/sale_purchase_service_grouping/__init__.py
+++ b/sale_purchase_service_grouping/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_purchase_service_grouping/__manifest__.py
+++ b/sale_purchase_service_grouping/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Moka Tourisme (https://www.mokatourisme.fr).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Purchase Service Grouping",
+    "summary": "Sale Purchase Service Grouping",
+    "version": "12.0.1.0.0",
+    "author": "Moka Tourisme, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/purchase-workflow",
+    "license": "AGPL-3",
+    "category": "Purchase Management",
+    "depends": ["sale_purchase"],
+    "data": ["views/product_category.xml"],
+    "demo": ["demo/product_demo.xml"],
+}

--- a/sale_purchase_service_grouping/demo/product_demo.xml
+++ b/sale_purchase_service_grouping/demo/product_demo.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="res_partner_supplier" model="res.partner">
+        <field name="name">Outsourced Service Company</field>
+    </record>
+
+    <record id="product_attribute_1" model="product.attribute">
+        <field name="name">Service Level</field>
+    </record>
+
+    <record id="product_attribute_value_1" model="product.attribute.value">
+        <field name="attribute_id" ref="product_attribute_1"/>
+        <field name="name">Standard</field>
+        <field name="sequence">1</field>
+    </record>
+
+    <record id="product_attribute_value_2" model="product.attribute.value">
+        <field name="attribute_id" ref="product_attribute_1"/>
+        <field name="name">Premium</field>
+        <field name="sequence">2</field>
+    </record>
+
+    <record id="product_category" model="product.category">
+        <field name="name">Outsourced Service</field>
+        <field name="parent_id" ref="product.product_category_3" />
+        <field name="purchase_service_grouping">sale.order</field>
+    </record>
+
+    <record id="product_a_product_template" model="product.template">
+        <field name="name">Outsourced Service A</field>
+        <field name="categ_id" ref="product_category" />
+        <field name="standard_price">100.0</field>
+        <field name="list_price">150.0</field>
+        <field name="type">service</field>
+        <field name="service_to_purchase" eval="True" />
+        <field name="uom_id" ref="uom.product_uom_hour" />
+        <field name="uom_po_id" ref="uom.product_uom_hour" />
+        <field name="seller_ids" eval="[(0, 0, {'name': ref('res_partner_supplier')})]" />
+    </record>
+
+    <record id="product_a_1" model="product.product">
+        <field name="attribute_value_ids" eval="[(4, ref('product_attribute_value_1'))]"/>
+        <field name="product_tmpl_id" ref="product_a_product_template"/>
+    </record>
+
+    <record id="product_a_2" model="product.product">
+        <field name="attribute_value_ids" eval="[(4, ref('product_attribute_value_2'))]"/>
+        <field name="product_tmpl_id" ref="product_a_product_template"/>
+    </record>
+
+    <record id="product_a_attribute_line_1" model="product.template.attribute.line">
+        <field name="product_tmpl_id" ref="product_a_product_template"/>
+        <field name="attribute_id" ref="product_attribute_1"/>
+        <field name="value_ids" eval="[(6, 0, [ref('product_attribute_value_1'), ref('product_attribute_value_2')])]" />
+    </record>
+
+    <record id="product_b" model="product.product">
+        <field name="name">Outsourced Service B</field>
+        <field name="categ_id" ref="product_category" />
+        <field name="standard_price">100.0</field>
+        <field name="list_price">200.0</field>
+        <field name="type">service</field>
+        <field name="service_to_purchase" eval="True" />
+        <field name="uom_id" ref="uom.product_uom_hour" />
+        <field name="uom_po_id" ref="uom.product_uom_hour" />
+        <field name="seller_ids" eval="[(0, 0, {'name': ref('res_partner_supplier')})]" />
+    </record>
+
+</odoo>

--- a/sale_purchase_service_grouping/models/__init__.py
+++ b/sale_purchase_service_grouping/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_category
+from . import purchase_order
+from . import sale_order_line

--- a/sale_purchase_service_grouping/models/product_category.py
+++ b/sale_purchase_service_grouping/models/product_category.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Moka Tourisme (https://www.mokatourisme.fr).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields
+
+
+class ProductCategory(models.Model):
+    _inherit = "product.category"
+
+    purchase_service_grouping = fields.Selection(
+        [
+            ("product.category", "Product Category"),
+            ("product.template", "Product Template"),
+            ("product", "Product"),
+            ("sale.order", "Sales Order"),
+        ],
+        string="Purchase Service Grouping",
+        help="Grouping policy used to purchase service products from Sales Orders.\n\n"
+        "* Sales Order: Group by Sales Order.\n"
+        "* Product Category: Group by Product Category.\n"
+        "* Product Template: Group by Product Template.\n"
+        "* Product: Group by Product.\n"
+        "\nGrouping by Supplier will always be applied.",
+    )

--- a/sale_purchase_service_grouping/models/purchase_order.py
+++ b/sale_purchase_service_grouping/models/purchase_order.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Moka Tourisme (https://www.mokatourisme.fr).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+from odoo.osv import expression
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        # Override.
+        #
+        # Make odoo think there isn't any existing purchase order to insert the
+        # products into.
+        #
+        # See :meth:`~sale_order_line._purchase_service_create`.
+        extra_domain = self.env.context.get("purchase_service_grouping_domain")
+        if extra_domain:
+            args = expression.AND([args, extra_domain])
+        return super().search(
+            args, offset=offset, limit=limit, order=order, count=count
+        )

--- a/sale_purchase_service_grouping/models/sale_order_line.py
+++ b/sale_purchase_service_grouping/models/sale_order_line.py
@@ -1,0 +1,69 @@
+# Copyright 2021 Moka Tourisme (https://www.mokatourisme.fr).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _purchase_service_get_po_domain(self):
+        """Returns the domain used to find the target Purchase Order
+
+        The domain is used to extend the original domain with expression.AND.
+        The original domain already looks like this:
+
+        .. code-block:: python
+
+            [
+                ("partner_id", "=", partner_supplier.id),
+                ("state", "=", "draft"),
+                ("company_id", "=", line.company_id.id),
+            ]
+        """
+        self.ensure_one()
+        grouping = self.product_id.categ_id.purchase_service_grouping
+        if not grouping:
+            return
+        elif grouping == "sale.order":
+            return [
+                ("order_line.sale_line_id.order_id", "=", self.order_id.id),
+            ]
+        elif grouping == "product.category":
+            return [
+                ("order_line.product_id.categ_id", "=", self.product_id.categ_id.id),
+            ]
+        elif grouping == "product.template":
+            return [
+                (
+                    "order_line.product_id.product_tmpl_id",
+                    "=",
+                    self.product_id.product_tmpl_id.id,
+                ),
+            ]
+        elif grouping == "product":
+            return [
+                ("order_line.product_id", "=", self.product_id.id),
+            ]
+
+    def _purchase_service_create(self, quantity=False):
+        # Override. Always create a new purchase.order
+        #
+        # We do this by tricking odoo into thinking there isn't any existing purchase
+        # order to insert the products into.
+        #
+        # We process all lines with no special grouping together as a recordset, as to
+        # benefit from the original method's optimizations.
+        #
+        # See :meth:`~purchase_order.search`.
+        records_group = self.filtered("product_id.categ_id.purchase_service_grouping")
+        records_no_group = self - records_group
+        res = super(SaleOrderLine, records_no_group)._purchase_service_create(quantity)
+        for rec in records_group:
+            extra_domain = rec._purchase_service_get_po_domain()
+            rec_ctx = rec.with_context(purchase_service_grouping_domain=extra_domain)
+            res[rec] = super(SaleOrderLine, rec_ctx)._purchase_service_create(
+                quantity=quantity
+            )
+        return res

--- a/sale_purchase_service_grouping/readme/CONFIGURE.rst
+++ b/sale_purchase_service_grouping/readme/CONFIGURE.rst
@@ -1,0 +1,11 @@
+Go to any Product Category, and set the desired grouping configuration for
+"Service to Purchase Grouping".
+
+Possible values are:
+
+* *Sales Order*: Group by Sales Order.
+* *Product Category*: Group by Product Category.
+* *Product Template*: Group by Product Template.
+* *Product*: Group by Product.
+
+An empty value defaults to the standard behaviour, which groups by Supplier.

--- a/sale_purchase_service_grouping/readme/DESCRIPTION.rst
+++ b/sale_purchase_service_grouping/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module allows to configure the grouping of generated Purchase Orders for
+`service_to_purchase` products.
+
+This configuration is done in the Product Category.

--- a/sale_purchase_service_grouping/readme/ROADMAP.rst
+++ b/sale_purchase_service_grouping/readme/ROADMAP.rst
@@ -1,0 +1,9 @@
+From a functional perspective, this module is similar to
+`procurement_purchase_no_grouping`.
+
+Technically, they're quite different, as service product don't generate procurements,
+the resulting Purchase Order is created differently.
+
+However, we could think about integrating the two modules so that the configuration
+on the `product.category` is merged and reused. From the user perspective it would
+make sense to configure this once per category for both services and stockable products.

--- a/sale_purchase_service_grouping/tests/__init__.py
+++ b/sale_purchase_service_grouping/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_purchase_service_grouping

--- a/sale_purchase_service_grouping/tests/test_sale_purchase_service_grouping.py
+++ b/sale_purchase_service_grouping/tests/test_sale_purchase_service_grouping.py
@@ -1,0 +1,97 @@
+# Copyright 2021 Moka Tourisme (https://www.mokatourisme.fr).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestSalePurchaseServiceGrouping(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        module = "sale_purchase_service_grouping"
+        cls.partner = cls.env.ref("base.res_partner_1")
+        cls.supplier = cls.env.ref("{}.res_partner_supplier".format(module))
+        cls.category = cls.env.ref("{}.product_category".format(module))
+        cls.product_a_1 = cls.env.ref("{}.product_a_1".format(module))
+        cls.product_a_2 = cls.env.ref("{}.product_a_2".format(module))
+        cls.product_b = cls.env.ref("{}.product_b".format(module))
+
+    def _search_purchases(self):
+        return self.env["purchase.order"].search(
+            [("partner_id", "=", self.supplier.id)]
+        )
+
+    def _create_sale_order(self, product_qty, **vals):
+        order_vals = {
+            "partner_id": self.partner.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": product.id,
+                        "product_uom_qty": qty,
+                    }
+                )
+                for product, qty in product_qty
+            ],
+        }
+        if vals:
+            order_vals.update(vals)
+        return self.env["sale.order"].create(order_vals)
+
+    def test_purchase_service_group_by_category_grouped(self):
+        self.category.purchase_service_grouping = "product.category"
+        self._create_sale_order([(self.product_b, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_1, 1)]).action_confirm()
+        self.assertEqual(len(self._search_purchases()), 1)
+
+    def test_purchase_service_group_by_category_ungrouped(self):
+        self.category.purchase_service_grouping = "product.category"
+        category_c = self.category.copy({"name": "New Categ"})
+        self.product_b.categ_id = category_c
+        self._create_sale_order([(self.product_b, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_1, 1)]).action_confirm()
+        self.assertEqual(len(self._search_purchases()), 2)
+
+    def test_purchase_service_group_by_template(self):
+        self.category.purchase_service_grouping = "product.template"
+        self._create_sale_order([(self.product_b, 1)]).action_confirm()
+        self._create_sale_order([(self.product_b, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_1, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_2, 1)]).action_confirm()
+        self.assertEqual(len(self._search_purchases()), 2)
+
+    def test_purchase_service_group_by_product(self):
+        self.category.purchase_service_grouping = "product"
+        self._create_sale_order([(self.product_b, 1)]).action_confirm()
+        self._create_sale_order([(self.product_b, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_1, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_2, 1)]).action_confirm()
+        self.assertEqual(len(self._search_purchases()), 3)
+
+    def test_purchase_service_group_by_order_ungrouped(self):
+        self.category.purchase_service_grouping = "sale.order"
+        self._create_sale_order([(self.product_b, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_1, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_2, 1)]).action_confirm()
+        self.assertEqual(len(self._search_purchases()), 3)
+
+    def test_purchase_service_group_by_order_grouped(self):
+        self._create_sale_order(
+            [
+                (self.product_b, 1),
+                (self.product_a_1, 1),
+                (self.product_a_2, 1),
+            ]
+        ).action_confirm()
+        self.assertEqual(len(self._search_purchases()), 1)
+
+    def test_purchase_service_group_default(self):
+        self.category.purchase_service_grouping = False
+        self._create_sale_order([(self.product_b, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_1, 1)]).action_confirm()
+        self._create_sale_order([(self.product_a_2, 1)]).action_confirm()
+        self.assertEqual(len(self._search_purchases()), 1)

--- a/sale_purchase_service_grouping/views/product_category.xml
+++ b/sale_purchase_service_grouping/views/product_category.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2021 Moka Tourisme (https://www.mokatourisme.fr).
+    @author Iván Todorovich <ivan.todorovich@gmail.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="product_category_form_view" model="ir.ui.view">
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="product.product_category_form_view"/>
+        <field name="arch" type="xml">
+            <group name="first" position="after">
+                <group name="service_grouping">
+                    <field name="purchase_service_grouping" />
+                </group>
+            </group>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module allows to configure the grouping of generated Purchase Orders for `service_to_purchase` products.

This configuration is done in the Product Category.

Possible values are:

* *Sales Order*: Group by Sales Order.
* *Product Category*: Group by Product Category.
* *Product Template*: Group by Product Template.
* *Product*: Group by Product.

An empty value defaults to the standard behaviour, which groups by Supplier.

---

From a functional perspective, this module is similar to`procurement_purchase_no_grouping`.

Technically, they're quite different, as service product don't generate procurements.
In fact this module doesn't even depend on `stock`.
