### PR TITLE
[14.0][FIX] purchase_request_tier_validation, can't approve after validated

### DIFF
--- a/purchase_request_tier_validation/views/purchase_request_view.xml
+++ b/purchase_request_tier_validation/views/purchase_request_view.xml
@@ -2,6 +2,26 @@
 <!-- Copyright 2019-2020 ForgeFlow S.L.
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
+    <record id="view_purchase_request_form_inherit_tier" model="ir.ui.view">
+        <field name="name">purchase.request.tier.validation.form</field>
+        <field name="model">purchase.request</field>
+        <field name="inherit_id" ref="purchase_request.view_purchase_request_form" />
+        <field name="arch" type="xml">
+            <button name="button_approved" position="attributes">
+                <attribute name="states">draft</attribute>
+                <attribute name="string">Confirm</attribute>
+            </button>
+            <button name="button_to_approve" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </button>
+            <field name="state" position="attributes">
+                <attribute
+                    name="statusbar_visible"
+                >draft,approved,done,rejected</attribute>
+            </field>
+        </field>
+    </record>
+
     <record id="view_purchase_request_filter" model="ir.ui.view">
         <field
             name="name"


### PR DESCRIPTION
Based on the issue requested here, https://github.com/OCA/purchase-workflow/commit/77db8b614cdddad20b7d7b1a1469b721a20203cc#diff-0128e96626da93b08c70ac85a5dbd4c64d081285f0a50f921aa87b07e4d2a4aa

We found that, for purchase.request, we will need to rearrange the confirm button a bit to ensure it compatible with the _state_from, _state_to.