### PR TITLE
[IMP] purchase_order_line_price_history: shrink button

### DIFF
--- a/purchase_order_line_price_history/views/purchase_views.xml
+++ b/purchase_order_line_price_history/views/purchase_views.xml
@@ -10,7 +10,7 @@
             <xpath expr="//field[@name='order_line']/tree">
                 <button
                     name="%(purchase_order_line_price_history_action)d"
-                    string="Price history"
+                    title="Price history"
                     type="action"
                     icon="fa-clock-o"
                 />


### PR DESCRIPTION
The button has grown in size on migration.

Fix https://github.com/OCA/purchase-workflow/issues/1841 @moduon MT-2735