### PR TITLE
[16.0][IMP] purchase_order_line_menu: remove the form view to prevent the user from making uncontrolled modifications

### DIFF
--- a/purchase_order_line_menu/views/purchase_order_line_views.xml
+++ b/purchase_order_line_menu/views/purchase_order_line_views.xml
@@ -14,7 +14,7 @@
         <field name="name">Purchase Order Lines</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">purchase.order.line</field>
-        <field name="view_mode">tree,form,pivot</field>
+        <field name="view_mode">tree,pivot</field>
     </record>
 
     <menuitem


### PR DESCRIPTION
As we can see in: https://github.com/OCA/sale-workflow/blob/16.0/sale_order_line_menu/views/sale_order_line_views.xml#L17, the form view is not added. Therefore it is a considerable improvement to remove the form view from here too, to avoid that the user can make uncontrolled modifications from this access and consequently affect the purchase order itself and related documents.