### PR TITLE
[14.0][FIX] product_form_purchase_link squash warning duplicate name

### DIFF
--- a/product_form_purchase_link/models/product_product.py
+++ b/product_form_purchase_link/models/product_product.py
@@ -8,7 +8,7 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     purchase_lines_count = fields.Integer(
-        compute="_compute_purchase_lines_count", string="Purchased"
+        compute="_compute_purchase_lines_count", string="Times purchased"
     )
 
     def _compute_purchase_lines_count(self):

--- a/product_form_purchase_link/models/product_template.py
+++ b/product_form_purchase_link/models/product_template.py
@@ -12,7 +12,7 @@ class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     purchase_lines_count = fields.Float(
-        compute="_compute_purchase_lines_count", string="Purchased"
+        compute="_compute_purchase_lines_count", string="Times purchased"
     )
 
     @api.depends("product_variant_ids.purchase_lines_count")


### PR DESCRIPTION
fixed warnings about duplicate names

```
odoo.addons.base.models.ir_model: Two fields (purchase_lines_count, purchased_product_qty) of product.product() have the same label: Purchased. 
odoo.addons.base.models.ir_model: Two fields (purchase_lines_count, purchased_product_qty) of product.template() have the same label: Purchased.
```

see also #1649