### PR TITLE
[14.0][ADD] purchase_supplierinfo_product_breakdown

### DIFF
--- a/purchase_supplierinfo_product_breakdown/README.rst
+++ b/purchase_supplierinfo_product_breakdown/README.rst
@@ -1,0 +1,1 @@
+Please refer to the module description

--- a/purchase_supplierinfo_product_breakdown/__init__.py
+++ b/purchase_supplierinfo_product_breakdown/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_supplierinfo_product_breakdown/__manifest__.py
+++ b/purchase_supplierinfo_product_breakdown/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "Purchase Supplierinfo Product Breakdown",
+    "summary": "Purchase Supplierinfo Product Breakdown",
+    "author": "Ooops, Cetmix, Odoo Community Association (OCA)",
+    "version": "14.0.1.0.0",
+    "category": "Purchase Management",
+    "website": "https://github.com/OCA/purchase-workflow",
+    "depends": ["purchase"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/res_partner_views.xml",
+        "views/product_supplierinfo_views.xml",
+        "views/product_template_views.xml",
+    ],
+    "demo": [
+        "data/demo.xml",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+}

--- a/purchase_supplierinfo_product_breakdown/data/demo.xml
+++ b/purchase_supplierinfo_product_breakdown/data/demo.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+
+    <record id="res_partner_test_demo_anna" model="res.partner">
+        <field name="name">Anna</field>
+        <field name="use_product_components">True</field>
+    </record>
+    <record id="res_partner_supplier_test_demo_max" model="res.partner">
+        <field name="name">Max</field>
+    </record>
+    <record id="product_product_test_demo_toolbox" model="product.product">
+        <field name="name">Toolbox</field>
+        <field name="standard_price">100.0</field>
+        <field name="type">consu</field>
+        <field name="uom_id" ref="uom.product_uom_unit" />
+    </record>
+    <record id="product_product_test_demo_hammer" model="product.product">
+        <field name="name">Hammer</field>
+        <field name="standard_price">5.0</field>
+        <field name="type">consu</field>
+        <field name="uom_id" ref="uom.product_uom_unit" />
+    </record>
+    <record id="product_product_test_demo_saw" model="product.product">
+        <field name="name">Saw</field>
+        <field name="standard_price">3.0</field>
+        <field name="type">consu</field>
+        <field name="uom_id" ref="uom.product_uom_unit" />
+    </record>
+    <record id="product_product_test_demo_drill" model="product.product">
+        <field name="name">Drill</field>
+        <field name="standard_price">10.0</field>
+        <field name="type">consu</field>
+        <field name="uom_id" ref="uom.product_uom_unit" />
+    </record>
+
+</odoo>

--- a/purchase_supplierinfo_product_breakdown/models/__init__.py
+++ b/purchase_supplierinfo_product_breakdown/models/__init__.py
@@ -1,0 +1,4 @@
+from . import product_supplierinfo
+from . import product_supplierinfo_component
+from . import product_template
+from . import res_partner

--- a/purchase_supplierinfo_product_breakdown/models/product_supplierinfo.py
+++ b/purchase_supplierinfo_product_breakdown/models/product_supplierinfo.py
@@ -1,0 +1,54 @@
+from odoo import _, api, fields, models
+
+
+class ProductSupplierInfo(models.Model):
+    _inherit = "product.supplierinfo"
+
+    product_use_components = fields.Boolean(
+        related="product_tmpl_id.use_product_components"
+    )
+    partner_use_components = fields.Boolean(related="name.use_product_components")
+    component_ids = fields.One2many(
+        comodel_name="product.supplierinfo.component", inverse_name="supplierinfo_id"
+    )
+    product_variant_ids = fields.One2many(related="product_tmpl_id.product_variant_ids")
+
+    @api.constrains("component_ids")
+    def check_component_ids(self):
+        """Checking a component for uniqueness"""
+        for supplier in self:
+            components = supplier.component_ids.mapped("component_id")
+            if supplier.product_variant_ids & components:
+                raise models.ValidationError(
+                    _("Components must not contain parent products!")
+                )
+            grouped_data = self.env["product.supplierinfo.component"].read_group(
+                domain=[("supplierinfo_id", "=", supplier.id)],
+                fields=["component_id"],
+                groupby=["component_id"],
+            )
+            if list(filter(lambda c: c.get("component_id_count") > 1, grouped_data)):
+                raise models.ValidationError(_("Components must be unique!"))
+
+    def action_open_component_view(self):
+        """Open product components view"""
+        self.ensure_one()
+        if not (self.product_use_components and self.partner_use_components):
+            raise models.UserError(
+                _(
+                    "You need to activate 'Use Product Component' "
+                    "in both Product and Vendor to use it."
+                )
+            )
+        view = self.env.ref(
+            "purchase_supplierinfo_product_breakdown.product_supplierinfo_component_form_view"  # noqa
+        )
+        return {
+            "name": _("Product Components"),
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "product.supplierinfo",
+            "res_id": self.id,
+            "view_id": view.id,
+            "target": "new",
+        }

