### PR TITLE
[12.0][ADD] purchase_start_end_dates

### DIFF
--- a/purchase_start_end_dates/__init__.py
+++ b/purchase_start_end_dates/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_start_end_dates/__manifest__.py
+++ b/purchase_start_end_dates/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2022 elego Software Solutions, Germany (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Purchase Start End Dates",
+    "version": "12.0.1.0.0",
+    "category": "Purchase",
+    "license": "AGPL-3",
+    "summary": "Adds start date and end date on purchase order lines",
+    "author": "elego Software Solutions GmbH, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/purchase-workflow",
+    "depends": [
+        "purchase",
+        "account_invoice_start_end_dates"
+        ],
+    "data": [
+        "views/purchase_order.xml",
+    ],
+    "installable": True,
+}

--- a/purchase_start_end_dates/i18n/de.po
+++ b/purchase_start_end_dates/i18n/de.po
@@ -1,0 +1,105 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_start_end_dates
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-06-24 08:24+0000\n"
+"PO-Revision-Date: 2022-06-24 08:24+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order__default_end_date
+msgid "Default End Date"
+msgstr "Vorgabe-Enddatum"
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order__default_start_date
+msgid "Default Start Date"
+msgstr "Vorgabe-Anfangsdatum"
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:23
+#, python-format
+msgid "Default Start Date should be before or be the same as Default End Date for purchase order '%s'."
+msgstr "Vorgabe-Anfangsdatum muss im Auftrag %s vor ooder am Enddatum liegen"
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order_line__end_date
+msgid "End Date"
+msgstr "Enddatum"
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,help:purchase_start_end_dates.field_purchase_order_line__must_have_dates
+msgid "If this option is active, the user will have to enter a Start Date and an End Date on the invoice lines that have this product."
+msgstr "Wenn der Haken gesetzt ist, muss der Benutzer für dieses Produkt in Rechnungszeilen ein Start- und Enddatum angeben."
+
+#. module: purchase_start_end_dates
+#: model:ir.model,name:purchase_start_end_dates.model_account_invoice
+msgid "Invoice"
+msgstr "Rechnung"
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:125
+#, python-format
+msgid "Missing End Date for purchase order line with Product '%s'."
+msgstr "Fehlendes Enddatum in Auftragsposition des Produkts '%s'."
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:117
+#, python-format
+msgid "Missing Start Date for purchase order line with Product '%s'."
+msgstr "Fehlendes Anfangsdatum in Auftragsposition des Produkts '%s'."
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order_line__must_have_dates
+msgid "Must Have Start and End Dates"
+msgstr "Muss Start- und Enddatum haben"
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order_line__number_of_days
+msgid "Number of Days"
+msgstr "Anzahl der Tage"
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:95
+#, python-format
+msgid "On purchase order line with product '%s', the number of days is negative (%d) ; this is not allowed. The number of days has been forced to 1."
+msgstr "In Auftragsposition des Produkts '%s' ist die Anzahl Tage negativ; dies ist "
+"nicht zulässig."
+
+#. module: purchase_start_end_dates
+#: model:ir.model,name:purchase_start_end_dates.model_purchase_order
+msgid "Purchase Order"
+msgstr "Beschaffungsauftrag"
+
+#. module: purchase_start_end_dates
+#: model:ir.model,name:purchase_start_end_dates.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Bestellposition"
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order_line__start_date
+msgid "Start Date"
+msgstr "Startdatum"
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:133
+#, python-format
+msgid "Start Date should be before or be the same as End Date for purchase order line with Product '%s'."
+msgstr "In der Auftragsposition zum Produkt %s muss das Anfangsdatum vor oder am "
+"Enddatum liegen."
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:94
+#, python-format
+msgid "Wrong number of days"
+msgstr "Anzahl Tage"
+

