### PR TITLE
[IMP] purchase_request: split field "Quantity in RFQ or PO"" in purchased_qty and rfq_qty fields.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,9 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
-      - name: Get python version
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+          python-version: "3.9"
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit

--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -103,7 +103,12 @@ class PurchaseRequestLine(models.Model):
     )
 
     purchased_qty = fields.Float(
-        string="Quantity in RFQ or PO",
+        string="Purchased Quantity",
+        digits="Product Unit of Measure",
+        compute="_compute_purchased_qty",
+    )
+    rfq_qty = fields.Float(
+        string="Quantity in RFQ",
         digits="Product Unit of Measure",
         compute="_compute_purchased_qty",
     )
@@ -117,11 +122,21 @@ class PurchaseRequestLine(models.Model):
         copy=False,
     )
     purchase_state = fields.Selection(
-        compute="_compute_purchase_state",
+        [
+            ("draft", "RFQ"),
+            ("sent", "RFQ Sent"),
+            ("to approve", "To Approve"),
+            ("approved", "Approved"),
+            ("partially", "Partially Purchased"),
+            ("purchase", "Purchased"),
+            ("done", "Locked"),
+            ("cancel", "Cancelled"),
+        ],
         string="Purchase Status",
-        selection=lambda self: self.env["purchase.order"]._fields["state"].selection,
+        compute="_compute_purchase_state",
         store=True,
     )
