### PR TITLE
[15.0][FIX] purchase_discount: price_unit update recursion failure

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -65,15 +65,21 @@ class PurchaseOrderLine(models.Model):
         HACK: This is needed while https://github.com/odoo/odoo/pull/29983
         is not merged.
         """
+        # Use 'skip_update_price_unit' context key to avoid infinite
+        # recursion. Updating the price_unit field here triggers the
+        # 'write' method of 'purchase.order.line' in stock_account
+        # module which triggers this method again.
+        if self.env.context.get("skip_update_price_unit"):
+            return super()._get_stock_move_price_unit()
         price_unit = False
         price = self._get_discounted_price_unit()
         if price != self.price_unit:
             # Only change value if it's different
             price_unit = self.price_unit
-            self.price_unit = price
+            self.with_context(skip_update_price_unit=True).price_unit = price
         price = super()._get_stock_move_price_unit()
         if price_unit:
-            self.price_unit = price_unit
+            self.with_context(skip_update_price_unit=True).price_unit = price_unit
         return price
 
     @api.onchange("product_qty", "product_uom")

--- a/purchase_discount/models/stock_move.py
+++ b/purchase_discount/models/stock_move.py
@@ -7,6 +7,11 @@ from odoo import models
 class StockMove(models.Model):
     _inherit = "stock.move"
 
+    def write(self, values):
+        if self.env.context.get("skip_update_price_unit") and values.get("price_unit"):
+            values.pop("price_unit")
+        return super().write(values)
+
     def _get_price_unit(self):
         """Get correct price with discount replacing current price_unit
         value before calling super and restoring it later for assuring

--- a/purchase_discount/tests/test_product_supplierinfo_discount.py
+++ b/purchase_discount/tests/test_product_supplierinfo_discount.py
@@ -140,3 +140,24 @@ class TestProductSupplierinfoDiscount(TransactionCase):
         )
         self.assertTrue(seller)
         self.assertEqual(seller.discount, 40)
+
+    def test_007_change_price_unit_autoupdate_stock_move(self):
+        partner = self.env.ref("base.res_partner_3")
+        product = self.env.ref("product.product_product_8")
+        order = self.env["purchase.order"].create({"partner_id": partner.id})
+        self.purchase_order_line_model.create(
+            {
+                "date_planned": fields.Datetime.now(),
+                "discount": 40,
+                "name": product.name,
+                "price_unit": 10.0,
+                "product_id": product.id,
+                "product_qty": 1.0,
+                "product_uom": product.uom_po_id.id,
+                "order_id": order.id,
+            }
+        )
+        order.button_confirm()
+        self.assertEqual(order.order_line.move_ids.price_unit, 6)
+        order.order_line.price_unit = 100
+        self.assertEqual(order.order_line.move_ids.price_unit, 60)


### PR DESCRIPTION
Cc @Tecnativa TT42304

Since 'Commit' [#123 ](https://github.com/odoo/odoo/commit/e7dfe10c81e69e3eb82b209db25483f29eb557e6) , creating a purchase order or updating the price_unit of an existing one causes infinite recursion. This PR tries to avoid that.

ping @chienandalu @sergio-teruel @pedrobaeza 

