### PR TITLE
[15.0][FIX] purchase_security: prevent access error & rules for order lines

### DIFF
--- a/purchase_security/__manifest__.py
+++ b/purchase_security/__manifest__.py
@@ -11,7 +11,7 @@
     "license": "AGPL-3",
     "depends": ["purchase"],
     "maintainers": ["pilarvargas-tecnativa"],
-    "data": ["security/security.xml"],
+    "data": ["security/security.xml", "views/purchase_order_views.xml"],
     "installable": True,
     "auto_install": False,
 }

--- a/purchase_security/readme/CONTRIBUTORS.rst
+++ b/purchase_security/readme/CONTRIBUTORS.rst
@@ -2,3 +2,6 @@
 
   * João Marques
   * Pilar Vargas
+* `Solvos <https://www.solvos.es>`_:
+
+  * David Alonso <david.alonso@solvos.es>

--- a/purchase_security/readme/USAGE.rst
+++ b/purchase_security/readme/USAGE.rst
@@ -2,8 +2,10 @@ To use this module, you need to:
 
 #. Go to **Purchase > Orders > Purchase Orders**
 #. Create a Purchase Order and assing a **Purchase Representative**
-   (in the **Other Information** tab). By default, it will be the current user.
+   (in the **Other Information** tab), if you are a Purchase User or Manager.
+   If you are a Purchass User (own orders), i'll be automatically assigned,
+   and you won't be able to change it
 #. Confirm the Purchase Order
 #. Go back to the **Purchase Orders** view.
-#. If you are the Purchase Representative or a Purchase Manager, you should be
-   able to see the order you created. If not, you shouldn't.
+#. If you are a Purchase User or a Purchase Manager, you should be
+   able to see all orders. If not, you'll only see your own orders.

--- a/purchase_security/security/security.xml
+++ b/purchase_security/security/security.xml
@@ -30,5 +30,22 @@
             >['|',('user_id','=',user.id),('user_id','=',False)]</field>
             <field name="groups" eval="[(4,ref('group_purchase_own_orders'))]" />
         </record>
+        <record model="ir.rule" id="purchase_order_line_group_purchase_manager_rule">
+            <field name="name">View purchase order lines (manager)</field>
+            <field name="model_id" ref="purchase.model_purchase_order_line" />
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="groups" eval="[(4, ref('purchase.group_purchase_manager'))]" />
+        </record>
+        <record
+            model="ir.rule"
+            id="purchase_order_line_group_purchase_order_own_orders"
+        >
+            <field name="name">View purchase order lines (own responsible)</field>
+            <field name="model_id" ref="purchase.model_purchase_order_line" />
+            <field
+                name="domain_force"
+            >['|',('order_id.user_id','=',user.id),('order_id.user_id','=',False)]</field>
+            <field name="groups" eval="[(4,ref('group_purchase_own_orders'))]" />
+        </record>
     </data>
 </odoo>

--- a/purchase_security/views/purchase_order_views.xml
+++ b/purchase_security/views/purchase_order_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="purchase_order_form_own_orders" model="ir.ui.view">
+        <field name="name">purchase.order.form (own orders)</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="groups_id" eval="[(4, ref('group_purchase_own_orders'))]" />
+        <field name="arch" type="xml">
+            <field name="user_id" position="attributes">
+                <attribute name="readonly">1</attribute>
+                <attribute name="force_save">1</attribute>
+            </field>
+        </field>
+    </record>
+    <record id="purchase_order_form_all_orders" model="ir.ui.view">
+        <field name="name">purchase.order.form (all orders)</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase_order_form_own_orders" />
+        <field name="groups_id" eval="[(4, ref('purchase.group_purchase_manager'))]" />
+        <field name="arch" type="xml">
+            <field name="user_id" position="attributes">
+                <attribute name="readonly">0</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When a Purchase User (own orders) create or edit an order, if changes Representative user to another and save it, an access error is raised. With this change, those users cannot change the default Representative, then orders are initially assigned to them, and no errors were fired.

fw-port of #1313 

When merged this fix, I'll migrate `purchase_security` to v16.