### PR TITLE
[14.0] Allow to hook to PR picking confirm message

### DIFF
--- a/purchase_request/models/stock_picking.py
+++ b/purchase_request/models/stock_picking.py
@@ -32,8 +32,7 @@ class StockPicking(models.Model):
         message += "</ul>"
         return message
 
-    def _action_done(self):
-        super(StockPicking, self)._action_done()
+    def _purchase_request_picking_confirm_message(self):
         request_obj = self.env["purchase.request"]
         for picking in self:
             requests_dict = {}
@@ -64,3 +63,7 @@ class StockPicking(models.Model):
                         body=message,
                         author_id=self.env.user.partner_id.id,
                     )
+
+    def _action_done(self):
+        super(StockPicking, self)._action_done()
+        self._purchase_request_picking_confirm_message()


### PR DESCRIPTION
To be able to extend or disable a purchase request picking confirmation message needs a separate function.