### PR TITLE
[14.0][FIX] purchase_force_invoiced: Adapt BI report to the check

### DIFF
--- a/purchase_force_invoiced/reports/__init__.py
+++ b/purchase_force_invoiced/reports/__init__.py
@@ -1,4 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from . import model
-from . import reports
+from . import purchase_report

--- a/purchase_force_invoiced/reports/purchase_report.py
+++ b/purchase_force_invoiced/reports/purchase_report.py
@@ -1,0 +1,21 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+# Copyright 2022 Tecnativa - Pedro M. Baeza
+
+from odoo import models
+
+
+class PurchaseReport(models.Model):
+    _inherit = "purchase.report"
+
+    def _select(self):
+        """Put quantity to be billed as 0 if it has been forced."""
+        select_str = super()._select()
+        select_str = select_str.replace(
+            "case when t.purchase_method = 'purchase'",
+            "case when po.force_invoiced then 0.0 "
+            "else (case when t.purchase_method = 'purchase' ",
+        )
+        select_str = select_str.replace(
+            "end as qty_to_be_billed", "end) end as qty_to_be_billed"
+        )
+        return select_str


### PR DESCRIPTION
The purchase BI analysis is not taking into account the "Force invoiced" check for showing their quantity to be billed, so it
gives contradictory information from the search filter and the pivot.

This commit adapts the SQL report for taking this into account.

FW-port of #1531 for v14

@Tecnativa