### PR TITLE
[14.0][FIX] purchase_order_general_discount: Squash warning - button missing title

### DIFF
--- a/purchase_order_general_discount/views/purchase_order_view.xml
+++ b/purchase_order_general_discount/views/purchase_order_view.xml
@@ -17,6 +17,7 @@
                         name="action_update_general_discount"
                         class="oe_link oe_edit_only fa fa-refresh"
                         type="object"
+                        title="Update general discounts"
                         help="Update general discounts"
                     />
                 </div>


### PR DESCRIPTION
Small patch to fix a warning caused by a missing title attribute
```
View name: purchase.order form
Error context:
 view: ir.ui.view(2658,)
 xmlid: purchase_order_form
 view.model: purchase.order
 view.parent: ir.ui.view(2088,)
 file: /opt/odoo/auto/addons/purchase_order_general_discount/views/purchase_order_view.xml
```