### PR TITLE
[15.0][FIX] purchase_deposit: split function _prepare_advance_purchase_line for hook

### DIFF
--- a/purchase_deposit/wizard/purchase_make_invoice_advance.py
+++ b/purchase_deposit/wizard/purchase_make_invoice_advance.py
@@ -144,6 +144,19 @@ class PurchaseAdvancePaymentInv(models.TransientModel):
         )
         return invoice
 
+    def _prepare_advance_purchase_line(self, order, product, tax_ids, amount):
+        return {
+            "name": _("Advance: %s") % (time.strftime("%m %Y"),),
+            "price_unit": amount,
+            "product_qty": 0.0,
+            "order_id": order.id,
+            "product_uom": product.uom_id.id,
+            "product_id": product.id,
+            "taxes_id": [(6, 0, tax_ids)],
+            "date_planned": datetime.today().strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+            "is_deposit": True,
+        }
+
     def create_invoices(self):
         Purchase = self.env["purchase.order"]
         IrDefault = self.env["ir.default"].sudo()
@@ -190,21 +203,10 @@ class PurchaseAdvancePaymentInv(models.TransientModel):
             else:
                 tax_ids = taxes.ids
             context = {"lang": order.partner_id.lang}
-            po_line = PurchaseLine.create(
-                {
-                    "name": _("Advance: %s") % (time.strftime("%m %Y"),),
-                    "price_unit": amount,
-                    "product_qty": 0.0,
-                    "order_id": order.id,
-                    "product_uom": product.uom_id.id,
-                    "product_id": product.id,
-                    "taxes_id": [(6, 0, tax_ids)],
-                    "date_planned": datetime.today().strftime(
-                        DEFAULT_SERVER_DATETIME_FORMAT
-                    ),
-                    "is_deposit": True,
-                }
+            adv_po_line_dict = self._prepare_advance_purchase_line(
+                order, product, tax_ids, amount
             )
+            po_line = PurchaseLine.create(adv_po_line_dict)
             del context
 
             if self._context.get("create_bills", False):

--- a/purchase_deposit/wizard/purchase_make_invoice_advance.py
+++ b/purchase_deposit/wizard/purchase_make_invoice_advance.py
@@ -121,6 +121,7 @@ class PurchaseAdvancePaymentInv(models.TransientModel):
                         "purchase_line_id": po_line.id,
                         "tax_ids": [(6, 0, tax_ids)],
                         "analytic_account_id": po_line.account_analytic_id.id or False,
+                        "analytic_tag_ids": [(6, 0, po_line.analytic_tag_ids.ids)],
                     },
                 )
             ],


### PR DESCRIPTION
1. cherry-pick from https://github.com/OCA/purchase-workflow/pull/1329
2. send analytic_tag in deposit vals