### PR TITLE
[IMP] purchase_request: update existing line if any

### DIFF
--- a/purchase_request/models/stock_rule.py
+++ b/purchase_request/models/stock_rule.py
@@ -112,6 +112,7 @@ class StockRule(models.Model):
                 .search([dom for dom in domain])
                 .filtered(
                     lambda x: procurement.product_id in x.line_ids.mapped("product_id")
+                    and x.purchase_count == 0
                 )
             )
             pr = pr[0] if pr else False
@@ -138,6 +139,11 @@ class StockRule(models.Model):
             [
                 ("product_id", "=", request_line_data["product_id"]),
                 ("date_required", "=", request_line_data["date_required"].date()),
+                (
+                    "purchase_state",
+                    "=",
+                    False,
+                ),  # avoid updating if there is RFQ or PO linked
             ],
         )
         if same_product_date_request_line:


### PR DESCRIPTION
Problem:
with current module state there are many request lines created for same product and same day.
Aim of this PR is to prevent creating new line if Purchase Request with line for same product and date was found - in that case we update only product_qty on existing line.