### PR TITLE
[13.0][FIX] purchase_blanket_order: Use purchasing UoM.

### DIFF
--- a/purchase_blanket_order/models/blanket_orders.py
+++ b/purchase_blanket_order/models/blanket_orders.py
@@ -544,7 +544,7 @@ class BlanketOrderLine(models.Model):
         if self.product_id:
             name = self.product_id.name
             if not self.product_uom:
-                self.product_uom = self.product_id.uom_id.id
+                self.product_uom = self.product_id.uom_po_id or self.product_id.uom_id
             if self.order_id.partner_id and float_is_zero(
                 self.price_unit, precision_digits=precision
             ):


### PR DESCRIPTION
The default behavior in a PO is that the purchsing UoM is used
as the PO line UoM when set in the product. Blanket Orders should
do the same, otherwise it is a bit confusing.

@ForgeFlow