### PR TITLE
[13.0][FIX] purchase_blanket_order: Don't compare with translatable string

### DIFF
--- a/purchase_blanket_order/models/blanket_orders.py
+++ b/purchase_blanket_order/models/blanket_orders.py
@@ -273,13 +273,13 @@ class BlanketOrder(models.Model):
         for order in self:
             vals = {"confirmed": True}
             # Set name by sequence only if is necessary
-            if order.name == _("Draft"):
+            if order.name == "Draft":
                 sequence_obj = self.env["ir.sequence"]
                 if order.company_id:
                     sequence_obj = sequence_obj.with_context(
                         force_company=order.company_id.id
                     )
-                name = sequence_obj.next_by_code("purchase.blanket.order") or _("Draft")
+                name = sequence_obj.next_by_code("purchase.blanket.order") or "Draft"
                 vals.update({"name": name})
             order.write(vals)
         return True


### PR DESCRIPTION
Currently the check for assigning a new sequence is done over a translatable string, but the initial sequence name is not done being translatable, so we should make both to compare the same string.

TT37792