### PR TITLE
[FIX] purchase_analytic_global: saving the purchase mustn't remove the analytic accounts on lines when lines have different analytic accounts

### DIFF
--- a/purchase_analytic_global/models/purchase.py
+++ b/purchase_analytic_global/models/purchase.py
@@ -27,4 +27,5 @@ class PurchaseOrder(models.Model):
 
     def _inverse_analytic_account(self):
         for rec in self:
-            rec.order_line.account_analytic_id = rec.account_analytic_id
+            if rec.account_analytic_id:
+                rec.order_line.account_analytic_id = rec.account_analytic_id


### PR DESCRIPTION
If different analytic accounts are chosen on order lines when the save button is clicked they are removed -> this PR fixes this