### PR TITLE
[14.0] [FIX] product_form_purchase_link: purchase_lines_count label

### DIFF
--- a/product_form_purchase_link/models/product_template.py
+++ b/product_form_purchase_link/models/product_template.py
@@ -12,7 +12,7 @@ class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     purchase_lines_count = fields.Float(
-        compute="_compute_purchase_lines_count", string="Sold"
+        compute="_compute_purchase_lines_count", string="Purchased"
     )
 
     @api.depends("product_variant_ids.purchase_lines_count")


### PR DESCRIPTION
I think the label is wrong and it's raising a lot of warnings like `Two fields (sales_count, purchase_lines_count) of [] have the same label: Sold.`