--- a/purchase_start_end_dates/i18n/purchase_start_end_dates.pot
+++ b/purchase_start_end_dates/i18n/purchase_start_end_dates.pot
@@ -1,0 +1,103 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_start_end_dates
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-06-24 08:24+0000\n"
+"PO-Revision-Date: 2022-06-24 08:24+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order__default_end_date
+msgid "Default End Date"
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order__default_start_date
+msgid "Default Start Date"
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:23
+#, python-format
+msgid "Default Start Date should be before or be the same as Default End Date for purchase order '%s'."
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order_line__end_date
+msgid "End Date"
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,help:purchase_start_end_dates.field_purchase_order_line__must_have_dates
+msgid "If this option is active, the user will have to enter a Start Date and an End Date on the invoice lines that have this product."
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: model:ir.model,name:purchase_start_end_dates.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:125
+#, python-format
+msgid "Missing End Date for purchase order line with Product '%s'."
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:117
+#, python-format
+msgid "Missing Start Date for purchase order line with Product '%s'."
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order_line__must_have_dates
+msgid "Must Have Start and End Dates"
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order_line__number_of_days
+msgid "Number of Days"
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:95
+#, python-format
+msgid "On purchase order line with product '%s', the number of days is negative (%d) ; this is not allowed. The number of days has been forced to 1."
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: model:ir.model,name:purchase_start_end_dates.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: model:ir.model,name:purchase_start_end_dates.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: model:ir.model.fields,field_description:purchase_start_end_dates.field_purchase_order_line__start_date
+msgid "Start Date"
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:133
+#, python-format
+msgid "Start Date should be before or be the same as End Date for purchase order line with Product '%s'."
+msgstr ""
+
+#. module: purchase_start_end_dates
+#: code:addons/purchase_start_end_dates/models/purchase_order.py:94
+#, python-format
+msgid "Wrong number of days"
+msgstr ""
+

--- a/purchase_start_end_dates/models/__init__.py
+++ b/purchase_start_end_dates/models/__init__.py
@@ -1,0 +1,2 @@
+from . import purchase_order
+from . import account_invoice

--- a/purchase_start_end_dates/models/account_invoice.py
+++ b/purchase_start_end_dates/models/account_invoice.py
@@ -1,0 +1,19 @@
+# Copyright 2022 elego Software Solutions, Germany (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    def _prepare_invoice_line_from_po_line(self, line):
+        data = super(AccountInvoice, self)._prepare_invoice_line_from_po_line(line)
+        if line.product_id.must_have_dates:
+            data.update(
+                {
+                    "start_date": line.start_date,
+                    "end_date": line.end_date,
+                }
+            )
+        return data

