### PR TITLE
[14.0][FIX] po_secondary_unit: Drop 0 qty test assert on POL with secondary UoM

### DIFF
--- a/purchase_order_secondary_unit/tests/test_purchase_order_secondary_unit.py
+++ b/purchase_order_secondary_unit/tests/test_purchase_order_secondary_unit.py
@@ -54,7 +54,6 @@ class TestPurchaseOrderSecondaryUnit(SavepointCase):
         with purchase_order.order_line.edit(0) as line:
             # Test _compute product_qty
             line.secondary_uom_id = self.secondary_unit
-            self.assertEqual(line.product_qty, 0.0)
             line.secondary_uom_qty = 10.0
             self.assertEqual(line.product_qty, 7.0)
             # Test onchange product uom


### PR DESCRIPTION
Due to a change on https://github.com/OCA/purchase-workflow/commit/ef214d19706f15509f77abf047d1e1ea1487700b removed assert was failing from tests.

CC @pedrobaeza @sergio-teruel 