### PR TITLE
[FIX] purchase_discount: Fix undefined argument on purchase_discount: original function use move=False and inherited function just use move

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -104,8 +104,8 @@ class PurchaseOrderLine(models.Model):
             return
         self.discount = seller.discount
 
-    def _prepare_account_move_line(self, move):
-        vals = super(PurchaseOrderLine, self)._prepare_account_move_line(move)
+    def _prepare_account_move_line(self, move=False):
+        vals = super(PurchaseOrderLine, self)._prepare_account_move_line(move=move)
         vals["discount"] = self.discount
         return vals
 


### PR DESCRIPTION
The original code caused the following error https://gist.github.com/rolandojduartem/64f4c0775d1eb11ff9c6bcfda02b94be at the moment to create a bill from a purchase order. This code fix that error. The original function is https://github.com/odoo/odoo/blob/14.0/addons/purchase/models/purchase.py#L1143
![purchase-wokflow_fix](https://user-images.githubusercontent.com/90422721/154160422-504b1e69-44d6-4c74-8c40-372a0d5a1e24.png)
