### PR TITLE
[13.0][FIX] purchase_last_price_info : convert last price based on product purchase unit of measure

### DIFF
--- a/purchase_last_price_info/models/product_product.py
+++ b/purchase_last_price_info/models/product_product.py
@@ -56,10 +56,16 @@ class ProductProduct(models.Model):
     @api.depends("last_purchase_line_id")
     def _compute_last_purchase_line_id_info(self):
         for item in self:
-            item.last_purchase_price = item.last_purchase_line_id.price_unit
-            item.last_purchase_date = item.last_purchase_line_id.date_order
-            item.last_purchase_supplier_id = item.last_purchase_line_id.partner_id
-            item.last_purchase_currency_id = item.last_purchase_line_id.currency_id
+            po_line = item.last_purchase_line_id
+            po_line_uom = po_line.product_uom
+            item.last_purchase_price = (
+                po_line_uom._compute_price(po_line.price_unit, item.uom_po_id,)
+                if po_line_uom
+                else po_line.price_unit
+            )
+            item.last_purchase_date = po_line.date_order
+            item.last_purchase_supplier_id = po_line.partner_id
+            item.last_purchase_currency_id = po_line.currency_id
 
     @api.depends("last_purchase_line_id", "last_purchase_currency_id")
     def _compute_show_last_purchase_price_currency(self):

--- a/purchase_last_price_info/models/product_template.py
+++ b/purchase_last_price_info/models/product_template.py
@@ -52,7 +52,13 @@ class ProductTemplate(models.Model):
     @api.depends("last_purchase_line_id")
     def _compute_last_purchase_line_id_info(self):
         for item in self:
-            item.last_purchase_price = item.last_purchase_line_id.price_unit
-            item.last_purchase_date = item.last_purchase_line_id.date_order
-            item.last_purchase_supplier_id = item.last_purchase_line_id.partner_id
-            item.last_purchase_currency_id = item.last_purchase_line_id.currency_id
+            po_line = item.last_purchase_line_id
+            po_line_uom = po_line.product_uom
+            item.last_purchase_price = (
+                po_line_uom._compute_price(po_line.price_unit, item.uom_po_id,)
+                if po_line_uom
+                else po_line.price_unit
+            )
+            item.last_purchase_date = po_line.date_order
+            item.last_purchase_supplier_id = po_line.partner_id
+            item.last_purchase_currency_id = po_line.currency_id


### PR DESCRIPTION
Before this PR, if you purchased for example a **dozen** of units at 1200, you would have 1200 as last purchase price. Even if the product purchase UoM was unit.
After this PR, the purchase last price of the product will be 100. As we purchased 12 units for a total of 1200. So the last purchase price is converted between the actual purchase UoM and the product purchase UoM.

I can forward it to 14.0 if accepted.

@LoisRForgeFlow 