+
     move_dest_ids = fields.One2many(
         comodel_name="stock.move",
         inverse_name="created_purchase_request_line_id",
@@ -287,14 +302,11 @@ class PurchaseRequestLine(models.Model):
     @api.onchange("product_id")
     def onchange_product_id(self):
         if self.product_id:
-            name = self.product_id.name
-            if self.product_id.code:
-                name = "[{}] {}".format(self.product_id.code, name)
+            self.name = self.product_id.display_name
             if self.product_id.description_purchase:
-                name += "\n" + self.product_id.description_purchase
-            self.product_uom_id = self.product_id.uom_id.id
+                self.name += " " + self.product_id.description_purchase
+            self.product_uom_id = self.product_id.uom_po_id.id
             self.product_qty = 1
-            self.name = name
 
     def do_cancel(self):
         """Actions to perform when cancelling a purchase request line."""
@@ -314,13 +326,16 @@ class PurchaseRequestLine(models.Model):
     def _compute_purchased_qty(self):
         for rec in self:
             rec.purchased_qty = 0.0
-            for line in rec.purchase_lines.filtered(lambda x: x.state != "cancel"):
-                if rec.product_uom_id and line.product_uom != rec.product_uom_id:
+            rec.rfq_qty = 0.0
+            for line in rec.purchase_lines:
+                if line.state in ["purchase", "done"]:
                     rec.purchased_qty += line.product_uom._compute_quantity(
                         line.product_qty, rec.product_uom_id
                     )
                 else:
-                    rec.purchased_qty += line.product_qty
+                    rec.rfq_qty += line.product_uom._compute_quantity(
+                        line.product_qty, rec.product_uom_id
+                    )
 
     @api.depends("purchase_lines.state", "purchase_lines.order_id.state")
     def _compute_purchase_state(self):
@@ -328,17 +343,35 @@ class PurchaseRequestLine(models.Model):
             temp_purchase_state = False
             if rec.purchase_lines:
                 if any([po_line.state == "done" for po_line in rec.purchase_lines]):
-                    temp_purchase_state = "done"
-                elif all([po_line.state == "cancel" for po_line in rec.purchase_lines]):
-                    temp_purchase_state = "cancel"
+                    qty_done = sum(
+                        [
+                            po_line.product_uom._compute_quantity(
+                                po_line.product_qty, rec.product_uom_id
+                            )
+                            for po_line in rec.purchase_lines.filtered(
+                                lambda po: po.state == "done"
+                            )
+                        ]
+                    )
+                    temp_purchase_state = (
+                        "done" if qty_done >= rec.product_qty else "partially"
+                    )
                 elif any(
                     [po_line.state == "purchase" for po_line in rec.purchase_lines]
                 ):
-                    temp_purchase_state = "purchase"
-                elif any(
-                    [po_line.state == "to approve" for po_line in rec.purchase_lines]
-                ):
-                    temp_purchase_state = "to approve"
+                    qty_purchased = sum(
+                        [
+                            po_line.product_uom._compute_quantity(
+                                po_line.product_qty, rec.product_uom_id
+                            )
+                            for po_line in rec.purchase_lines.filtered(
+                                lambda po: po.state == "purchase"
+                            )
+                        ]
+                    )
+                    temp_purchase_state = (
+                        "purchase" if qty_purchased >= rec.product_qty else "partially"
+                    )
                 elif any([po_line.state == "sent" for po_line in rec.purchase_lines]):
                     temp_purchase_state = "sent"
                 elif all(
@@ -378,7 +411,7 @@ class PurchaseRequestLine(models.Model):
         rl_qty = 0.0
         # Recompute quantity by adding existing running procurements.
         if new_pr_line:
-            rl_qty = po_line.product_uom_qty
+            rl_qty = po_line.product_qty
         else:
             for prl in po_line.purchase_request_lines:
                 for alloc in prl.purchase_request_allocation_ids:

--- a/purchase_request/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request/tests/test_purchase_request_to_rfq.py
@@ -233,10 +233,15 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
                 item.onchange_product_id()
         wiz_id.make_purchase_order()
         self.assertEquals(
-            purchase_request_line1.purchased_qty, 1.0, "Should be a quantity of 1"
+            purchase_request_line1.rfq_qty, 1.0, "Quantity in RFQ should be 1"
         )
         self.assertEquals(
-            purchase_request_line2.purchased_qty, 1.0, "Should be a quantity of 1"
+            purchase_request_line2.rfq_qty, 1.0, "Quantity in RFQ should be 1"
+        )
+        purchase_request_line1.purchase_lines.order_id.button_confirm()
+        purchase_request_line1._compute_purchased_qty()
+        self.assertEquals(
+            purchase_request_line1.purchased_qty, 1.0, "Purchased quantity should be 1"
         )
 
     def test_purchase_request_to_purchase_rfq_multiple_PO_purchaseUoM(self):

--- a/purchase_request/views/purchase_request_line_view.xml
+++ b/purchase_request/views/purchase_request_line_view.xml
@@ -19,6 +19,7 @@
                 <field name="date_required" />
                 <field name="estimated_cost" widget="monetary" />
                 <field name="currency_id" invisible="1" />
+                <field name="rfq_qty" />
                 <field name="purchased_qty" />
                 <field name="purchase_state" />
                 <field name="product_id" />
@@ -157,6 +158,7 @@
                     <notebook>
                         <page name="purchase_lines" string="Purchase Order Lines">
                             <group>
+                                <field name="rfq_qty" />
                                 <field name="purchased_qty" />
                                 <field name="purchase_state" />
                             </group>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -184,6 +184,7 @@
                                     />
                                     <field name="cancelled" invisible="1" />
                                     <field name="is_editable" invisible="1" />
+                                    <field name="rfq_qty" />
                                     <field name="purchased_qty" />
                                     <field name="purchase_state" />
                                 </tree>
@@ -274,6 +275,7 @@
                                             >
                                                 <group>
                                                     <group name="purchase_state">
+                                                        <field name="rfq_qty" />
                                                         <field name="purchased_qty" />
                                                         <field name="purchase_state" />
                                                         <field name="qty_in_progress" />

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -285,7 +285,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                     po_line_data["name"] = item.name
                 po_line = po_line_obj.create(po_line_data)
                 po_line_product_uom_qty = po_line.product_uom._compute_quantity(
-                    po_line.product_uom_qty, alloc_uom
+                    po_line.product_qty, alloc_uom
                 )
                 wizard_product_uom_qty = wizard_uom._compute_quantity(
                     item.product_qty, alloc_uom


### PR DESCRIPTION
Features in this PR:
* Split field purchased_qty (Quantity in RFQ or PO) into twice different fields: purchased_qty and rfq_qty. Also added to views.
* Add to the compute method of the purchase request line state the dependence on quantities (i.e.: A purchase request line is not done if the purchase order quantities are less than de purchase request line quantities)
* Add the description of purchase request line to the purchase order line.