### PR TITLE
[15.0][IMP] purchase_tier_validation: Do not merge purchase orders under validation

### DIFF
--- a/purchase_tier_validation/models/purchase_order.py
+++ b/purchase_tier_validation/models/purchase_order.py
@@ -11,3 +11,9 @@ class PurchaseOrder(models.Model):
     _state_to = ["purchase", "approved"]
 
     _tier_validation_manual_config = False
+
+    # Do not merge purchase orders under validation
+    def _make_po_get_domain(self, company_id, values, partner):
+        domain = super()._make_po_get_domain(company_id, values, partner)
+        domain += (('reviewer_ids', '=', False), )
+        return domain


### PR DESCRIPTION
Before this PR.
When an PO is in validation, and a new PO for the same supplier was made. The original PO could be updaten (merged) even when one user already had given an approval in a sequential approval process..

This PR prevents the purchase order to be merged with another, when it is in an validation process.