### PR TITLE
[14.0][FIX] purchase_request _compute_open_product_qty

### DIFF
--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -82,7 +82,7 @@ class PurchaseRequestAllocation(models.Model):
     )
     def _compute_open_product_qty(self):
         for rec in self:
-            if rec.purchase_state in ["cancel", "done"]:
+            if rec.purchase_state == "cancel":
                 rec.open_product_qty = 0.0
             else:
                 rec.open_product_qty = (


### PR DESCRIPTION
The field `qty_done` on model `purchase.request.line` is not calculated well when flag `po_lock` on Company is set True. 
This is happen because of the method `_compute_open_product_qty` on model `purchase.request.allocation` which is not calculating the `open_product_qty` on model `purchase.request.allocation` if the Purchases order is Locked before the Delivery Order is completed.
'done' state does not indicate the delivery status.