### PR TITLE
[15.0] [FIX] `purchase_receipt_expectation_manual`: wizard lines overflow

### DIFF
--- a/purchase_receipt_expectation_manual/wizards/purchase_order_manual_receipt.xml
+++ b/purchase_receipt_expectation_manual/wizards/purchase_order_manual_receipt.xml
@@ -23,28 +23,26 @@
                         <field name="checks_result" invisible="1" />
                         <field name="checks_result_msg" nolabel="1" readonly="1" />
                     </div>
-                    <group name="lines">
-                        <field name="line_ids" nolabel="1">
-                            <tree editable="bottom">
-                                <field name="wizard_id" invisible="1" />
-                                <field name="purchase_order_id" invisible="1" />
-                                <field name="uom_category_id" invisible="1" />
-                                <field
-                                    name="purchase_line_id"
-                                    string="Line to receive"
-                                    domain="[('order_id', '=', purchase_order_id), ('feasible_for_manual_receipt', '=', True)]"
-                                />
-                                <field name="product_id" />
-                                <field name="qty" />
-                                <field
-                                    name="uom_id"
-                                    domain="[('category_id', '=', uom_category_id)]"
-                                />
-                                <field name="currency_id" invisible="1" />
-                                <field name="unit_price" />
-                            </tree>
-                        </field>
-                    </group>
+                    <field name="line_ids" nolabel="1">
+                        <tree editable="bottom">
+                            <field name="wizard_id" invisible="1" />
+                            <field name="purchase_order_id" invisible="1" />
+                            <field name="uom_category_id" invisible="1" />
+                            <field
+                                name="purchase_line_id"
+                                string="Line to receive"
+                                domain="[('order_id', '=', purchase_order_id), ('feasible_for_manual_receipt', '=', True)]"
+                            />
+                            <field name="product_id" />
+                            <field name="qty" />
+                            <field
+                                name="uom_id"
+                                domain="[('category_id', '=', uom_category_id)]"
+                            />
+                            <field name="currency_id" invisible="1" />
+                            <field name="unit_price" />
+                        </tree>
+                    </field>
                 </sheet>
                 <footer>
                     <button


### PR DESCRIPTION
**Before:**
![before](https://user-images.githubusercontent.com/1914185/210807869-a4bf8789-b541-4487-a918-91e40ebb221d.png)



**After:**
![after](https://user-images.githubusercontent.com/1914185/210807883-12a895d9-a5a7-4cc4-b195-8015197a971b.png)