--- a/purchase_supplierinfo_product_breakdown/models/product_supplierinfo_component.py
+++ b/purchase_supplierinfo_product_breakdown/models/product_supplierinfo_component.py
@@ -1,0 +1,43 @@
+from odoo import api, fields, models
+
+
+class ProductSupplierInfoComponent(models.Model):
+    _name = "product.supplierinfo.component"
+    _description = "Supplierinfo Product Component"
+
+    supplierinfo_id = fields.Many2one(
+        comodel_name="product.supplierinfo", string="Supplier Info"
+    )
+    parent_product_ids = fields.One2many(related="supplierinfo_id.product_variant_ids")
+    partner_id = fields.Many2one(related="supplierinfo_id.name")
+    component_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Component",
+        required=True,
+        domain="[('id', 'not in', parent_product_ids)]",
+    )
+    component_uom_category_id = fields.Many2one(
+        related="component_id.uom_id.category_id"
+    )
+    product_uom_qty = fields.Float(
+        string="Qty per Unit",
+        default=1.0,
+        required=True,
+    )
+    product_uom_id = fields.Many2one(
+        comodel_name="uom.uom",
+        string="Unit of Measure",
+        domain=[("category_id", "=", component_uom_category_id)],
+        required=True,
+    )
+
+    @api.onchange("component_id")
+    def onchange_component_id(self):
+        """Set default value on component onchange"""
+        component = self.component_id
+        self.update(
+            {
+                "product_uom_qty": 1.0,
+                "product_uom_id": component.uom_po_id or component.uom_id,
+            }
+        )

--- a/purchase_supplierinfo_product_breakdown/models/product_template.py
+++ b/purchase_supplierinfo_product_breakdown/models/product_template.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    use_product_components = fields.Boolean()

--- a/purchase_supplierinfo_product_breakdown/models/res_partner.py
+++ b/purchase_supplierinfo_product_breakdown/models/res_partner.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    use_product_components = fields.Boolean()

--- a/purchase_supplierinfo_product_breakdown/readme/CONTRIBUTORS.rst
+++ b/purchase_supplierinfo_product_breakdown/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Ooops404 <https://ooops404.com>
+* Cetmix <https://cetmix.com>

--- a/purchase_supplierinfo_product_breakdown/readme/DESCRIPTION.rst
+++ b/purchase_supplierinfo_product_breakdown/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module allows to relate components and their qty to a product supplierinfo for a specific vendor.
+
+It can be used as a base module for further implementations.

--- a/purchase_supplierinfo_product_breakdown/readme/USAGE.rst
+++ b/purchase_supplierinfo_product_breakdown/readme/USAGE.rst
@@ -1,0 +1,4 @@
+* In vendor, enable **Use Product Components** option in the **Sales & Purchases** tab.
+* In product, enable **Use Product Components** option in the **Purchase** tab.
+* If both product and vendor have the flag activated, in the **Purchase** tab of the **Product**, table **Vendor**  there will be a button at the end of the supplierinfo line.
+* Click the button and add components for the product.

