### PR TITLE
[13.0][ADD] purchase_origin_link_sale: add a link to the Sale Order

### DIFF
--- a/purchase_origin_link_sale/__init__.py
+++ b/purchase_origin_link_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_origin_link_sale/__manifest__.py
+++ b/purchase_origin_link_sale/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Purchase Order Origin Link Sale",
+    "summary": "Add clickable link to the Sale Order in purchase source document.",
+    "version": "13.0.1.0.0",
+    "license": "LGPL-3",
+    "website": "https://github.com/OCA/purchase-workflow",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Purchase",
+    "depends": ["purchase_origin_link", "sale"],
+    "data": [],
+    "installable": True,
+    "maintainers": ["JudithAforgeFlow"],
+    "auto_install": True,
+}

--- a/purchase_origin_link_sale/models/__init__.py
+++ b/purchase_origin_link_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase

--- a/purchase_origin_link_sale/models/purchase.py
+++ b/purchase_origin_link_sale/models/purchase.py
@@ -1,0 +1,20 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def _selection_reference_model(self):
+        res = super()._selection_reference_model() + [("sale.order", "Sale Order")]
+        return res
+
+    @api.depends(lambda x: x._get_depends_compute_source_doc_ref())
+    def _compute_source_doc_ref(self):
+        super()._compute_source_doc_ref()
+        for rec in self:
+            so = self.env["sale.order"].search([("name", "like", rec.origin)])
+            if len(so) == 1:
+                rec.origin_reference = "{},{}".format(so._name, so.id or 0)

--- a/purchase_origin_link_sale/readme/CONTRIBUTORS.rst
+++ b/purchase_origin_link_sale/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Judith Almoño <judith.almono@forgeflow.com>

--- a/purchase_origin_link_sale/readme/DESCRIPTION.rst
+++ b/purchase_origin_link_sale/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module adds a clickable link to Sale Orders on the Source Document of Purchase Orders. It depends on the base module: "purchase_origin_link"

--- a/purchase_origin_link_sale/tests/__init__.py
+++ b/purchase_origin_link_sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_purchase_origin_link_sale

--- a/purchase_origin_link_sale/tests/test_purchase_origin_link_sale.py
+++ b/purchase_origin_link_sale/tests/test_purchase_origin_link_sale.py
@@ -1,0 +1,41 @@
+from odoo.tests.common import SavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPurchaseOriginLinkSale(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestPurchaseOriginLinkSale, cls).setUpClass()
+        vendor = cls.env["res.partner"].create({"name": "Partner #2"})
+        supplierinfo = cls.env["product.supplierinfo"].create({"name": vendor.id})
+        cls.product = cls.env["product.product"].create(
+            {"name": "Product Test", "seller_ids": [(6, 0, [supplierinfo.id])]}
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Partner #1"})
+
+    def test_01_purchase_origin_link_sale(self):
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "price_unit": self.product.list_price,
+                            "name": self.product.name,
+                        },
+                    )
+                ],
+            }
+        )
+        sale_order.with_context(test_enabled=True).action_confirm()
+
+        vals = {"partner_id": self.partner.id, "origin": str(sale_order.name)}
+
+        purchase_order = self.env["purchase.order"].create(vals)
+
+        self.assertTrue(type(purchase_order.origin_reference), self.env["sale.order"])
+        self.assertTrue(purchase_order.origin_reference, sale_order.id)

--- a/setup/purchase_origin_link_sale/odoo/addons/purchase_origin_link_sale
+++ b/setup/purchase_origin_link_sale/odoo/addons/purchase_origin_link_sale
@@ -1,0 +1,1 @@
+../../../../purchase_origin_link_sale

--- a/setup/purchase_origin_link_sale/setup.py
+++ b/setup/purchase_origin_link_sale/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module adds a clickable link to Sale Orders on the Source Document of Purchase Orders

CC @ForgeFlow