### PR TITLE
purchase_request: fix cancel purchase_request_line

### DIFF
--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -298,10 +298,20 @@ class PurchaseRequestLine(models.Model):
 
     def do_cancel(self):
         """Actions to perform when cancelling a purchase request line."""
+        # Changing the procure method, since related moves should pick
+        # goods from stock after request lines are cancelled.
+        for line in self:
+            move_dest_ids = line.move_dest_ids
+            move_dest_ids.write({"procure_method": "make_to_stock"})
+            move_dest_ids._recompute_state()
         self.write({"cancelled": True})
 
     def do_uncancel(self):
         """Actions to perform when uncancelling a purchase request line."""
+        for line in self:
+            move_dest_ids = line.move_dest_ids
+            move_dest_ids.write({"procure_method": "make_to_order"})
+            move_dest_ids._recompute_state()
         self.write({"cancelled": False})
 
     def write(self, vals):


### PR DESCRIPTION
With odoo core, when a purchase order line is cancelled, the `move_dest_ids`'s procure methods are updated, as seen here https://github.com/odoo/odoo/blob/14.0/addons/purchase_stock/models/purchase.py#L109-L110

With purchase_request, we should have the same behavior, if a purchase_request_line related to stock_moves is cancelled, those moves shouldn't be `Waiting for another operation anymore`.