### PR TITLE
[13.0][IMP] purchase_discount: flag discount hack

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -61,7 +61,7 @@ class PurchaseOrderLine(models.Model):
         value before calling super and restoring it later for assuring
         maximum inheritability.
 
-        HACK: This is needed while https://github.com/odoo/odoo/pull/29983
+        HACK: This is needed while https://github.com/odoo/odoo/pull/92933
         is not merged.
         """
         price_unit = False
@@ -69,10 +69,10 @@ class PurchaseOrderLine(models.Model):
         if price != self.price_unit:
             # Only change value if it's different
             price_unit = self.price_unit
-            self.price_unit = price
+            self.with_context(purchase_discount=True).price_unit = price
         price = super()._get_stock_move_price_unit()
         if price_unit:
-            self.price_unit = price_unit
+            self.with_context(purchase_discount=True).price_unit = price_unit
         return price
 
     @api.onchange("product_qty", "product_uom")

--- a/purchase_stock_price_unit_sync/models/purchase_order.py
+++ b/purchase_stock_price_unit_sync/models/purchase_order.py
@@ -9,8 +9,11 @@ class PurchaseOrderLine(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if ("price_unit" in vals or "discount" in vals) and (
-            not self.env.context.get("skip_stock_price_unit_sync")
+        if (
+            ("price_unit" in vals or "discount" in vals)
+            and not self.env.context.get("skip_stock_price_unit_sync")
+            # This context is present when the purchase_discount hack is being made
+            and not self.env.context.get("purchase_discount")
         ):
             self.stock_price_unit_sync()
         return res


### PR DESCRIPTION
As Odoo isn't using its hook method yet, we still need to be using the price unit hack that makes two writes in order to be able to correctly compute the discount. This writes can confound other modules and even provoke an infinite loop in some situations. We should at least flag it to allow to ignore these writes.

We can see an example in this PR with `purchase_stock_price_unit_sync`

At the same time, we proposed again to Odoo to used its hook method which would avoid us this dirty hack:

- https://github.com/odoo/odoo/pull/92933

cc @Tecnativa TT36816

ping @pedrobaeza @sergio-teruel 