### PR TITLE
[FIX] purchase_force_invoiced - state don't change when force_invoiced field is selected

### DIFF
--- a/purchase_force_invoiced/model/purchase.py
+++ b/purchase_force_invoiced/model/purchase.py
@@ -21,6 +21,6 @@ class PurchaseOrder(models.Model):
     def _get_invoiced(self):
         super(PurchaseOrder, self)._get_invoiced()
         for order in self.filtered(
-            lambda po: po.force_invoiced and po.invoice_status == "to invoice"
+            lambda po: po.force_invoiced and po.invoice_status in ("to invoice", "no")
         ):
             order.invoice_status = "invoiced"

--- a/purchase_force_invoiced/readme/CONTRIBUTORS.rst
+++ b/purchase_force_invoiced/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Jordi Ballester <jordi.ballester@eficent.com>
 * Rattapong Chokmasermkul <rattapongc@ecosoft.co.th>
+* Kilian Niubo <kniubo@nuobit.com>


### PR DESCRIPTION
It seems to be a bug since the invoice_status 'nothing to bill' does not change when force_invoice is checked.

Please, can you review it @eantones 