### PR TITLE
[14.0][FIX]purchase_quick, defensive when pma_parent is not defined

### DIFF
--- a/purchase_quick/models/product_product.py
+++ b/purchase_quick/models/product_product.py
@@ -23,6 +23,9 @@ class ProductProduct(models.Model):
     def _compute_seller_price(self):
         po = self.pma_parent
         for record in self:
+            if po is None:
+                record.seller_price = 0.0
+                continue
             seller = record._select_seller(
                 partner_id=po.partner_id,
                 quantity=record.qty_to_process or 1,


### PR DESCRIPTION
When saving a product where seller_price is displayed, the method  is computed even if not comming from purchase.
As the context is not defined, then pma_parent is not defined.
Then it throws an exception `None Type has no attribute  'partner_id' `
This fix is a defensive