### PR TITLE
[FIX] purchase_order_approved: Allow to receive products when in 'Purchase' state

### DIFF
--- a/purchase_order_approved/views/purchase_order_view.xml
+++ b/purchase_order_approved/views/purchase_order_view.xml
@@ -26,7 +26,7 @@
             <field name="order_line" position="attributes">
                 <attribute
                     name="attrs"
-                >{'readonly': [('state', 'in', ('purchase', 'done', 'cancel', 'approved'))]}</attribute>
+                >{'readonly': [('state', 'in', ('done', 'cancel', 'approved'))]}</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
…chase' state

In core module, service products can be received by editing the received quantity on 'purchase' order state. This restablishes that behaviour