### PR TITLE
[14.0][IMP] purchase_triple_discount: Display discount2 and discount3 field…

### DIFF
--- a/purchase_triple_discount/__manifest__.py
+++ b/purchase_triple_discount/__manifest__.py
@@ -13,6 +13,7 @@
         "account_invoice_triple_discount",
     ],
     "data": [
+        "views/purchase_order_report.xml",
         "views/product_supplierinfo_view.xml",
         "views/purchase_view.xml",
         "views/res_partner_view.xml",

--- a/purchase_triple_discount/views/purchase_order_report.xml
+++ b/purchase_triple_discount/views/purchase_order_report.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="report_purchaseorder_document_triple_discount"
+        inherit_id="purchase_discount.report_purchaseorder_document"
+    >
+        <xpath expr="//table/thead/tr/th[@name='th_discount']" position="after">
+            <th name="th_discount2" class="text-right">
+                <strong>Disc. 2 (%)</strong>
+            </th>
+           <th name="th_discount3" class="text-right">
+                <strong>Disc. 3 (%)</strong>
+            </th>
+        </xpath>
+        <xpath expr="//table/tbody//tr//td[@name='td_discount']" position="after">
+            <td name="td_discount2" class="text-right">
+                <span t-field="line.discount2" />
+            </td>
+            <td name="td_discount3" class="text-right">
+                <span t-field="line.discount3" />
+            </td>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
…s on purchase report

Discount 2 and discount 3 fields were not displayed on purchase report, which could create confusion when visualizing the report.