### PR TITLE
[FIX] Missing Key for Delivery Split

### DIFF
--- a/purchase_delivery_split_date/__manifest__.py
+++ b/purchase_delivery_split_date/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Purchase Delivery Split Date",
-    "version": "14.0.1.1.1",
+    "version": "14.0.1.1.2",
     "summary": "Allows Purchase Order you confirm to generate one Incoming "
     "Shipment for each expected date indicated in the Purchase Order Lines",
     "author": "Numerigraphe, ForgeFlow, Camptocamp, Odoo Community Association (OCA)",

--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -126,7 +126,7 @@ class PurchaseOrder(models.Model):
                             continue
                         if (
                             move.picking_id.scheduled_date.date() != date_key
-                            or pickings_by_date[date_key] != move.picking_id
+                            or pickings_by_date.get(date_key) != move.picking_id
                         ):
                             if date_key not in pickings_by_date:
                                 copy_vals = line._first_picking_copy_vals(key, line)


### PR DESCRIPTION
Fix the problem then `purchase_delivery_split_date` module is installed after Odoo was in use for some time and there are already Transfers with moves for different dates than the Date Scheduled.
