### PR TITLE
[14.0][FIX] duplicate quantity on manual delivery

### DIFF
--- a/purchase_manual_delivery/wizard/create_manual_stock_picking.py
+++ b/purchase_manual_delivery/wizard/create_manual_stock_picking.py
@@ -237,8 +237,11 @@ class CreateManualStockPickingWizardLine(models.TransientModel):
         for line in self:
             for val in line._prepare_stock_moves(picking):
                 if val.get("product_uom_qty", False):
+                    # CHECK ME: We can receive more than one move
                     val["product_uom_qty"] = line.product_uom._compute_quantity(
-                        line.qty, line.product_uom, rounding_method="HALF-UP"
+                        val["product_uom_qty"],
+                        line.product_uom,
+                        rounding_method="HALF-UP",
                     )
                 if (
                     val.get("location_dest_id", False)


### PR DESCRIPTION
We can receive more than one move in function _prepare_stock_moves, round up need to keep lines quantity total
@ForgeFlow