### PR TITLE
[FIX] purchase_order_line_sequence: sort lines by sequence

### DIFF
--- a/purchase_order_line_sequence/models/purchase.py
+++ b/purchase_order_line_sequence/models/purchase.py
@@ -48,7 +48,7 @@ class PurchaseOrder(models.Model):
     def _reset_sequence(self):
         for rec in self:
             current_sequence = 1
-            for line in rec.order_line:
+            for line in rec.order_line.sorted("sequence"):
                 line.sequence = current_sequence
                 current_sequence += 1
 


### PR DESCRIPTION
In some cases, `order_line` is not sorted by default by `sequence` field. In `write` method, new lines are always at the end of the recordset, which causes incorrect behavior. 

Steps to reproduce:

1. Create PO with two or more lines. Click on *Save* button.
2. Edit order. Add one order line.
3. Move order line up. The order lines are displayed correctly.
4. Click on *Save* button. 

Current behavior:

Moved order line hops back to the end of the order lines.