### PR TITLE
[15.0][FIX] purchase_request: analytic_tag widget many2many_tags

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -177,6 +177,7 @@
                                     <field
                                         name="analytic_tag_ids"
                                         groups="analytic.group_analytic_accounting"
+                                        widget="many2many_tags"
                                     />
                                     <field name="date_required" />
                                     <field name="estimated_cost" widget="monetary" />


### PR DESCRIPTION
Bug: Can't edit analytic tag in purchase request line (tree view)
Fix it by change field analytic_tag_ids to many2many_tags in line purchase request