### PR TITLE
[14.0] product_form_purchase_link: label on purchase_lines_count different from Odoo SA 

### DIFF
--- a/product_form_purchase_link/i18n/fr.po
+++ b/product_form_purchase_link/i18n/fr.po
@@ -47,8 +47,9 @@ msgstr ""
 #. module: product_form_purchase_link
 #: model:ir.model.fields,field_description:product_form_purchase_link.field_product_product__purchase_lines_count
 #: model:ir.model.fields,field_description:product_form_purchase_link.field_product_template__purchase_lines_count
-msgid "Purchased"
-msgstr ""
+#, fuzzy
+msgid "Purchased products"
+msgstr "Produits achetés"
 
 #. module: product_form_purchase_link
 #: model:ir.actions.act_window,name:product_form_purchase_link.action_purchase_line_product_product_tree

--- a/product_form_purchase_link/i18n/product_form_purchase_link.pot
+++ b/product_form_purchase_link/i18n/product_form_purchase_link.pot
@@ -44,7 +44,7 @@ msgstr ""
 #. module: product_form_purchase_link
 #: model:ir.model.fields,field_description:product_form_purchase_link.field_product_product__purchase_lines_count
 #: model:ir.model.fields,field_description:product_form_purchase_link.field_product_template__purchase_lines_count
-msgid "Purchased"
+msgid "Purchased products"
 msgstr ""
 
 #. module: product_form_purchase_link

--- a/product_form_purchase_link/models/product_product.py
+++ b/product_form_purchase_link/models/product_product.py
@@ -8,7 +8,7 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     purchase_lines_count = fields.Integer(
-        compute="_compute_purchase_lines_count", string="Purchased"
+        compute="_compute_purchase_lines_count", string="Purchased products"
     )
 
     def _compute_purchase_lines_count(self):

--- a/product_form_purchase_link/models/product_template.py
+++ b/product_form_purchase_link/models/product_template.py
@@ -12,7 +12,7 @@ class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     purchase_lines_count = fields.Float(
-        compute="_compute_purchase_lines_count", string="Purchased"
+        compute="_compute_purchase_lines_count", string="Purchased products"
     )
 
     @api.depends("product_variant_ids.purchase_lines_count")


### PR DESCRIPTION
Super easy PR to avoid warning due to duplicated label "Purchased" on both OCA `purchase_lines_count` field and Odoo SA [`purchased_product_qty`](https://github.com/odoo/odoo/blob/14.0/addons/purchase/models/product.py#L18) field.