### PR TITLE
[13.0][FIX] purchase_blanket_order: Set force_save="1" to Order Lines to prevent inconsistencies

### DIFF
--- a/purchase_blanket_order/views/purchase_blanket_order_views.xml
+++ b/purchase_blanket_order/views/purchase_blanket_order_views.xml
@@ -132,6 +132,7 @@
                         <page string="Order Lines">
                             <field
                                 name="line_ids"
+                                force_save="1"
                                 attrs="{'readonly': [('state', 'in', ('done','expired'))]}"
                             >
                                 <tree editable="bottom">


### PR DESCRIPTION
Set `force_save="1"` to Order Lines to prevent inconsistencies

**Before**
![antes](https://user-images.githubusercontent.com/4117568/193017474-42f03556-4e47-48a2-b7be-35a59915cf3a.gif)

**After**
![despues](https://user-images.githubusercontent.com/4117568/193017483-8fa0257f-f457-41fa-9d66-1a11a5daaedc.gif)

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT39646