### PR TITLE
[13.0][FIX] purchase_stock_price_unit_sync: Don't write on children SVLs

### DIFF
--- a/purchase_stock_price_unit_sync/models/purchase_order.py
+++ b/purchase_stock_price_unit_sync/models/purchase_order.py
@@ -32,7 +32,10 @@ class PurchaseOrderLine(models.Model):
                 bom_type="phantom",
             ):
                 continue
-            line.move_ids.mapped("stock_valuation_layer_ids").write(
+            line.move_ids.mapped("stock_valuation_layer_ids").filtered(
+                # Filter children SVLs (like landed cost)
+                lambda x: not x.stock_valuation_layer_id
+            ).write(
                 {
                     "unit_cost": line.with_context(
                         skip_stock_price_unit_sync=True


### PR DESCRIPTION
Steps to reproduce:

- Create a purchase order with an storable product and confirm it.
- Validate the reception picking.
- Create a landed cost linked to the reception picking and validate it.
- Now change the unit price in the purchase order.

Result: Both SVLs (stock valuation layers), the one for the reception, and the landed cost one, result overwritten with the new purchase unit price, while only the reception one should.

As the landed cost SVL is put as children (through the field `stock_valuation_layer_id`), we filter out these ones from the write.

@Tecnativa