### PR TITLE
[14.0][FIX] purchase_*_cancel_confirm: Add missing ir.config_parameter on tests

### DIFF
--- a/purchase_cancel_confirm/tests/test_purchase_cancel_confirm.py
+++ b/purchase_cancel_confirm/tests/test_purchase_cancel_confirm.py
@@ -7,6 +7,9 @@ class TestPurchaseCancelConfirm(TransactionCase):
     def setUp(self):
         super(TestPurchaseCancelConfirm, self).setUp()
         self.purchase_order_obj = self.env["purchase.order"]
+        self.env["ir.config_parameter"].sudo().set_param(
+            "purchase.order.cancel_confirm_disable", "False"
+        )
         self.purchase_order = self.purchase_order_obj.create(
             {
                 "partner_id": self.env.ref("base.res_partner_12").id,

--- a/purchase_request_cancel_confirm/tests/test_purchase_request_cancel_confirm.py
+++ b/purchase_request_cancel_confirm/tests/test_purchase_request_cancel_confirm.py
@@ -8,6 +8,9 @@ class TestPurchaseRequestCancelConfirm(TransactionCase):
     def setUp(self):
         super(TestPurchaseRequestCancelConfirm, self).setUp()
         self.purchase_request_obj = self.env["purchase.request"]
+        self.env["ir.config_parameter"].sudo().set_param(
+            "purchase.request.cancel_confirm_disable", "False"
+        )
         self.purchase_request_line_obj = self.env["purchase.request.line"]
         vals = {
             "picking_type_id": self.env.ref("stock.picking_type_in").id,


### PR DESCRIPTION
Fixing test due to new improvements on base_cancel_confirm module https://github.com/OCA/server-ux/pull/497

CC @ForgeFlow @francesco-ooops