### PR TITLE
[15.0][FIX] purchase_blanket_order: Set name by sequence only if is necessary.

### DIFF
--- a/purchase_blanket_order/models/blanket_orders.py
+++ b/purchase_blanket_order/models/blanket_orders.py
@@ -275,11 +275,15 @@ class BlanketOrder(models.Model):
     def action_confirm(self):
         self._validate()
         for order in self:
-            sequence_obj = self.env["ir.sequence"]
-            if order.company_id:
-                sequence_obj = sequence_obj.with_company(order.company_id)
-            name = sequence_obj.next_by_code("purchase.blanket.order")
-            order.write({"confirmed": True, "name": name})
+            vals = {"confirmed": True}
+            # Set name by sequence only if is necessary
+            if order.name == _("Draft"):
+                sequence_obj = self.env["ir.sequence"]
+                if order.company_id:
+                    sequence_obj = sequence_obj.with_company(order.company_id)
+                name = sequence_obj.next_by_code("purchase.blanket.order") or _("Draft")
+                vals.update({"name": name})
+            order.write(vals)
         return True
 
     def action_cancel(self):

--- a/purchase_blanket_order/tests/test_purchase_blanket_order.py
+++ b/purchase_blanket_order/tests/test_purchase_blanket_order.py
@@ -89,13 +89,17 @@ class TestPurchaseBlanketOrders(common.TransactionCase):
             blanket_order.sudo().action_confirm()
 
         blanket_order.validity_date = fields.Date.to_string(self.tomorrow)
+        initial_name = blanket_order.name
         blanket_order.sudo().action_confirm()
+        self.assertNotEqual(initial_name, blanket_order.name)
 
         blanket_order.sudo().action_cancel()
         self.assertEqual(blanket_order.state, "expired")
         blanket_order.sudo().set_to_draft()
         self.assertEqual(blanket_order.state, "draft")
+        previous_name = blanket_order.name
         blanket_order.sudo().action_confirm()
+        self.assertEqual(previous_name, blanket_order.name)
 
         self.assertEqual(blanket_order.state, "open")
         blanket_order.action_view_purchase_blanket_order_line()


### PR DESCRIPTION
FWP from 14.0. https://github.com/OCA/purchase-workflow/pull/1510

Set name by sequence only if is necessary.

Steps to reproduce it before:

- Create a blanket order and confirm > PBO/0001
- Convert to draft
- Confirm > PBO/0002

Please @pedrobaeza and @ernestotejeda can you review it?

@Tecnativa TT37792