### PR TITLE
[11.0][FIX] purchase_discount: Loss of decimals with discounts in subtotal

### DIFF
--- a/purchase_discount/README.rst
+++ b/purchase_discount/README.rst
@@ -40,6 +40,7 @@ Contributors
 * OpenERP S.A.
 * Ignacio Ibeas <ignacio@acysos.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Isaac Gallart <igallart@puntsistemes.es>
 
 Icon
 ----

--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -13,6 +13,8 @@ class PurchaseOrderLine(models.Model):
 
     @api.depends('discount')
     def _compute_amount(self):
+        original_digits = self._fields["price_unit"]._digits
+        self._fields["price_unit"]._digits = (16, 8)
         for line in self:
             price_unit = False
             # This is always executed for allowing other modules to use this
@@ -25,6 +27,7 @@ class PurchaseOrderLine(models.Model):
             super(PurchaseOrderLine, line)._compute_amount()
             if price_unit:
                 line.price_unit = price_unit
+            self._fields["price_unit"]._digits = original_digits
 
     discount = fields.Float(
         string='Discount (%)', digits=dp.get_precision('Discount'),


### PR DESCRIPTION
When you have purchase lines with discounts, it not calculate good
the subtotal line.

Example:

Price_unit configured with two decimals:

1 - 25000 * 0.27 and 5% discount -> 6412.50

But Odoo says:
6500

With this commit the subtotal is correct:
6412.5

https://github.com/OCA/purchase-workflow/issues/1369
