### PR TITLE
15.0 fix default note purchase order

### DIFF
--- a/purchase_default_terms_conditions/models/purchase.py
+++ b/purchase_default_terms_conditions/models/purchase.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
+from odoo.tools import is_html_empty
 
 
 class PurchaseOrder(models.Model):
@@ -10,7 +11,7 @@ class PurchaseOrder(models.Model):
 
     @api.onchange("partner_id", "company_id")
     def onchange_partner_id(self):
-        if self.partner_id.purchase_note:
+        if not is_html_empty(self.partner_id.purchase_note):
             self.notes = self.partner_id.purchase_note
         elif (
             self.env["ir.config_parameter"]


### PR DESCRIPTION
Adding check on function onchange_partner_id on model purchase.order: suppose we have defined a specific default_note on the partner and after deleted it: since the field is html, the <p><br/></p> value remains in the db, which affects the onchange, returning the <p><br/></p> on the purchase.order note.