### PR TITLE
[16.0][FIX] purchase_deposit: Allow register deposit by users without permissions for the first time.

### DIFF
--- a/purchase_deposit/wizard/purchase_make_invoice_advance.py
+++ b/purchase_deposit/wizard/purchase_make_invoice_advance.py
@@ -163,10 +163,10 @@ class PurchaseAdvancePaymentInv(models.TransientModel):
         product = self.purchase_deposit_product_id
         if not product:
             vals = self._prepare_deposit_product()
-            product = self.purchase_deposit_product_id = self.env[
-                "product.product"
-            ].create(vals)
-            self.env.company.purchase_deposit_product_id = product
+            product = self.purchase_deposit_product_id = (
+                self.env["product.product"].sudo().create(vals)
+            )
+            self.env.company.sudo().purchase_deposit_product_id = product
         PurchaseLine = self.env["purchase.order.line"]
         for order in purchases:
             amount = self.amount


### PR DESCRIPTION
Previously, users without 'write' access to the 'product.product' model and the 'res.users' model were unable to Register Deposit for the first time. 

@qrtl