### PR TITLE
[14.0][FIX] purchase_discount: Prevent price_unit recursion error since https://github.com/odoo/odoo/commit/87ffe5983be7f0f4a926b458c4bd1f13001048ec

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -65,15 +65,16 @@ class PurchaseOrderLine(models.Model):
         HACK: This is needed while https://github.com/odoo/odoo/pull/29983
         is not merged.
         """
+        bypass_price_unit = self.env.context.get("bypass_override_price_unit")
         price_unit = False
         price = self._get_discounted_price_unit()
-        if price != self.price_unit:
+        if price != self.price_unit and not bypass_price_unit:
             # Only change value if it's different
             price_unit = self.price_unit
-            self.price_unit = price
+            self.with_context(bypass_override_price_unit=True).price_unit = price
         price = super()._get_stock_move_price_unit()
-        if price_unit:
-            self.price_unit = price_unit
+        if price_unit and not bypass_price_unit:
+            self.with_context(bypass_override_price_unit=True).price_unit = price_unit
         return price
 
     @api.onchange("product_qty", "product_uom")

--- a/purchase_propagate_qty/README.rst
+++ b/purchase_propagate_qty/README.rst
@@ -31,10 +31,6 @@ quantity is decreased. This module changes the behavior of Odoo and propagates
 the decrease if the new purchased quantity is below the already received
 quantity. The increase is also propagated.
 
-When used with `purchase_delivery_split_date` it allows to split a purchase line
-when a vendor announces he can only make a partial delivery for date1 and the
-remaining quantity at a later date.
-
 **Table of contents**
 
 .. contents::

--- a/purchase_propagate_qty/readme/DESCRIPTION.rst
+++ b/purchase_propagate_qty/readme/DESCRIPTION.rst
@@ -3,7 +3,3 @@ increase is propagated on the reception, however nothing is done if the
 quantity is decreased. This module changes the behavior of Odoo and propagates
 the decrease if the new purchased quantity is below the already received
 quantity. The increase is also propagated.
-
-When used with `purchase_delivery_split_date` it allows to split a purchase line
-when a vendor announces he can only make a partial delivery for date1 and the
-remaining quantity at a later date.

--- a/purchase_propagate_qty/static/description/index.html
+++ b/purchase_propagate_qty/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Purchase Propagate Quantity</title>
 <style type="text/css">
 
@@ -373,9 +373,6 @@ increase is propagated on the reception, however nothing is done if the
 quantity is decreased. This module changes the behavior of Odoo and propagates
 the decrease if the new purchased quantity is below the already received
 quantity. The increase is also propagated.</p>
-<p>When used with <cite>purchase_delivery_split_date</cite> it allows to split a purchase line
-when a vendor announces he can only make a partial delivery for date1 and the
-remaining quantity at a later date.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">


### PR DESCRIPTION
Prevent `price_unit` recursion error since https://github.com/odoo/odoo/commit/87ffe5983be7f0f4a926b458c4bd1f13001048ec

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa 