### PR TITLE
[15.0][FIX] purchase_invoice_plan: full path with tree_view_ref

### DIFF
--- a/purchase_invoice_plan/views/purchase_view.xml
+++ b/purchase_invoice_plan/views/purchase_view.xml
@@ -103,7 +103,7 @@
                     />
                     <field
                         name="invoice_plan_ids"
-                        context="{'tree_view_ref': 'view_purchase_invoice_plan_tree'}"
+                        context="{'tree_view_ref': 'purchase_invoice_plan.view_purchase_invoice_plan_tree'}"
                         attrs="{'invisible': [('invoice_plan_ids', '=', [])]}"
                     />
                     <group class="oe_subtotal_footer oe_right">


### PR DESCRIPTION
[Small Fix]
Some module reference this module it can warning log

'tree_view_ref' requires a fully-qualified external id (got: 'view_purchase_invoice_plan_tree' for model purchase.invoice.plan). Please use the complete `module.view_id` form instead

