### PR TITLE
[14.0][IMP] purchase_order_uninvoiced_amount: Make field stored to fix the grouped sum values in purchase tree view

### DIFF
--- a/purchase_order_uninvoiced_amount/models/purchase_order.py
+++ b/purchase_order_uninvoiced_amount/models/purchase_order.py
@@ -44,4 +44,5 @@ class PurchaseOrder(models.Model):
         readonly=True,
         compute="_compute_amount_uninvoiced",
         tracking=True,
+        store=True,
     )


### PR DESCRIPTION
cc @Tecnativa TT38874

Forwardport from https://github.com/OCA/purchase-workflow/commit/7b20c22315c9a686299b0d3e0e05895fb2c00690

ping @carlosdauden @chienandalu 