### PR TITLE
[15.0][FIX]purchase_allowed_product: search product by vendor reference

### DIFF
--- a/purchase_allowed_product/__manifest__.py
+++ b/purchase_allowed_product/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/OCA/purchase-workflow",
     "author": "Akretion, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["purchase"],
+    "depends": ["purchase", "base_view_inheritance_extension"],
     "data": [
         "views/res_partner_view.xml",
         "views/account_move_views.xml",

--- a/purchase_allowed_product/views/purchase_order_view.xml
+++ b/purchase_allowed_product/views/purchase_order_view.xml
@@ -20,19 +20,19 @@
                 expr="//field[@name='order_line']/tree/field[@name='product_id']"
                 position="attributes"
             >
-                <attribute name="context">{
-                    'restrict_supplier_id': parent.partner_id,
-                    'use_only_supplied_product': parent.use_only_supplied_product
-                }</attribute>
+                <attribute name="context" operation="update">
+                    {'restrict_supplier_id': parent.partner_id,
+                    'use_only_supplied_product': parent.use_only_supplied_product}
+                </attribute>
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/form//field[@name='product_id']"
                 position="attributes"
             >
-                <attribute name="context">{
-                    'restrict_supplier_id': parent.partner_id,
-                    'use_only_supplied_product': parent.use_only_supplied_product
-                }</attribute>
+                <attribute name="context" operation="update">
+                    {'restrict_supplier_id': parent.partner_id,
+                    'use_only_supplied_product': parent.use_only_supplied_product}
+                </attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
At the moment, when this module is installed, it is not possible to use the vendor product code to find products in purchase order lines when a vendor is selected in the order.

This fix is intended to sort that out. The current version of the module replaces the context applied by the base module purchase on the product_id field in the purchase order form view. With this fix, the original context is kept plus the new features provided by the context parameters restrict_supplier_id and use_only_supplied_product are added.