### PR TITLE
[13.0][FIX] purchase_requisition_order_remaining_qty: Use all purchase orders (except canceled orders) to get the value of the proposed_qty field.

### DIFF
--- a/purchase_requisition_order_remaining_qty/models/purchase_requisition_line.py
+++ b/purchase_requisition_order_remaining_qty/models/purchase_requisition_line.py
@@ -22,7 +22,7 @@ class PurchaseRequisitionLine(models.Model):
         for item in self:
             item.proposed_qty = sum(
                 item.requisition_id.purchase_ids.filtered(
-                    lambda x: x.state in ("draft", "sent", "to approve")
+                    lambda x: x.state not in ("cancel")
                 )
                 .order_line.filtered(lambda x: x.product_id == item.product_id)
                 .mapped("product_qty")

--- a/purchase_requisition_order_remaining_qty/tests/test_purchase_requisition_order_remaining_qty.py
+++ b/purchase_requisition_order_remaining_qty/tests/test_purchase_requisition_order_remaining_qty.py
@@ -41,6 +41,7 @@ class TestPurchaseRequisitionOrderRemainingQty(common.SavepointCase):
         self.assertEqual(requisition_line.proposed_qty, 0)
         # New order with qty: 5. Example: product_qty: 5, proposed_qty: 0
         order = self.action_purchase_requisition_to_so(requisition.id)
+        order.button_confirm()
         order_line = order.order_line.filtered(lambda x: x.product_id == self.product)
         self.assertEqual(order_line.product_qty, 5)
         self.assertEqual(requisition_line.proposed_qty, 5)


### PR DESCRIPTION
Use all purchase orders (except canceled orders) to get the value of the `proposed_qty` field.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT33877