### PR TITLE
[IMP] purch_part_incoterm: add incoterm_address_id

### DIFF
--- a/purchase_partner_incoterm/__manifest__.py
+++ b/purchase_partner_incoterm/__manifest__.py
@@ -7,11 +7,15 @@
     "category": "Purchase",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
+    "maintainers": ["TDu", "bealdav"],
     "depends": [
         "account",
-        "purchase",
+        "purchase_stock",
     ],
     "website": "https://github.com/OCA/purchase-workflow",
-    "data": ["views/partner_view.xml"],
+    "data": [
+        "views/partner_view.xml",
+        "views/purchase_view.xml",
+    ],
     "installable": True,
 }

--- a/purchase_partner_incoterm/models/purchase_order.py
+++ b/purchase_partner_incoterm/models/purchase_order.py
@@ -1,13 +1,20 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
+    incoterm_address_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Incoterm Address",
+        help="Address where goods responsibility is transferred to the buyer",
+    )
+
     @api.onchange("partner_id")
     def onchange_partner_id(self):
         res = super().onchange_partner_id()
         self.incoterm_id = self.partner_id.purchase_incoterm_id
+        self.incoterm_address_id = self.partner_id.purchase_incoterm_address_id
         return res

--- a/purchase_partner_incoterm/models/res_partner.py
+++ b/purchase_partner_incoterm/models/res_partner.py
@@ -11,3 +11,8 @@ class ResPartner(models.Model):
         ondelete="restrict",
         string="Default Purchase Incoterm",
     )
+    purchase_incoterm_address_id = fields.Many2one(
+        comodel_name="res.partner",
+        ondelete="restrict",
+        string="Default Purchase Incoterm Address",
+    )

--- a/purchase_partner_incoterm/readme/CONTRIBUTORS.rst
+++ b/purchase_partner_incoterm/readme/CONTRIBUTORS.rst
@@ -2,3 +2,5 @@
     * Thierry Ducrest <thierry.ducrest@camptocamp.com>
 * `Trobz <https://trobz.com>`_:
     * Son Ho <sonhd@trobz.com>
+* `Akretion <https://akretion.com>`_:
+    * David BEAL <david.beal@akretion.com>

--- a/purchase_partner_incoterm/readme/DESCRIPTION.rst
+++ b/purchase_partner_incoterm/readme/DESCRIPTION.rst
@@ -1,1 +1,4 @@
-This module adds incoterms for suppliers and purchase order
+This module adds incoterms for suppliers and purchase order:
+
+* incoterm modes
+* incoterm address

--- a/purchase_partner_incoterm/views/partner_view.xml
+++ b/purchase_partner_incoterm/views/partner_view.xml
@@ -8,6 +8,7 @@
     <field name="arch" type="xml">
       <group name="purchase" position="inside">
         <field name="purchase_incoterm_id" />
+        <field name="purchase_incoterm_address_id" />
       </group>
     </field>
   </record>

--- a/purchase_partner_incoterm/views/purchase_view.xml
+++ b/purchase_partner_incoterm/views/purchase_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+  <record id="purchase_order_view_form_inherit" model="ir.ui.view">
+    <field name="model">purchase.order</field>
+    <field name="inherit_id" ref="purchase_stock.purchase_order_view_form_inherit" />
+    <field name="arch" type="xml">
+      <field name="incoterm_id" position="after">
+        <field name="incoterm_address_id" />
+      </field>
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
Add fields incoterm_address _id on partner and purchase.order

Needs to depends on purchase_stock because field is not in defined in purchase view

Please @TDu @sonhd91 could you make review ?

Thanks


cc @rvalyi @hparfr 