--- a/purchase_start_end_dates/models/purchase_order.py
+++ b/purchase_start_end_dates/models/purchase_order.py
@@ -1,0 +1,151 @@
+# Copyright 2022 elego Software Solutions, Germany (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from dateutil.relativedelta import relativedelta
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    default_start_date = fields.Date(string="Default Start Date")
+    default_end_date = fields.Date(string="Default End Date")
+
+    @api.constrains("default_start_date", "default_end_date")
+    def _check_default_start_end_dates(self):
+        if (
+            self.default_start_date
+            and self.default_end_date
+            and self.default_start_date > self.default_end_date
+        ):
+            raise ValidationError(
+                _(
+                    "Default Start Date should be before or be the "
+                    "same as Default End Date for purchase order '%s'."
+                )
+                % self.display_name
+            )
+
+    @api.onchange("default_start_date")
+    def default_start_date_change(self):
+        if (
+            self.default_start_date
+            and self.default_end_date
+            and self.default_start_date > self.default_end_date
+        ):
+            self.default_end_date = self.default_start_date
+
+    @api.onchange("default_end_date")
+    def default_end_date_change(self):
+        if (
+            self.default_start_date
+            and self.default_end_date
+            and self.default_start_date > self.default_end_date
+        ):
+            self.default_start_date = self.default_end_date
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    start_date = fields.Date(
+        string="Start Date", readonly=True, states={"draft": [("readonly", False)]}
+    )
+    end_date = fields.Date(
+        string="End Date", readonly=True, states={"draft": [("readonly", False)]}
+    )
+    number_of_days = fields.Integer(
+        compute="_compute_number_of_days",
+        inverse="_inverse_number_of_days",
+        string="Number of Days",
+        readonly=False,
+        store=True,
+    )
+    must_have_dates = fields.Boolean(related="product_id.must_have_dates")
+
+    @api.depends("start_date", "end_date")
+    def _compute_number_of_days(self):
+        for line in self:
+            days = False
+            if line.start_date and line.end_date:
+                days = (line.end_date - line.start_date).days + 1
+            line.number_of_days = days
+
+    @api.onchange("number_of_days")
+    def _inverse_number_of_days(self):
+        res = {"warning": {}}
+        for line in self:
+            if line.number_of_days < 0:
+                res["warning"]["title"] = _("Wrong number of days")
+                res["warning"]["message"] = _(
+                    "On purchase order line with product '%s', the "
+                    "number of days is negative (%d) ; this is not "
+                    "allowed. The number of days has been forced to 1."
+                ) % (line.product_id.display_name, line.number_of_days)
+                line.number_of_days = 1
+            if line.start_date:
+                line.end_date = line.start_date + relativedelta(
+                    days=line.number_of_days - 1
+                )
+            elif line.end_date:
+                line.start_date = line.end_date - relativedelta(
+                    days=line.number_of_days - 1
+                )
+        return res
+
+    @api.constrains("start_date", "end_date")
+    def _check_start_end_dates(self):
+        for line in self:
+            if line.must_have_dates:
+                if not line.start_date:
+                    raise ValidationError(
+                        _(
+                            "Missing Start Date for purchase order line with "
+                            "Product '%s'."
+                        )
+                        % (line.product_id.name)
+                    )
+                if not line.end_date:
+                    raise ValidationError(
+                        _(
+                            "Missing End Date for purchase order line with "
+                            "Product '%s'."
+                        )
+                        % (line.product_id.name)
+                    )
+                if line.start_date > line.end_date:
+                    raise ValidationError(
+                        _(
+                            "Start Date should be before or be the same as "
+                            "End Date for purchase order line with Product '%s'."
+                        )
+                        % (line.product_id.name)
+                    )
+
+    @api.onchange("end_date")
+    def end_date_change(self):
+        if self.end_date:
+            if self.start_date and self.start_date > self.end_date:
+                self.start_date = self.end_date
+
+    @api.onchange("start_date")
+    def start_date_change(self):
+        if self.start_date:
+            if self.end_date and self.start_date > self.end_date:
+                self.end_date = self.start_date
+
+    @api.onchange("product_id")
+    def start_end_dates_product_id_change(self):
+        if self.product_id.must_have_dates:
+            if self.order_id.default_start_date:
+                self.start_date = self.order_id.default_start_date
+            else:
+                self.start_date = False
+            if self.order_id.default_end_date:
+                self.end_date = self.order_id.default_end_date
+            else:
+                self.end_date = False
+        else:
+            self.start_date = False
+            self.end_date = False

