### PR TITLE
[14.0][FIX] purchase_delivery_split_date: fix date_planned can be False

### DIFF
--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -93,7 +93,7 @@ class PurchaseOrderLine(models.Model):
         res = super()._onchange_quantity()
         # preserve the date which was presumably set on the PO line if it is
         # later than the date computed from the Vendor information
-        if self.date_planned <= date_planned:
+        if date_planned and self.date_planned <= date_planned:
             self.date_planned = date_planned
         return res
 


### PR DESCRIPTION
Comparing date and bool throws exception

Fix issue introduced in https://github.com/OCA/purchase-workflow/pull/1314

ping @HoKhanhNguyen99  @leemannd  @HviorForgeFlow