### PR TITLE
[14.0] purchase_request consider so origin

### DIFF
--- a/purchase_request/models/__init__.py
+++ b/purchase_request/models/__init__.py
@@ -6,6 +6,7 @@ from . import purchase_request
 from . import purchase_request_line
 from . import stock_rule
 from . import product_template
+from . import product_product
 from . import purchase_order
 from . import stock_move
 from . import stock_move_line

--- a/purchase_request/models/orderpoint.py
+++ b/purchase_request/models/orderpoint.py
@@ -9,14 +9,15 @@ class Orderpoint(models.Model):
 
     def _quantity_in_progress(self):
         res = super(Orderpoint, self)._quantity_in_progress()
-        for prline in self.env["purchase.request.line"].search(
-            [
-                ("request_id.state", "in", ("draft", "approved", "to_approve")),
-                ("orderpoint_id", "in", self.ids),
-                ("purchase_state", "=", False),
-            ]
-        ):
-            res[prline.orderpoint_id.id] += prline.product_uom_id._compute_quantity(
-                prline.product_qty, prline.orderpoint_id.product_uom, round=False
-            )
+        for orderpoint in self:
+            for prline in self.env["purchase.request.line"].search(
+                [
+                    ("request_id.state", "in", ("draft", "approved", "to_approve")),
+                    ("product_id", "=", orderpoint.product_id.id),
+                    ("purchase_state", "=", False),
+                ]
+            ):
+                res[orderpoint.id] += prline.product_uom_id._compute_quantity(
+                    prline.product_qty, orderpoint.product_uom, round=False
+                )
         return res

--- a/purchase_request/models/orderpoint.py
+++ b/purchase_request/models/orderpoint.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2019 ForgeFlow, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 
-from odoo import models
+from odoo import api, models
 
 
 class Orderpoint(models.Model):
@@ -21,3 +21,13 @@ class Orderpoint(models.Model):
                     prline.product_qty, orderpoint.product_uom, round=False
                 )
         return res
+
+    @api.depends(
+        "product_id.purchase_request_line_ids.product_qty",
+        "product_id.purchase_request_line_ids.purchase_state",
+        "product_id.purchase_request_line_ids.request_id.state",
+        "product_id.purchase_request_line_ids.product_uom_id",
+        "product_id.purchase_request_line_ids",
+    )
+    def _compute_qty(self):
+        return super()._compute_qty()

--- a/purchase_request/models/product_product.py
+++ b/purchase_request/models/product_product.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    purchase_request_line_ids = fields.One2many("purchase.request.line", "product_id")

--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -75,7 +75,7 @@ class StockMove(models.Model):
     def _compute_purchase_request_ids(self):
         for rec in self:
             rec.purchase_request_ids = rec.purchase_request_allocation_ids.mapped(
-                "purchase_request_id"
+                "purchase_request_line_id.request_id"
             )
 
     def _merge_moves_fields(self):


### PR DESCRIPTION
When a `stock.rule` is configured as `mts_else_mto`, we might have
`purchase.request` created with `SOXXXXXX` as origin.
This commit includes those `purchase.request` in the
`stock.warehouse.orderpoint`'s `qty_forecast` compute method.

Also, as we introduced fields in the _compute_qty method, we need to add them
in its `@api.depends`