### PR TITLE
[14.0][ENH] purchase_invoice_plan, freeze plan amount if already invoiced

### DIFF
--- a/purchase_invoice_plan/views/purchase_view.xml
+++ b/purchase_invoice_plan/views/purchase_view.xml
@@ -27,6 +27,7 @@
                     optional="show"
                     attrs="{'readonly': [('no_edit', '=', True)]}"
                 />
+                <field name="amount_invoiced" optional="hide" sum="Amount" />
                 <field name="to_invoice" />
                 <field name="invoiced" />
                 <field name="invoice_ids" optional="hide" widget="many2many_tags" />
@@ -191,6 +192,7 @@
                 <field name="invoice_type" />
                 <field name="percent" optional="show" sum="Percent" />
                 <field name="amount" optional="show" sum="Amount" />
+                <field name="amount_invoiced" optional="show" sum="Amount" />
                 <field name="to_invoice" />
                 <field name="invoiced" />
                 <field name="invoice_ids" widget="many2many_tags" />


### PR DESCRIPTION
There are case when, even after some installment has been invoiced, user still add/edit purchase line amount which effect invoice plan. For example, given

Purchase Order = 400, with 2 Installments with the 1st installment already invoiced.
1. 50% = 200 (invoiced = 200)
2. 50% = 200

Then, after that, user change purchase so that amount become 800.

Before this enhancement (WRONG), the invoice plan table will be readjust as following (fixed percent as 50/50)
1. 50% = 400 (invoiced = 200)
2. 50% = 400

To be CORRECT, this PR ensure that the invoice plan table can become
1. 25% = 200 (invoiced = 200)
2. 75% = 600

Note: user can change installment 2 or even add installment 3

![po_invoice_plan](https://user-images.githubusercontent.com/1973598/168028243-9d84238e-44c8-446a-863a-f33a8ae0ff1c.gif)



