### PR TITLE
[13][ADD] purchase_origin_link: add a link to the Source Document

### DIFF
--- a/purchase_origin_link/__init__.py
+++ b/purchase_origin_link/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_origin_link/__manifest__.py
+++ b/purchase_origin_link/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Purchase Order Origin Link",
+    "summary": "Add clickable link in purchase source document.",
+    "version": "13.0.1.0.0",
+    "license": "LGPL-3",
+    "website": "https://github.com/OCA/purchase-workflow",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Purchase",
+    "depends": ["purchase"],
+    "data": ["views/purchase_views.xml"],
+    "installable": True,
+    "maintainers": ["JudithAforgeFlow"],
+}

--- a/purchase_origin_link/models/__init__.py
+++ b/purchase_origin_link/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase

--- a/purchase_origin_link/models/purchase.py
+++ b/purchase_origin_link/models/purchase.py
@@ -1,0 +1,27 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, fields, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    origin_reference = fields.Reference(
+        selection="_selection_reference_model",
+        compute="_compute_source_doc_ref",
+        readonly=True,
+        string="Source Document",
+    )
+
+    def _selection_reference_model(self):
+        return []
+
+    @api.model
+    def _get_depends_compute_source_doc_ref(self):
+        return ["origin"]
+
+    @api.depends(lambda x: x._get_depends_compute_source_doc_ref())
+    def _compute_source_doc_ref(self):
+        for rec in self:
+            rec.origin_reference = False

--- a/purchase_origin_link/readme/CONTRIBUTORS.rst
+++ b/purchase_origin_link/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Judith Almoño <judith.almono@forgeflow.com>

--- a/purchase_origin_link/readme/DESCRIPTION.rst
+++ b/purchase_origin_link/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module adds a clickable link to the "Source Document" in Purchase Orders.
+This module does nothing by itself, it needs some submodules to compute links to other documents.

--- a/purchase_origin_link/views/purchase_views.xml
+++ b/purchase_origin_link/views/purchase_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <record id="purchase_order_form" model="ir.ui.view">
+            <field
+                name="name"
+            >purchase.order.form (purchase_order_reference_link)</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_form" />
+            <field name="arch" type="xml">
+                <field name="origin" position="after">
+                    <field
+                        name="origin_reference"
+                        attrs="{'invisible': [('origin_reference', '=', False)]}"
+                    />
+                </field>
+                <field name="origin" position="attributes">
+                    <attribute
+                        name="attrs"
+                    >{'invisible': ['|',('origin', '=', False),('origin_reference', '!=', False)]}</attribute>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/setup/purchase_origin_link/odoo/addons/purchase_origin_link
+++ b/setup/purchase_origin_link/odoo/addons/purchase_origin_link
@@ -1,0 +1,1 @@
+../../../../purchase_origin_link

--- a/setup/purchase_origin_link/setup.py
+++ b/setup/purchase_origin_link/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module adds a clickable link to the "Source Document" in Purchase Orders.

CC @Forgeflow