### PR TITLE
[14.0][FIX]product_form_purchase_link: replace purchased_product_qty by purchase_lines_count

### DIFF
--- a/product_form_purchase_link/__init__.py
+++ b/product_form_purchase_link/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_form_purchase_link/models/__init__.py
+++ b/product_form_purchase_link/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_product
+from . import product_template

--- a/product_form_purchase_link/models/product_product.py
+++ b/product_form_purchase_link/models/product_product.py
@@ -1,0 +1,30 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    purchase_lines_count = fields.Integer(
+        compute="_compute_purchase_lines_count", string="Purchased"
+    )
+
+    def _compute_purchase_lines_count(self):
+        if not self.user_has_groups("purchase.group_purchase_user") or not self.ids:
+            self.purchase_lines_count = 0.0
+            return
+        domain = [
+            ("state", "in", ["purchase", "done"]),
+            ("product_id", "in", self.ids),
+            ("company_id", "in", self.env.companies.ids),
+        ]
+        purchase_line_data = self.env["purchase.order.line"].read_group(
+            domain, ["product_id"], ["product_id"]
+        )
+        mapped_data = {
+            m["product_id"][0]: m["product_id_count"] for m in purchase_line_data
+        }
+        for product in self:
+            product.purchase_lines_count = mapped_data.get(product.id, 0)

--- a/product_form_purchase_link/models/product_template.py
+++ b/product_form_purchase_link/models/product_template.py
@@ -1,0 +1,26 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    purchase_lines_count = fields.Float(
+        compute="_compute_purchase_lines_count", string="Sold"
+    )
+
+    @api.depends("product_variant_ids.purchase_lines_count")
+    def _compute_purchase_lines_count(self):
+        for product in self:
+            product.purchase_lines_count = sum(
+                [
+                    p.purchase_lines_count
+                    for p in product.with_context(active_test=False).product_variant_ids
+                ]
+            )

--- a/product_form_purchase_link/views/product_product.xml
+++ b/product_form_purchase_link/views/product_product.xml
@@ -7,6 +7,7 @@
             name="name"
         >product.product.purchase.button.inherit (in product_form_purchase_link)</field>
         <field name="model">product.product</field>
+        <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]" />
         <field
             name="inherit_id"
             ref="purchase.product_normal_form_view_inherit_purchase"
@@ -21,7 +22,7 @@
                 >
                     <field
                         string="Purchases"
-                        name="purchased_product_qty"
+                        name="purchase_lines_count"
                         widget="statinfo"
                     />
                 </button>

--- a/product_form_purchase_link/views/product_template.xml
+++ b/product_form_purchase_link/views/product_template.xml
@@ -7,6 +7,7 @@
             name="name"
         >product.template.purchase.button.inherit (in product_form_purchase_link)</field>
         <field name="model">product.template</field>
+        <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]" />
         <field
             name="inherit_id"
             ref="purchase.view_product_template_purchase_buttons_from"
@@ -21,7 +22,7 @@
                 >
                     <field
                         string="Purchases"
-                        name="purchased_product_qty"
+                        name="purchase_lines_count"
                         widget="statinfo"
                     />
                 </button>


### PR DESCRIPTION
Fixes same issue as in https://github.com/OCA/sale-workflow/pull/2120/

The purchase_lines_count field calculates the sum of the "product_uom_qty" of that product for each purchase line instead of the number of purchase lines.

Now, the number in the button shows the correct number of purchase lines.