### PR TITLE
[14.0][FIX] purchase_request: merging two lines had wrong quantities

### DIFF
--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -371,14 +371,8 @@ class PurchaseRequestLine(models.Model):
 
         rl_qty = 0.0
         # Recompute quantity by adding existing running procurements.
-        if new_pr_line:
-            rl_qty = po_line.product_uom_qty
-        else:
-            for prl in po_line.purchase_request_lines:
-                for alloc in prl.purchase_request_allocation_ids:
-                    rl_qty += alloc.product_uom_id._compute_quantity(
-                        alloc.requested_product_uom_qty, purchase_uom
-                    )
+        for rl in po_line.purchase_request_lines:
+            rl_qty += rl.product_uom_id._compute_quantity(rl.product_qty, purchase_uom)
         qty = max(rl_qty, supplierinfo_min_qty)
         return qty
 


### PR DESCRIPTION
For example, a Request has tow lines for the same product.
One with quantity 2 and another with quantity 3.
When these lines are merged into a single PO line,
final quantity was 4 instead of the expected 5.

The problem could be tracked down to the _calc_new_qty method.
Undoing a change in https://github.com/OCA/purchase-workflow/commit/8b527c4efaaf56ea33621abf81a2ddc1e0e9d27d
resolved this basic case.

Closes #1271
