### PR TITLE
[14.0][FIX] purchase_picking_state: Add post_install tag in tests to prevent test errors

### DIFF
--- a/purchase_picking_state/tests/test_purchase_picking_state.py
+++ b/purchase_picking_state/tests/test_purchase_picking_state.py
@@ -3,11 +3,13 @@
 
 from datetime import datetime
 
+from odoo.tests import tagged
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT as DTF
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@tagged("post_install", "-at_install")
 class TestPurchasePickingState(AccountTestInvoicingCommon):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Add `post_install` tag in tests to prevent test errors since https://github.com/odoo/odoo/commit/81aac30dd2278e43a43cf8fd6cef31e1e8c60f3f

Please @pedrobaeza can you review it?

@Tecnativa TT33774