### PR TITLE
[13.0][IMP] purchase_order_uninvoiced_amount: Make field stored to fix the grouped sum values in purchase tree view

### DIFF
--- a/purchase_order_uninvoiced_amount/models/purchase_order.py
+++ b/purchase_order_uninvoiced_amount/models/purchase_order.py
@@ -44,4 +44,5 @@ class PurchaseOrder(models.Model):
         readonly=True,
         compute="_compute_amount_uninvoiced",
         tracking=True,
+        store=True,
     )


### PR DESCRIPTION
cc @Tecnativa TT38874

The amount_uninvoiced field in the purchase order tree view is set with the attribute sum=.... but the field is compute no store so the grouped value is not displayed.

ping @carlosdauden @chienandalu 