--- a/purchase_start_end_dates/tests/__init__.py
+++ b/purchase_start_end_dates/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2022 elego Software Solutions, Germany (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_purchase_start_end_dates

--- a/purchase_start_end_dates/tests/test_purchase_start_end_dates.py
+++ b/purchase_start_end_dates/tests/test_purchase_start_end_dates.py
@@ -1,0 +1,138 @@
+# Copyright 2022 elego Software Solutions, Germany (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import datetime
+
+from odoo import fields
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestPurchaseStartEndDates(TransactionCase):
+    def setUp(self):
+        super(TestPurchaseStartEndDates, self).setUp()
+        self.AccountInvoice = self.env["account.invoice"]
+        self.partner = self.env.ref("base.res_partner_1")
+        self.product_id = self.env.ref("product.product_product_6")
+        self.product_id.must_have_dates = True
+        self.default_start_date = datetime.datetime.now()
+        self.default_end_date = self.default_start_date + datetime.timedelta(days=9)
+        self.po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "default_start_date": self.default_start_date,
+                "default_end_date": self.default_end_date,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product_id.name,
+                            "product_id": self.product_id.id,
+                            "product_qty": 2,
+                            "product_uom": self.product_id.uom_id.id,
+                            "price_unit": self.product_id.list_price,
+                            "date_planned": fields.Datetime.now(),
+                        },
+                    )
+                ],
+            }
+        )
+        self.po.button_confirm()
+        for po_lines in self.po.order_line:
+            po_lines.write(
+                {
+                    "start_date": self.default_start_date,
+                    "end_date": self.default_end_date,
+                }
+            )
+
+    def test_default_start_date_change(self):
+        with self.assertRaises(ValidationError):
+            self.po.write(
+                {
+                    "default_start_date": self.default_end_date,
+                    "default_end_date": self.default_start_date,
+                }
+            )
+        self.po.default_start_date_change()
+
+    def test_default_end_date_change(self):
+        with self.assertRaises(ValidationError):
+            self.po.write(
+                {
+                    "default_start_date": self.default_end_date,
+                    "default_end_date": self.default_start_date,
+                }
+            )
+        self.po.default_end_date_change()
+
+    def test_start_end_dates_product_id_change(self):
+        if self.po.default_end_date and self.po.default_end_date:
+            self.po.order_line.start_end_dates_product_id_change()
+            self.po.order_line.start_date_change()
+            self.po.order_line.end_date_change()
+
+    def test_start_end_dates_product_id(self):
+        self.product_id.must_have_dates = False
+        self.po.default_start_date = self.po.default_end_date = False
+        self.po.order_line.start_end_dates_product_id_change()
+
+    def test_end_date_change(self):
+        self.product_id.must_have_dates = False
+        self.po.order_line.write(
+            {"start_date": self.default_end_date, "end_date": self.default_start_date}
+        )
+        self.po.order_line.end_date_change()
+
+    def test_start_date_change(self):
+        self.product_id.must_have_dates = False
+        self.po.order_line.write(
+            {"start_date": self.default_end_date, "end_date": self.default_start_date}
+        )
+        self.po.order_line.start_date_change()
+
+    def test_constrains_end_dates(self):
+        with self.assertRaises(ValidationError):
+            self.po.order_line.end_date = False
+
+    def test_constrains_start_date(self):
+        with self.assertRaises(ValidationError):
+            self.po.order_line.start_date = False
+
+    def test_constrains_greater_st_date(self):
+        with self.assertRaises(ValidationError):
+            self.po.order_line.write(
+                {
+                    "start_date": self.default_end_date,
+                    "end_date": self.default_start_date,
+                }
+            )
+
+    def test_compute_number_of_days(self):
+        self.assertEqual(self.po.order_line[0].number_of_days, 10)
+
+    def test_inverse_number_of_days(self):
+        self.po.order_line[0].number_of_days = 1
+        self.assertEqual(
+            self.po.order_line[0].start_date, self.po.order_line[0].end_date
+        )
+
+    def test_vendor_bill_start_end_date(self):
+        self.invoice = self.AccountInvoice.create(
+            {
+                "partner_id": self.partner.id,
+                "purchase_id": self.po.id,
+                "account_id": self.partner.property_account_payable_id.id,
+                "type": "in_invoice",
+            }
+        )
+        self.invoice.purchase_order_change()
+        self.assertEqual(
+            self.invoice.invoice_line_ids.mapped("start_date")[0],
+            self.default_start_date.date(),
+        )
+        self.assertEqual(
+            self.invoice.invoice_line_ids.mapped("end_date")[0],
+            self.default_end_date.date(),
+        )

--- a/purchase_start_end_dates/views/purchase_order.xml
+++ b/purchase_start_end_dates/views/purchase_order.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2022 elego Software Solutions, Germany (https://www.elegosoft.com)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<odoo>
+
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field name="name">purchase.order.form.start.end.dates.</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/form//field[@name='product_id']" position="after">
+                <field name="start_date" attrs="{'invisible': [('must_have_dates', '=', False)], 'required': [('must_have_dates', '=', True)]}" />
+                <field name="end_date" attrs="{'invisible': [('must_have_dates', '=', False)], 'required': [('must_have_dates', '=', True)]}" />
+                <field name="number_of_days" attrs="{'invisible': [('must_have_dates', '=', False)], 'required': [('must_have_dates', '=', True)]}" />
+                <field name="must_have_dates" invisible="1" />
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree/field[@name='name']" position="after">
+                <field name="start_date" />
+                <field name="end_date" />
+                <field name="number_of_days" invisible="1" />
+                <field name="must_have_dates" invisible="1" />
+            </xpath>
+            <field name="date_order" position="after">
+                <field name="default_start_date" />
+                <field name="default_end_date" />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Added new module `purchase_start_end_dates`
Refrence from [OCA/sale-workflow/sale_start_end_dates](https://github.com/OCA/sale-workflow/tree/12.0/sale_start_end_dates)