### PR TITLE
[FIX] Adding tags to unittests for purchase_deposit and purchase_order_line_sequence

### DIFF
--- a/purchase_deposit/tests/test_purchase_deposit.py
+++ b/purchase_deposit/tests/test_purchase_deposit.py
@@ -4,9 +4,11 @@
 
 from odoo import fields
 from odoo.exceptions import UserError
+from odoo.tests import tagged
 from odoo.tests.common import Form, TransactionCase
 
 
+@tagged("post_install", "-at_install")
 class TestPurchaseDeposit(TransactionCase):
     def setUp(self):
         super(TestPurchaseDeposit, self).setUp()

--- a/purchase_order_line_sequence/tests/test_po_lines_sequence.py
+++ b/purchase_order_line_sequence/tests/test_po_lines_sequence.py
@@ -5,10 +5,11 @@
 
 from datetime import datetime
 
-from odoo.tests import common
+from odoo.tests import common, tagged
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
 
+@tagged('post_install', '-at_install')
 class TestPurchaseOrder(common.TransactionCase):
     def setUp(self):
         super(TestPurchaseOrder, self).setUp()


### PR DESCRIPTION
After this change the tests will also run successful
If you do only
`odoo -i purchase_deposit --stop-after-init --test-enable`
or
`odoo -i purchase_order_line_sequence --stop-after-init --test-enable`

Now they fail because of missing account.journal entries

This was also done for https://github.com/OCA/contract/pull/876