### PR TITLE
[13.0][FIX] procurement_purchase_no_grouping: Take into account SO updates

### DIFF
--- a/procurement_purchase_no_grouping/README.rst
+++ b/procurement_purchase_no_grouping/README.rst
@@ -52,6 +52,14 @@ Go to each product category, and select one of these values in the field
 System default behaviour can be set up in System settings / Purchase / Procurement
 Purchase Grouping
 
+Known issues / Roadmap
+======================
+
+- If you reuse the same procurement group between several sales orders, and
+  using "No line grouping", they will be grouped anyways, as the criteria for
+  grouping or not should be kept to the same procurement group, as it's the only
+  way to get proper quantities updates after confirming the sales order.
+
 Bug Tracker
 ===========
 

--- a/procurement_purchase_no_grouping/models/purchase_order.py
+++ b/procurement_purchase_no_grouping/models/purchase_order.py
@@ -1,6 +1,6 @@
 # Copyright 2015 AvanzOsc (http://www.avanzosc.es)
-# Copyright 2015-2016 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Tecnativa - Carlos Dauden
+# Copyright 2015-2021 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import models
@@ -20,9 +20,19 @@ class PurchaseOrderLine(models.Model):
         company_id,
         values,
     ):
+        """If not grouping by line, we should make an exception when you update an
+        existing sales order line, so we filter a bit more by procurement group.
+
+        NOTE: This makes that if you manually assign the same procurement group to
+        several different sales orders, the grouping will be done no matter the grouping
+        criteria, but this is the only way to do it without having to put a lot of glue
+        modules, and on standard operation mode, procurement groups are not reused
+        between sales orders.
+        """
+        obj = self
         if values.get("grouping") == "line":
-            return False
-        return super()._find_candidate(
+            obj = self.filtered(lambda x: x.order_id.group_id == values.get("group_id"))
+        return super(PurchaseOrderLine, obj)._find_candidate(
             product_id,
             product_qty,
             product_uom,

--- a/procurement_purchase_no_grouping/readme/ROADMAP.rst
+++ b/procurement_purchase_no_grouping/readme/ROADMAP.rst
@@ -1,0 +1,4 @@
+- If you reuse the same procurement group between several sales orders, and
+  using "No line grouping", they will be grouped anyways, as the criteria for
+  grouping or not should be kept to the same procurement group, as it's the only
+  way to get proper quantities updates after confirming the sales order.

--- a/procurement_purchase_no_grouping/static/description/index.html
+++ b/procurement_purchase_no_grouping/static/description/index.html
@@ -375,11 +375,12 @@ to system default.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -401,8 +402,17 @@ settings will be applied.</li>
 <p>System default behaviour can be set up in System settings / Purchase / Procurement
 Purchase Grouping</p>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>If you reuse the same procurement group between several sales orders, and
+using “No line grouping”, they will be grouped anyways, as the criteria for
+grouping or not should be kept to the same procurement group, as it’s the only
+way to get proper quantities updates after confirming the sales order.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/purchase-workflow/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -410,16 +420,16 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>AvanzOSC</li>
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Pedro M. Baeza</li>
@@ -435,7 +445,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
Steps to reproduce:

- Create a product with MTO route and "No line grouping" product category.
- Create an SO with such product and quantity = 1.
- Confirm it.
- A purchase order is created with such product and qty = 1.
- Edit the sales order, and change quantity = 2.

Current behavior:

A new purchase line is created with quantity = 2, having ordered 3 units instead of 2.

Expected behavior:

The same existing purchase line is updated with quantity = 2.

------

For solving this problem, we are going to group by procurement group instead of simply discarding any possible line grouping.

NOTE: This makes that if you manually assign the same procurement group to several different sales orders, the grouping will be done no matter the grouping criteria, but this is the only way to do it without having to put a lot of glue modules, and on standard operation mode, procurement groups are not reused between sales orders.

@Tecnativa TT33031