### PR TITLE
[16.0][FIX] purchase_allowed_product: cannot find the vendor's products.

### DIFF
--- a/purchase_allowed_product/__manifest__.py
+++ b/purchase_allowed_product/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/OCA/purchase-workflow",
     "author": "Akretion, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["purchase"],
+    "depends": ["purchase", "base_view_inheritance_extension"],
     "data": [
         "views/res_partner_views.xml",
         "views/account_move_views.xml",

--- a/purchase_allowed_product/models/product.py
+++ b/purchase_allowed_product/models/product.py
@@ -27,7 +27,7 @@ class ProductProduct(models.Model):
                 .commercial_partner_id
             )
             supplierinfos = self.env["product.supplierinfo"].search(
-                [("name", "=", seller.id)]
+                [("partner_id", "=", seller.id)]
             )
             args += [
                 "|",

--- a/purchase_allowed_product/tests/test_purchase_allowed_product.py
+++ b/purchase_allowed_product/tests/test_purchase_allowed_product.py
@@ -13,7 +13,7 @@ class TestPurchaseAllowedProduct(TransactionCase):
         self.product_model = self.env["product.product"]
         self.partner_4 = self.env.ref("base.res_partner_4")
         self.supplierinfo = self.supplierinfo_model.search(
-            [("name", "=", self.partner_4.id)]
+            [("partner_id", "=", self.partner_4.id)]
         )
         self.partner_4_supplied_products = self.product_model.search(
             [

--- a/purchase_allowed_product/views/purchase_order_views.xml
+++ b/purchase_allowed_product/views/purchase_order_views.xml
@@ -20,19 +20,19 @@
                 expr="//field[@name='order_line']/tree/field[@name='product_id']"
                 position="attributes"
             >
-                <attribute name="context">{
-                    'restrict_supplier_id': parent.partner_id,
-                    'use_only_supplied_product': parent.use_only_supplied_product
-                }</attribute>
+                <attribute name="context" operation="update">
+                    {'restrict_supplier_id': parent.partner_id,
+                    'use_only_supplied_product': parent.use_only_supplied_product}
+                </attribute>
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/form//field[@name='product_id']"
                 position="attributes"
             >
-                <attribute name="context">{
-                    'restrict_supplier_id': parent.partner_id,
-                    'use_only_supplied_product': parent.use_only_supplied_product
-                }</attribute>
+                <attribute name="context" operation="update">
+                    {'restrict_supplier_id': parent.partner_id,
+                    'use_only_supplied_product': parent.use_only_supplied_product}
+                </attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
[FP] PR #1797 to find products by the seller's reference.

[FIX] When a quote request is created and the option ''Use only allowed products'' is checked, the supplier's products do not appear in the dropdown when trying to add a new product. 
This is because the "name" field of the product.supplierinfo module in [v15](https://github.com/odoo/odoo/blob/92a81e84d92abee48c333a07055324b47e1f5d76/addons/product/models/product.py#L822) is renamed to "partner_id" in [v16](https://github.com/odoo/odoo/blob/966a7e9a01297c95a7768daef0d9662e7d343f6a/addons/product/models/product_supplierinfo.py#L29).

To reproduce the error:.
1. Go to the Purchasing module -> Configuration -> Vendor price List
2. Create a new one with a product and a Vendor.
3. Create a quote request.
4. Fill in the Vendor field with the partner from the 'Vendor price List' we have just created.
5. Check 'Use only allowed products'.
6. Add a product

You can see that no product appears.