### PR TITLE
[ADD][14.0] Module: purchase_order_line_note

### DIFF
--- a/purchase_order_line_note/__init__.py
+++ b/purchase_order_line_note/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_order_line_note/__manifest__.py
+++ b/purchase_order_line_note/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Purchase Order Line Note",
+    "summary": "Note on purchase order line",
+    "version": "14.0.1.0.0",
+    "category": "Purchase",
+    "website": "https://github.com/OCA/purchase-workflow",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["Kev-Roche"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "purchase",
+    ],
+    "data": [
+        "views/purchase_order_line.xml",
+    ],
+}

--- a/purchase_order_line_note/i18n/fr.po
+++ b/purchase_order_line_note/i18n/fr.po
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * purchase_order_line_note
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-09-13 14:02+0000\n"
+"PO-Revision-Date: 2022-09-13 16:03+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 3.1.1\n"
+
+#. module: purchase_order_line_note
+#: model:ir.model.fields,field_description:purchase_order_line_note.field_purchase_order_line__display_name
+msgid "Display Name"
+msgstr "Nom"
+
+#. module: purchase_order_line_note
+#: model:ir.model.fields,field_description:purchase_order_line_note.field_purchase_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: purchase_order_line_note
+#: model:ir.model.fields,field_description:purchase_order_line_note.field_purchase_order_line____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: purchase_order_line_note
+#: model:ir.model.fields,field_description:purchase_order_line_note.field_purchase_order_line__note
+#: model_terms:ir.ui.view,arch_db:purchase_order_line_note.purchase_order_view_form
+msgid "Note"
+msgstr "Note"
+
+#. module: purchase_order_line_note
+#: model:ir.model,name:purchase_order_line_note.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Ligne de commande d'achat"

--- a/purchase_order_line_note/models/__init__.py
+++ b/purchase_order_line_note/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order_line

--- a/purchase_order_line_note/models/purchase_order_line.py
+++ b/purchase_order_line_note/models/purchase_order_line.py
@@ -1,0 +1,11 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    note = fields.Text()

--- a/purchase_order_line_note/readme/CONTRIBUTORS.rst
+++ b/purchase_order_line_note/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Kévin Roche <kevin.roche@akretion.com>

--- a/purchase_order_line_note/readme/DESCRIPTION.rst
+++ b/purchase_order_line_note/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module add the field note on the purchase order line

--- a/purchase_order_line_note/views/purchase_order_line.xml
+++ b/purchase_order_line_note/views/purchase_order_line.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+     @author Kévin Roche <kevin.roche@akretion.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="purchase_order_view_form" model="ir.ui.view">
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree/field[@name='name']" position="after">
+                <field name="note" optional="hide" />
+            </xpath>
+            <xpath expr="//form/field[@name='name']" position="after">
+                <label
+                    for="note"
+                    string="Note"
+                    attrs="{'invisible': [('display_type', '!=', False)]}"
+                />
+                <field
+                    name="note"
+                    optional="hide"
+                    attrs="{'invisible': [('display_type', '!=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/purchase_order_line_note/odoo/addons/purchase_order_line_note
+++ b/setup/purchase_order_line_note/odoo/addons/purchase_order_line_note
@@ -1,0 +1,1 @@
+../../../../purchase_order_line_note

--- a/setup/purchase_order_line_note/setup.py
+++ b/setup/purchase_order_line_note/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Similar to https://github.com/OCA/sale-workflow/tree/14.0/sale_order_line_note, add a note to purchase line.