--- a/purchase_supplierinfo_product_breakdown/security/ir.model.access.csv
+++ b/purchase_supplierinfo_product_breakdown/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_supplierinfo_component_user,access.product.supplierinfo.component.user,model_product_supplierinfo_component,base.group_user,1,0,0,0
+access_product_supplierinfo_component_manager,access.product.supplierinfo.component.manager,model_product_supplierinfo_component,purchase.group_purchase_manager,1,1,1,1
+access_product_supplierinfo_component_system,access.product.supplierinfo.component.system,model_product_supplierinfo_component,base.group_system,1,1,1,1

--- a/purchase_supplierinfo_product_breakdown/tests/__init__.py
+++ b/purchase_supplierinfo_product_breakdown/tests/__init__.py
@@ -1,0 +1,3 @@
+from . import common
+from . import test_product_supplierinfo_component
+from . import test_supplierinfo

--- a/purchase_supplierinfo_product_breakdown/tests/common.py
+++ b/purchase_supplierinfo_product_breakdown/tests/common.py
@@ -1,0 +1,56 @@
+from odoo.tests import Form, TransactionCase
+
+
+class SupplierInfoCommon(TransactionCase):
+    def setUp(self):
+        super(SupplierInfoCommon, self).setUp()
+        self.view_name = "purchase_supplierinfo_product_breakdown.product_supplierinfo_component_form_view"  # noqa
+        self.res_partner_anna = self.env.ref(
+            "purchase_supplierinfo_product_breakdown.res_partner_test_demo_anna",
+            raise_if_not_found=False,
+        )
+        self.res_partner_supplier_max = self.env.ref(
+            "purchase_supplierinfo_product_breakdown.res_partner_supplier_test_demo_max",
+            raise_if_not_found=False,
+        )
+        self.product_product_toolbox = self.env.ref(
+            "purchase_supplierinfo_product_breakdown.product_product_test_demo_toolbox",
+            raise_if_not_found=False,
+        )
+        self.product_product_component_hammer = self.env.ref(
+            "purchase_supplierinfo_product_breakdown.product_product_test_demo_hammer",
+            raise_if_not_found=False,
+        )
+        self.product_product_component_saw = self.env.ref(
+            "purchase_supplierinfo_product_breakdown.product_product_test_demo_saw",
+            raise_if_not_found=False,
+        )
+        self.product_product_component_drill = self.env.ref(
+            "purchase_supplierinfo_product_breakdown.product_product_test_demo_drill",
+            raise_if_not_found=False,
+        )
+
+        with Form(self.product_product_component_hammer) as form:
+            with form.seller_ids.new() as seller:
+                seller.name = self.res_partner_supplier_max
+                seller.price = 5
+
+        with Form(self.product_product_component_saw) as form:
+            with form.seller_ids.new() as seller:
+                seller.name = self.res_partner_supplier_max
+                seller.price = 3.0
+
+        with Form(self.product_product_toolbox) as form:
+            with form.seller_ids.new() as seller:
+                seller.name = self.res_partner_anna
+                seller.price = 100.0
+
+        self.product_supplier_info = self.product_product_toolbox.seller_ids
+
+        with Form(self.product_supplier_info, view=self.view_name) as form:
+            with form.component_ids.new() as line:
+                line.component_id = self.product_product_component_hammer
+                line.product_uom_qty = 5
+            with form.component_ids.new() as line:
+                line.component_id = self.product_product_component_saw
+                line.product_uom_qty = 3

