### PR TITLE
[14.0][IMP] purchase_blanket_order: Add partner_ref field + order blanket orders from date_start desc field.

### DIFF
--- a/purchase_blanket_order/models/blanket_orders.py
+++ b/purchase_blanket_order/models/blanket_orders.py
@@ -11,6 +11,7 @@ class BlanketOrder(models.Model):
     _name = "purchase.blanket.order"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Blanket Order"
+    _order = "date_start desc, id desc"
 
     @api.model
     def _default_currency(self):
@@ -43,6 +44,7 @@ class BlanketOrder(models.Model):
         tracking=True,
         states={"draft": [("readonly", False)]},
     )
+    partner_ref = fields.Char(string="Vendor Reference", copy=False)
     line_ids = fields.One2many(
         "purchase.blanket.order.line",
         "order_id",

--- a/purchase_blanket_order/models/blanket_orders.py
+++ b/purchase_blanket_order/models/blanket_orders.py
@@ -396,7 +396,7 @@ class BlanketOrderLine(models.Model):
                 }
             )
 
-    name = fields.Char("Description", track_visibility="onchange")
+    name = fields.Char("Description", tracking=True)
     sequence = fields.Integer()
     order_id = fields.Many2one(
         "purchase.blanket.order", required=True, ondelete="cascade"

--- a/purchase_blanket_order/report/report.xml
+++ b/purchase_blanket_order/report/report.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <report
-        id="report_blanket_order"
-        string="Purchase Blanket Order"
-        model="purchase.blanket.order"
-        report_type="qweb-pdf"
-        file="purchase_blanket_order.report_blanketorder"
-        name="purchase_blanket_order.report_blanketorder"
-    />
+    <record id="report_blanket_order" model="ir.actions.report">
+        <field name="name">Purchase Blanket Order</field>
+        <field name="model">purchase.blanket.order</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">purchase_blanket_order.report_blanketorder</field>
+        <field name="report_file">purchase_blanket_order.report_blanketorder</field>
+    </record>
 </odoo>

--- a/purchase_blanket_order/views/purchase_blanket_order_views.xml
+++ b/purchase_blanket_order/views/purchase_blanket_order_views.xml
@@ -10,6 +10,8 @@
                 decoration-info="state in ('draft','to_approve')"
                 decoration-muted="state in ('expired')"
             >
+                <field name="date_start" />
+                <field name="partner_ref" optional="hide" />
                 <field name="name" />
                 <field name="user_id" />
                 <field name="partner_id" />
@@ -95,6 +97,7 @@
                                 context="{'res_partner_search_mode': 'supplier', 'show_address': 1}"
                                 options='{"always_reload": True}'
                             />
+                            <field name="partner_ref" />
                             <field name="payment_term_id" />
                         </group>
                         <group name="group_top_right">

--- a/purchase_blanket_order/wizard/create_purchase_orders.py
+++ b/purchase_blanket_order/wizard/create_purchase_orders.py
@@ -14,8 +14,12 @@ class BlanketOrderWizard(models.TransientModel):
     @api.model
     def _default_order(self):
         # in case the cron hasn't run
+        active_model = self.env.context.get("active_model", False)
         self.env["purchase.blanket.order"].expire_orders()
-        if not self.env.context.get("active_id"):
+        if (
+            not self.env.context.get("active_id")
+            or active_model != "purchase.blanket.order"
+        ):
             return False
         blanket_order = self.env["purchase.blanket.order"].search(
             [("id", "=", self.env.context["active_id"])], limit=1
@@ -84,9 +88,11 @@ class BlanketOrderWizard(models.TransientModel):
         ]
         return lines
 
-    blanket_order_id = fields.Many2one("purchase.blanket.order", readonly=True)
+    blanket_order_id = fields.Many2one(
+        "purchase.blanket.order", readonly=True, default=_default_order
+    )
     purchase_order_id = fields.Many2one(
-        "purchase.order", string="Purchase Order", domain=[("state", "=", "draft")]
+        "purchase.order", string="Purchase Order", domain=[("state", "=", "draft")],
     )
     line_ids = fields.One2many(
         "purchase.blanket.order.wizard.line",
@@ -151,7 +157,12 @@ class BlanketOrderWizard(models.TransientModel):
                 "partner_id": int(supplier),
             }
             if self.blanket_order_id:
-                order_vals.update({"origin": self.blanket_order_id.name})
+                order_vals.update(
+                    {
+                        "partner_ref": self.blanket_order_id.partner_ref,
+                        "origin": self.blanket_order_id.name,
+                    }
+                )
             order_vals.update(
                 {
                     "currency_id": currency_id if currency_id else False,

--- a/purchase_blanket_order/wizard/create_purchase_orders.py
+++ b/purchase_blanket_order/wizard/create_purchase_orders.py
@@ -92,7 +92,9 @@ class BlanketOrderWizard(models.TransientModel):
         "purchase.blanket.order", readonly=True, default=_default_order
     )
     purchase_order_id = fields.Many2one(
-        "purchase.order", string="Purchase Order", domain=[("state", "=", "draft")],
+        "purchase.order",
+        string="Purchase Order",
+        domain=[("state", "=", "draft")],
     )
     line_ids = fields.One2many(
         "purchase.blanket.order.wizard.line",


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/purchase-workflow/pull/1506

Changes done:
- [x] Add partner_ref field
- [x] Apply _order according to `date_start` desc field
- [x] Forgotten changes in migration to 14.0

Please @pedrobaeza and @ernestotejeda can you review it?

@Tecnativa TT37792