### PR TITLE
[14.0][FIX] purchase_request : supplier can be an individual

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -15,8 +15,6 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         comodel_name="res.partner",
         string="Supplier",
         required=True,
-        domain=[("is_company", "=", True)],
-        context={"res_partner_search_mode": "supplier", "default_is_company": True},
     )
     item_ids = fields.One2many(
         comodel_name="purchase.request.line.make.purchase.order.item",


### PR DESCRIPTION
After create PR, next step is creating RFQ.
But the problem is user can not select supplier as an individual partner.

![supplier_cant_be_individuals](https://user-images.githubusercontent.com/96042966/219598716-7e09c7de-ee0e-4b8a-a302-142d634c04b2.gif)

After fixed, when create RFQ, user can select supplier as an individual not only company.

![supplier_be_individuals](https://user-images.githubusercontent.com/96042966/219600202-bb584101-7218-41ff-b876-9ad7a9a67338.gif)

