### PR TITLE
purchase_discount: prevent test failure if no CoA installed

### DIFF
--- a/purchase_discount/tests/test_purchase_discount.py
+++ b/purchase_discount/tests/test_purchase_discount.py
@@ -2,11 +2,11 @@
 # Copyright 2015-2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import odoo.tests.common as common
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo import fields
 
 
-class TestPurchaseOrder(common.SavepointCase):
+class TestPurchaseOrder(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super(TestPurchaseOrder, cls).setUpClass()


### PR DESCRIPTION
intention is to fix this error seen on odoo.sh

```
2022-03-18 12:40:13,718 4 ERROR version-14-app-purchase-discount-4487497 odoo.addons.purchase_discount.tests.test_purchase_discount: ERROR: TestPurchaseOrder.test_invoice
Traceback (most recent call last):
  File "/home/odoo/src/user/purchase_discount/tests/test_purchase_discount.py", line 157, in test_invoice
    invoice._onchange_purchase_auto_complete()
  File "/home/odoo/src/odoo/addons/purchase/models/account_invoice.py", line 47, in _onchange_purchase_auto_complete
    invoice_vals = self.purchase_id.with_company(self.purchase_id.company_id)._prepare_invoice()
  File "/home/odoo/src/odoo/addons/purchase_stock/models/purchase.py", line 140, in _prepare_invoice
    invoice_vals = super()._prepare_invoice()
  File "/home/odoo/src/odoo/addons/purchase/models/purchase.py", line 545, in _prepare_invoice
    journal = self.env['account.move'].with_context(default_move_type=move_type)._get_default_journal()
  File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 111, in _get_default_journal
    journal = self._search_default_journal(journal_types)
  File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 83, in _search_default_journal
    raise UserError(error_msg)
odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: purchase
```