--- a/purchase_supplierinfo_product_breakdown/tests/test_product_supplierinfo_component.py
+++ b/purchase_supplierinfo_product_breakdown/tests/test_product_supplierinfo_component.py
@@ -1,0 +1,54 @@
+from odoo import exceptions
+from odoo.tests import Form, tagged
+
+from .common import SupplierInfoCommon
+
+
+@tagged("post_install", "-at_install")
+class TestProductSupplierInfoComponent(SupplierInfoCommon):
+    """
+    TEST 1 - Checking field values when changing a component
+    TEST 2 - Throws an error when Component is not unique or equal to parent product
+    """
+
+    # TEST 1 - Checking field values when changing a component
+    def test_onchange_components_value(self):
+        """Checking field values when changing a component"""
+        component = self.product_supplier_info.component_ids[0]
+        self.assertEqual(
+            component.component_id,
+            self.product_product_component_hammer,
+            msg="Component must be equal to 'Test Component #1'",
+        )
+        self.assertEqual(
+            component.product_uom_qty, 5, msg="Product Qty must be equal to 5"
+        )
+        with Form(
+            self.product_supplier_info, view=self.view_name
+        ) as form, form.component_ids.edit(index=0) as comp:
+            comp.component_id = self.product_product_component_drill
+            self.assertEqual(
+                comp.product_uom_qty, 1, msg="Product Qty must be equal to 1"
+            )
+            self.assertEqual(
+                self.product_product_component_drill.uom_id, comp.product_uom_id
+            )
+
+    # TEST 2 - Throws an error when Component is not unique or equal to parent product
+    def test_component_is_not_unique_or_parent_product(self):
+        """Throws an error when Component is not unique or equal to parent product"""
+        with self.assertRaises(exceptions.ValidationError):
+            with Form(self.product_supplier_info, view=self.view_name) as form:
+                with form.component_ids.new() as line:
+                    line.component_id = self.product_product_toolbox
+
+        with self.assertRaises(exceptions.ValidationError):
+            with Form(self.product_supplier_info, view=self.view_name) as form:
+                with form.component_ids.new() as line:
+                    line.component_id = self.product_product_component_hammer
+
+        with self.assertRaises(exceptions.ValidationError):
+            with Form(
+                self.product_supplier_info, view=self.view_name
+            ) as form, form.component_ids.edit(index=0) as line:
+                line.component_id = self.product_product_component_saw

--- a/purchase_supplierinfo_product_breakdown/tests/test_supplierinfo.py
+++ b/purchase_supplierinfo_product_breakdown/tests/test_supplierinfo.py
@@ -1,0 +1,59 @@
+from odoo import exceptions
+from odoo.tests import tagged
+
+from .common import SupplierInfoCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSupplierInfo(SupplierInfoCommon):
+    """
+    TEST 1 - Check if action is available to the supplier
+    TEST 2 - Action has the correct structure
+    """
+
+    # TEST 1 - Check if action is available to the supplier
+    def test_action_available_to_supplier(self):
+        """Check if action is available to the supplier"""
+        with self.assertRaises(exceptions.UserError):
+            self.product_supplier_info.action_open_component_view()
+
+        self.product_product_toolbox.use_product_components = True
+
+        action = self.product_supplier_info.action_open_component_view()
+        self.assertTrue(isinstance(action, dict), msg="Action must be dict type")
+
+    # TEST 2 - Action has the correct structure
+    def test_correct_action_structure(self):
+        """Action has the correct structure"""
+        self.product_product_toolbox.use_product_components = True
+
+        action = self.product_supplier_info.action_open_component_view()
+        self.assertEqual(
+            action.get("type"),
+            "ir.actions.act_window",
+            msg="Action type must be equal to 'ir.actions.act_window'",
+        )
+        self.assertEqual(
+            action.get("view_mode"),
+            "form",
+            msg="Action view mode must be equal to 'form'",
+        )
+        self.assertEqual(
+            action.get("res_model"),
+            "product.supplierinfo",
+            msg="Res Model must be equal to 'product.supplierinfo'",
+        )
+        self.assertEqual(
+            action.get("res_id"),
+            self.product_supplier_info.id,
+            msg="Res Id must be equal to {}".format(self.product_supplier_info),
+        )
+        view_id = self.ref(self.view_name)
+        self.assertEqual(
+            action.get("view_id"),
+            view_id,
+            msg="View id must be equal to {}".format(view_id),
+        )
+        self.assertEqual(
+            action.get("target"), "new", msg="Target must be equal to 'new'"
+        )

