### PR TITLE
[13.0][FIX] purchase_landed_cost: Avoid error in moves if the user does not have any purchase permission.

### DIFF
--- a/purchase_landed_cost/views/account_move_view.xml
+++ b/purchase_landed_cost/views/account_move_view.xml
@@ -3,6 +3,7 @@
     <record id="view_move_form" model="ir.ui.view">
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
+        <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]" />
         <field name="arch" type="xml">
             <notebook position="inside">
                 <page


### PR DESCRIPTION
Avoid error in moves if the user does not have any purchase permission.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38904