### PR TITLE
[14.0][FIX] sale_purchase_force_vendor: Display the vendor_id field only 1 time so that it is always displayed and apply the correct domain in both use cases

### DIFF
--- a/sale_purchase_force_vendor/__manifest__.py
+++ b/sale_purchase_force_vendor/__manifest__.py
@@ -7,7 +7,7 @@
     "website": "https://github.com/OCA/purchase-workflow",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["sale_purchase_stock"],
+    "depends": ["sale_purchase_stock", "web_domain_field"],
     "installable": True,
     "data": [
         "views/res_config_settings_view.xml",

--- a/sale_purchase_force_vendor/tests/test_sale_purchase_force_vendor.py
+++ b/sale_purchase_force_vendor/tests/test_sale_purchase_force_vendor.py
@@ -1,18 +1,32 @@
 # Copyright 2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import json
+
 from .common import TestSalePurchaseForceVendorBase
 
 
 class TestSalePurchaseForceVendor(TestSalePurchaseForceVendorBase):
     def test_misc(self):
         self.sale_order.action_confirm()
-        self.assertNotIn(self.partner, self.sale_order.order_line.allowed_vendor_ids)
-        self.assertIn(self.vendor_a, self.sale_order.order_line.allowed_vendor_ids)
-        self.assertIn(self.vendor_b, self.sale_order.order_line.allowed_vendor_ids)
         purchase_orders = self.sale_order._get_purchase_orders()
         self.assertEqual(len(purchase_orders), 1)
         self.assertEqual(purchase_orders.partner_id, self.vendor_b)
         self.assertEqual(len(self.product_a.seller_ids), 2)
         self.assertNotIn(self.vendor_a, self.product_b.seller_ids.mapped("name"))
         self.assertIn(self.vendor_b, self.product_b.seller_ids.mapped("name"))
+
+    def test_misc_force_vendor_restrict(self):
+        self.env.company.sale_purchase_force_vendor_restrict = True
+        self.sale_order.action_confirm()
+        line_0 = self.sale_order.order_line[0]
+        partners = self.env["res.partner"].search(json.loads(line_0.vendor_id_domain))
+        self.assertNotIn(self.partner, partners)
+        self.assertIn(self.vendor_a, partners)
+        self.assertIn(self.vendor_b, partners)
+
+    def test_misc_not_force_vendor_restrict(self):
+        self.env.company.sale_purchase_force_vendor_restrict = False
+        self.sale_order.action_confirm()
+        line_0 = self.sale_order.order_line[0]
+        self.assertEqual(json.loads(line_0.vendor_id_domain), [])

--- a/sale_purchase_force_vendor/views/sale_order_view.xml
+++ b/sale_purchase_force_vendor/views/sale_order_view.xml
@@ -12,33 +12,22 @@
                 expr="//field[@name='order_line']/tree/field[@name='price_unit']"
                 position="before"
             >
-                <field name="allowed_vendor_ids" invisible="1" />
+                <field name="vendor_id_domain" invisible="1" />
                 <field
                     name="vendor_id"
-                    attrs="{'column_invisible': [('parent.sale_purchase_force_vendor_restrict', '=', False)]}"
-                    domain="[('id','in', allowed_vendor_ids)]"
+                    domain="vendor_id_domain"
                     options='{"no_create": True}'
-                />
-                <field
-                    name="vendor_id"
-                    attrs="{'column_invisible': [('parent.sale_purchase_force_vendor_restrict', '=', True)]}"
-                    options='{"no_create": True}'
+                    optional="hide"
                 />
            </xpath>
            <xpath
                 expr="//field[@name='order_line']/form/group/group/field[@name='price_unit']"
                 position="before"
             >
-                <field name="allowed_vendor_ids" invisible="1" />
+            <field name="vendor_id_domain" invisible="1" />
                 <field
                     name="vendor_id"
-                    attrs="{'invisible': [('parent.sale_purchase_force_vendor_restrict', '=', False)]}"
-                    domain="[('id','in', allowed_vendor_ids)]"
-                    options='{"no_create": True}'
-                />
-                <field
-                    name="vendor_id"
-                    attrs="{'invisible': [('parent.sale_purchase_force_vendor_restrict', '=', True)]}"
+                    domain="vendor_id_domain"
                     options='{"no_create": True}'
                 />
            </xpath>


### PR DESCRIPTION
Display the `vendor_id` field only 1 time so that it is always displayed and apply the correct domain in both use cases

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT39679