--- a/purchase_supplierinfo_product_breakdown/views/product_supplierinfo_views.xml
+++ b/purchase_supplierinfo_product_breakdown/views/product_supplierinfo_views.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="product_supplierinfo_component_form_view" model="ir.ui.view">
+        <field name="name">product.supplierinfo.component.form.view</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="priority">200</field>
+        <field name="arch" type="xml">
+            <form string="Product Components">
+                <sheet>
+                    <field name="component_ids" widget="one2many">
+                        <tree string="Product Components" editable="bottom">
+                            <control>
+                                <create
+                                    name="add_product_control"
+                                    string="Add a Component"
+                                />
+                            </control>
+                            <field name="supplierinfo_id" invisible="1" />
+                            <field name="component_uom_category_id" invisible="1" />
+                            <field name="parent_product_ids" invisible="1" />
+                            <field name="component_id" />
+                            <field name="product_uom_qty" />
+                            <field name="product_uom_id" />
+                        </tree>
+                    </field>
+                    <footer>
+                        <button string="Save" class="btn-primary" special="save" />
+                        <button
+                            string="Cancel"
+                            class="btn-secondary"
+                            special="cancel"
+                        />
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="product_supplierinfo_tree_view3" model="ir.ui.view">
+        <field name="name">product.spplierinfo.inherit.tree.view</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="inherit_id" ref="purchase.product_supplierinfo_tree_view2" />
+        <field name="arch" type="xml">
+            <tree>
+                <field name="partner_use_components" invisible="1" />
+                <field name="product_use_components" invisible="1" />
+                <button
+                    name="action_open_component_view"
+                    type="object"
+                    icon="fa-list"
+                    attrs="{'invisible': ['|', ('partner_use_components', '=', False), ('product_use_components', '=', False)]}"
+                />
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/purchase_supplierinfo_product_breakdown/views/product_template_views.xml
+++ b/purchase_supplierinfo_product_breakdown/views/product_template_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_product_supplier_inherit" model="ir.ui.view">
+        <field name="name">product.template.supplier.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="purchase.view_product_supplier_inherit" />
+        <field name="arch" type="xml">
+            <group name="bill" position="inside">
+                <field name="use_product_components" />
+            </group>
+            <field name="seller_ids" position="attributes">
+                <attribute name="context">{
+                    'default_product_tmpl_id':context.get('product_tmpl_id',active_id),
+                    'product_template_invisible_variant': True,
+                    'tree_view_ref':'purchase_supplierinfo_product_breakdown.product_supplierinfo_tree_view3'
+                }
+                </attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/purchase_supplierinfo_product_breakdown/views/res_partner_views.xml
+++ b/purchase_supplierinfo_product_breakdown/views/res_partner_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_partner_property_form" model="ir.ui.view">
+        <field name="name">res.partner.purchase.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="purchase.view_partner_property_form" />
+        <field name="arch" type="xml">
+            <group name="purchase" position="inside">
+                <label for="use_product_components" />
+                <div
+                    name="partner_use_components"
+                    groups="purchase.group_purchase_user"
+                >
+                    <field name="use_product_components" />
+                </div>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/setup/purchase_supplierinfo_product_breakdown/odoo/addons/purchase_supplierinfo_product_breakdown
+++ b/setup/purchase_supplierinfo_product_breakdown/odoo/addons/purchase_supplierinfo_product_breakdown
@@ -1,0 +1,1 @@
+../../../../purchase_supplierinfo_product_breakdown

--- a/setup/purchase_supplierinfo_product_breakdown/setup.py
+++ b/setup/purchase_supplierinfo_product_breakdown/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Supersedes https://github.com/OCA/purchase-workflow/pull/1547#issuecomment-1226926583



This module allows to relate components and their qty to a product supplierinfo for a specific vendor.

It can be used as a base module for further implementations.

* In vendor, enable **Use Product Components** option in the **Sales & Purchases** tab.

* In product, enable **Use Product Components** option in the Purchase tab.

* If both product and vendor have the flag activated, in the **Purchase** tab of the **Product**, table **Vendor**  there will be a button at the end of the supplierinfo line.

* Click the button and add components for the product.