### PR TITLE
[14.0][FIX] purchase_propagate_qty: Ci error due to upstream change

### DIFF
--- a/purchase_propagate_qty/README.rst
+++ b/purchase_propagate_qty/README.rst
@@ -31,10 +31,6 @@ quantity is decreased. This module changes the behavior of Odoo and propagates
 the decrease if the new purchased quantity is below the already received
 quantity. The increase is also propagated.
 
-When used with `purchase_delivery_split_date` it allows to split a purchase line
-when a vendor announces he can only make a partial delivery for date1 and the
-remaining quantity at a later date.
-
 **Table of contents**
 
 .. contents::

--- a/purchase_propagate_qty/readme/DESCRIPTION.rst
+++ b/purchase_propagate_qty/readme/DESCRIPTION.rst
@@ -3,7 +3,3 @@ increase is propagated on the reception, however nothing is done if the
 quantity is decreased. This module changes the behavior of Odoo and propagates
 the decrease if the new purchased quantity is below the already received
 quantity. The increase is also propagated.
-
-When used with `purchase_delivery_split_date` it allows to split a purchase line
-when a vendor announces he can only make a partial delivery for date1 and the
-remaining quantity at a later date.

--- a/purchase_propagate_qty/static/description/index.html
+++ b/purchase_propagate_qty/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Purchase Propagate Quantity</title>
 <style type="text/css">
 
@@ -373,9 +373,6 @@ increase is propagated on the reception, however nothing is done if the
 quantity is decreased. This module changes the behavior of Odoo and propagates
 the decrease if the new purchased quantity is below the already received
 quantity. The increase is also propagated.</p>
-<p>When used with <cite>purchase_delivery_split_date</cite> it allows to split a purchase line
-when a vendor announces he can only make a partial delivery for date1 and the
-remaining quantity at a later date.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/ba4111e7a9202d801e3d51b55cad9659877e514a, tests are failing.

Analyzing the roout cause, this module was testing things that are not done by it, but a side effect of the previous status quo.

As such, we remove the tests that were testing this expected side effects, as well as removing the reference in the README. If the behavior wants to be restored, it should be explicitly handled in a module with its own tests.

@Tecnativa