### PR TITLE
[14.0][FIX] purchase_request: UoM not required on PO creation

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -352,7 +352,9 @@ class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):
         string="UoM",
         related="product_id.uom_po_id",
         readonly=False,
+        domain="[('category_id', '=', product_uom_category_id)]",
     )
+    product_uom_category_id = fields.Many2one(related="product_id.uom_id.category_id")
     keep_description = fields.Boolean(
         string="Copy descriptions to new PO",
         help="Set true if you want to keep the "

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -348,7 +348,10 @@ class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):
         string="Quantity to purchase", digits="Product Unit of Measure"
     )
     product_uom_id = fields.Many2one(
-        comodel_name="uom.uom", string="UoM", required=True
+        comodel_name="uom.uom",
+        string="UoM",
+        related="product_id.uom_po_id",
+        readonly=False,
     )
     keep_description = fields.Boolean(
         string="Copy descriptions to new PO",

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -37,6 +37,7 @@
                             <field name="name" />
                             <field name="product_qty" />
                             <field name="product_uom_id" groups="uom.group_uom" />
+                            <field name="product_uom_category_id" invisible="1" />
                             <field name="keep_description" widget="boolean_toggle" />
                         </tree>
                     </field>


### PR DESCRIPTION
Solves https://github.com/OCA/purchase-workflow/issues/1421

- [ ] Allow to create PO without UoM or selecting the PO ones by default.

- [ ] Restrict UoM selection to product UoM belonging category.

CC @ForgeFlow  @hitrosol 