### PR TITLE
[14.0] [MIG] purchase_discount: Port PR from 12.0 to 14.0

### DIFF
--- a/purchase_discount/README.rst
+++ b/purchase_discount/README.rst
@@ -109,6 +109,7 @@ Contributors
 
   * Pedro M. Baeza
   * Vicent Cubells <vicent.cubells@tecnativa.com>
+  * Carlos Roca
 
 * Sudhir Arya <sudhir@erpharbor.com>
 * Lorenzo Battistini <https://github.com/eLBati>

--- a/purchase_discount/models/product_supplierinfo.py
+++ b/purchase_discount/models/product_supplierinfo.py
@@ -28,7 +28,7 @@ class ProductSupplierInfo(models.Model):
         """Insert discount (or others) from context from purchase.order's
         _add_supplier_to_product method"""
         for vals in vals_list:
-            product_tmpl_id = vals["product_tmpl_id"]
+            product_tmpl_id = vals.get("product_tmpl_id")
             po_line_map = self.env.context.get("po_line_map", {})
             if product_tmpl_id in po_line_map:
                 po_line = po_line_map[product_tmpl_id]

--- a/purchase_discount/models/res_partner.py
+++ b/purchase_discount/models/res_partner.py
@@ -13,4 +13,5 @@ class ResPartner(models.Model):
         digits="Discount",
         help="This value will be used as the default one, for each new"
         " supplierinfo line depending on that supplier.",
+        track_visibility="onchange",
     )

--- a/purchase_discount/models/stock_move.py
+++ b/purchase_discount/models/stock_move.py
@@ -16,7 +16,7 @@ class StockMove(models.Model):
         is not merged.
         """
         price_unit = False
-        po_line = self.purchase_line_id
+        po_line = self.purchase_line_id.sudo()
         if po_line and self.product_id == po_line.product_id:
             price = po_line._get_discounted_price_unit()
             if price != po_line.price_unit:

--- a/purchase_discount/readme/CONTRIBUTORS.rst
+++ b/purchase_discount/readme/CONTRIBUTORS.rst
@@ -8,6 +8,7 @@
 
   * Pedro M. Baeza
   * Vicent Cubells <vicent.cubells@tecnativa.com>
+  * Carlos Roca
 
 * Sudhir Arya <sudhir@erpharbor.com>
 * Lorenzo Battistini <https://github.com/eLBati>

--- a/purchase_discount/static/description/index.html
+++ b/purchase_discount/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Purchase order lines with discounts</title>
 <style type="text/css">
 
@@ -448,6 +448,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Pedro M. Baeza</li>
 <li>Vicent Cubells &lt;<a class="reference external" href="mailto:vicent.cubells&#64;tecnativa.com">vicent.cubells&#64;tecnativa.com</a>&gt;</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 <li>Sudhir Arya &lt;<a class="reference external" href="mailto:sudhir&#64;erpharbor.com">sudhir&#64;erpharbor.com</a>&gt;</li>

--- a/purchase_discount/views/report_purchaseorder.xml
+++ b/purchase_discount/views/report_purchaseorder.xml
@@ -5,12 +5,10 @@
         inherit_id="purchase.report_purchaseorder_document"
     >
         <xpath expr="//table[1]/thead/tr//th[last()]" position="before">
-            <th class="text-right">
-                <strong>Disc. (%)</strong>
-            </th>
+            <th name="th_discount" class="text-right"><strong>Disc. (%)</strong></th>
         </xpath>
         <xpath expr="//td[span[@t-field='line.price_subtotal']]" position="before">
-            <td class="text-right">
+            <td name="td_discount" class="text-right">
                 <span t-field="line.discount" />
             </td>
         </xpath>


### PR DESCRIPTION
PR Port:
* [PR #1047 [12.0][FIX] purchase_discount](https://github.com/OCA/purchase-workflow/pull/1047)
* [PR #1091 [12.0][IMP] purchase_discount: Add tracking to default_supplierinfo_discount on partners](https://github.com/OCA/purchase-workflow/pull/1091)
* [PR #1189 [FIX] purchase_discount: access error](https://github.com/OCA/purchase-workflow/pull/1189)
* [PR #1222 [FIX] purchase_discount: supplierinfo with no template](https://github.com/OCA/purchase-workflow/pull/1222)