### PR TITLE
[14.0][IMP] purchase_force_invoiced: Add filter by company to avoid errors with inconsistent data

### DIFF
--- a/purchase_force_invoiced/tests/test_purchase_force_invoiced.py
+++ b/purchase_force_invoiced/tests/test_purchase_force_invoiced.py
@@ -19,7 +19,8 @@ class TestPurchaseForceInvoiced(TransactionCase):
                     "user_type_id",
                     "=",
                     self.env.ref("account.data_account_type_revenue").id,
-                )
+                ),
+                ("company_id", "=", self.env.company.id),
             ],
             limit=1,
         )

--- a/purchase_force_invoiced/tests/test_purchase_force_invoiced.py
+++ b/purchase_force_invoiced/tests/test_purchase_force_invoiced.py
@@ -8,7 +8,7 @@ from odoo.tests.common import TransactionCase
 
 class TestPurchaseForceInvoiced(TransactionCase):
     def setUp(self):
-        super(TestPurchaseForceInvoiced, self).setUp()
+        super().setUp()
         self.purchase_order_model = self.env["purchase.order"]
         self.purchase_order_line_model = self.env["purchase.order.line"]
         self.account_invoice_model = self.env["account.move"]
@@ -108,27 +108,27 @@ class TestPurchaseForceInvoiced(TransactionCase):
         pol1.qty_received = 1
         pol2.qty_received = 2
 
-        self.assertEquals(
+        self.assertEqual(
             po.invoice_status, "to invoice", "The invoice status should be To Invoice"
         )
 
         invoice = self._create_invoice_from_purchase(po)
         self.create_invoice_line(pol1, invoice)
         self.create_invoice_line(pol2, invoice)
-        self.assertEquals(
+        self.assertEqual(
             po.invoice_status, "invoiced", "The invoice status should be Invoiced"
         )
 
         # Reduce the invoiced qty
         for line in pol2.invoice_lines:
             line.with_context(check_move_validity=False).unlink()
-        self.assertEquals(
+        self.assertEqual(
             po.invoice_status, "to invoice", "The invoice status should be To Invoice"
         )
         # We set the force invoiced.
         po.button_done()
         po.force_invoiced = True
-        self.assertEquals(
+        self.assertEqual(
             po.invoice_status, "invoiced", "The invoice status should be Invoiced"
         )
         invoice = self._create_invoice_from_purchase(po)
@@ -136,7 +136,7 @@ class TestPurchaseForceInvoiced(TransactionCase):
         self.assertEqual(invoice_qty, 0.0)
         # We remove the force invoiced.
         po.force_invoiced = False
-        self.assertEquals(
+        self.assertEqual(
             po.invoice_status, "to invoice", "The invoice status should be To Invoice"
         )
         self.create_invoice_line(pol2, invoice)


### PR DESCRIPTION
Changes done:
- [x] Change assertEquals to assertEqual to prevent DeprecationWarning
- [x] Add filter by company to avoid errors with inconsistent data

@Tecnativa