### PR TITLE
[13.0][FIX] purchase_propagate_qty: CI error due to upstream change

### DIFF
--- a/purchase_propagate_qty/README.rst
+++ b/purchase_propagate_qty/README.rst
@@ -31,10 +31,6 @@ quantity is decreased. This module changes the behavior of Odoo and propagates
 the decrease if the new purchased quantity is below the already received
 quantity. The increase is also propagated.
 
-When used with `purchase_delivery_split_date` it allows to split a purchase line
-when a vendor announces he can only make a partial delivery for date1 and the
-remaining quantity at a later date.
-
 **Table of contents**
 
 .. contents::

--- a/purchase_propagate_qty/readme/DESCRIPTION.rst
+++ b/purchase_propagate_qty/readme/DESCRIPTION.rst
@@ -3,7 +3,3 @@ increase is propagated on the reception, however nothing is done if the
 quantity is decreased. This module changes the behavior of Odoo and propagates
 the decrease if the new purchased quantity is below the already received
 quantity. The increase is also propagated.
-
-When used with `purchase_delivery_split_date` it allows to split a purchase line
-when a vendor announces he can only make a partial delivery for date1 and the
-remaining quantity at a later date.

--- a/purchase_propagate_qty/static/description/index.html
+++ b/purchase_propagate_qty/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Purchase Propagate Quantity</title>
 <style type="text/css">
 
@@ -373,9 +373,6 @@ increase is propagated on the reception, however nothing is done if the
 quantity is decreased. This module changes the behavior of Odoo and propagates
 the decrease if the new purchased quantity is below the already received
 quantity. The increase is also propagated.</p>
-<p>When used with <cite>purchase_delivery_split_date</cite> it allows to split a purchase line
-when a vendor announces he can only make a partial delivery for date1 and the
-remaining quantity at a later date.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/purchase_propagate_qty/tests/test_purchase_delivery.py
+++ b/purchase_propagate_qty/tests/test_purchase_delivery.py
@@ -95,63 +95,6 @@ class TestQtyUpdate(SavepointCase):
         self.assertEqual(move1.product_uom_qty, 0)
         self.assertEqual(move1.state, "cancel")
 
-    def test_purchase_line_split_move(self):
-        line1 = self.po.order_line[0]
-        move1 = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
-        self.assertEqual(len(move1), 1)
-        # change price so when qty is updated, price is as well, an triggers the split
-        self.assertEqual(self.p1.seller_ids.price, 10.0)
-        self.p1.seller_ids.price = 9.0
-        line1._onchange_quantity()
-        line1.write({"product_qty": 64})
-        moves = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
-        self.assertEqual(len(moves), 2)
-        self.assertEqual(moves.mapped("product_uom_qty"), [42.0, 22.0])
-        # Then, decrease 11
-        line1.write({"product_qty": 53})
-        self.assertEqual(moves.mapped("product_uom_qty"), [42.0, 11.0])
-        # Again, decrease 11
-        line1.write({"product_qty": 42})
-        self.assertEqual(moves.mapped("product_uom_qty"), [42.0, 0.0])
-        active_move = moves.filtered(lambda m: m.state != "cancel")
-        inactive_move = moves.filtered(lambda m: m.state == "cancel")
-        self.assertEqual(active_move.product_uom_qty, 42)
-        self.assertEqual(inactive_move.product_uom_qty, 0)
-
-    def test_purchase_line_split_move_w_reserved_qty(self):
-        line1 = self.po.order_line[0]
-        move1 = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
-        self.assertEqual(len(move1), 1)
-        # change price so when qty is updated, price is as well, an triggers the split
-        self.assertEqual(self.p1.seller_ids.price, 10.0)
-        self.p1.seller_ids.price = 9.0
-        line1._onchange_quantity()
-        # Increase qty by 22, move1 should be split
-        line1.write({"product_qty": 64})
-        moves = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
-        move2 = moves - move1
-        # reserve 12 qty
-        move2.quantity_done = 12
-        self.assertEqual(move2._get_removable_qty(), 10)
-        line1.write({"product_qty": 60})
-        self.assertEqual(moves.mapped("product_uom_qty"), [42.0, 18.0])
-        # We cannot remove more than 10 on move2, deduce the max from it,
-        # then deduce from move1
-        line1.write({"product_qty": 50})
-        self.assertEqual(moves.mapped("product_uom_qty"), [38.0, 12.0])
-        # We should not be able to set a qty < to 12, since 12 products are reserved
-        exception_regex = (
-            "You cannot remove more that what remains to be done. "
-            "Max removable quantity 38.0."
-        )
-        with self.assertRaisesRegex(UserError, exception_regex):
-            line1.write({"product_qty": 11})
-        # with 12, move1 should be cancelled
-        line1.write({"product_qty": 12})
-        self.assertEqual(move1.product_uom_qty, 0.0)
-        self.assertEqual(move1.state, "cancel")
-        self.assertEqual(move2.product_uom_qty, 12.0)
-
     def test_reduce_purchase_qty_with_canceled_moves(self):
         """ Check canceled moves are not taken into account."""
         self.po.button_cancel()  # Cancel the moves


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/ba4111e7a9202d801e3d51b55cad9659877e514a, tests are failing.

Analyzing the roout cause, this module was testing things that are not done by it, but a side effect of the previous status quo.

As such, we remove the tests that were testing this expected side effects, as well as removing the reference in the README. If the
behavior wants to be restored, it should be explicitly handled in a module with its own tests.

@Tecnativa