### PR TITLE
[13.0][IMP] product_form_purchase_link: do not filter out rfq

### DIFF
--- a/product_form_purchase_link/views/purchase_order_line.xml
+++ b/product_form_purchase_link/views/purchase_order_line.xml
@@ -2,11 +2,31 @@
 <!-- Copyright 2019 ACSONE SA/NV
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-    <record model="ir.actions.act_window" id="action_purchase_line_product_tree">
-        <field name="context">{}</field>
+    <record id="purchase_order_line_search" model="ir.ui.view">
+        <field name="model">purchase.order.line</field>
         <field
-            name="domain"
-        >[('product_id.product_tmpl_id','in',active_ids), ('state', 'in', ['purchase', 'done'])]</field>
+            name="name"
+        >purchase.order.line.search (in product_form_purchase_link)</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_search" />
+        <field name="arch" type="xml">
+            <filter name="hide_cancelled" position="before">
+                <filter
+                    name="draft"
+                    string="RFQs"
+                    domain="[('state', 'in', ('draft', 'sent', 'to approve'))]"
+                />
+                <filter
+                    name="approved"
+                    string="Purchase Orders"
+                    domain="[('state', 'in', ('purchase', 'done'))]"
+                />
+                <separator />
+            </filter>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="action_purchase_line_product_tree">
+        <field name="context">{'search_default_approved':1}</field>
+        <field name="domain">[('product_id.product_tmpl_id','in',active_ids)]</field>
         <field name="name">Purchases</field>
         <field name="res_model">purchase.order.line</field>
         <field name="view_id" ref="purchase.purchase_order_line_tree" />
@@ -15,10 +35,8 @@
         model="ir.actions.act_window"
         id="action_purchase_line_product_product_tree"
     >
-        <field name="context">{}</field>
-        <field
-            name="domain"
-        >[('product_id','in',active_ids), ('state', 'in', ['purchase', 'done'])]</field>
+        <field name="context">{'search_default_approved':1}</field>
+        <field name="domain">[('product_id','in',active_ids)]</field>
         <field name="name">Purchases</field>
         <field name="res_model">purchase.order.line</field>
         <field name="view_id" ref="purchase.purchase_order_line_tree" />


### PR DESCRIPTION
This PR proposes to remove the filtering of the PO Lines based on the state as users may want to also see RFQs. To not modify the current behavior a default filter is added.

Similar proposal as in https://github.com/OCA/sale-workflow/pull/2301