### PR TITLE
[15.0][IMP] purchase_blanket_order: Add partner_ref field + order blanket orders from date_start desc field.

### DIFF
--- a/purchase_blanket_order/models/blanket_orders.py
+++ b/purchase_blanket_order/models/blanket_orders.py
@@ -11,6 +11,7 @@ class BlanketOrder(models.Model):
     _name = "purchase.blanket.order"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Blanket Order"
+    _order = "date_start desc, id desc"
 
     @api.model
     def _default_currency(self):
@@ -43,6 +44,7 @@ class BlanketOrder(models.Model):
         tracking=True,
         states={"draft": [("readonly", False)]},
     )
+    partner_ref = fields.Char(string="Vendor Reference", copy=False)
     line_ids = fields.One2many(
         "purchase.blanket.order.line",
         "order_id",

--- a/purchase_blanket_order/views/purchase_blanket_order_views.xml
+++ b/purchase_blanket_order/views/purchase_blanket_order_views.xml
@@ -10,6 +10,8 @@
                 decoration-info="state in ('draft','to_approve')"
                 decoration-muted="state in ('expired')"
             >
+                <field name="date_start" />
+                <field name="partner_ref" optional="hide" />
                 <field name="name" />
                 <field name="user_id" />
                 <field name="partner_id" />
@@ -95,6 +97,7 @@
                                 context="{'res_partner_search_mode': 'supplier', 'show_address': 1}"
                                 options='{"always_reload": True}'
                             />
+                            <field name="partner_ref" />
                             <field name="payment_term_id" />
                         </group>
                         <group name="group_top_right">


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/purchase-workflow/pull/1508

Changes done:
- [x] Add partner_ref field
- [x] Apply _order according to `date_start` desc field

Please @pedrobaeza and @ernestotejeda can you review it?

@Tecnativa TT37792