### PR TITLE
[13.0][IMP] purchase_order_line_sequence: use correct sequence in moves when section or notes in purchase order

### DIFF
--- a/purchase_order_line_sequence/models/purchase.py
+++ b/purchase_order_line_sequence/models/purchase.py
@@ -27,6 +27,10 @@ class PurchaseOrder(models.Model):
 
     def _create_picking(self):
         res = super(PurchaseOrder, self)._create_picking()
+        self._update_moves_sequence()
+        return res
+
+    def _update_moves_sequence(self):
         for order in self:
             if any(
                 [
@@ -39,11 +43,13 @@ class PurchaseOrder(models.Model):
                 )
                 if pickings:
                     picking = pickings[0]
+                    order_lines = order.order_line.filtered(
+                        lambda l: l.product_id.type in ["product", "consu"]
+                    )
                     for move, line in zip(
-                        sorted(picking.move_lines, key=lambda m: m.id), order.order_line
+                        sorted(picking.move_lines, key=lambda m: m.id), order_lines
                     ):
                         move.write({"sequence": line.sequence})
-        return res
 
     def _reset_sequence(self):
         for rec in self:
@@ -55,6 +61,8 @@ class PurchaseOrder(models.Model):
     def write(self, line_values):
         res = super(PurchaseOrder, self).write(line_values)
         self._reset_sequence()
+        if "order_line" in line_values:
+            self._update_moves_sequence()
         return res
 
     def copy(self, default=None):

--- a/purchase_order_line_sequence/tests/test_po_lines_sequence.py
+++ b/purchase_order_line_sequence/tests/test_po_lines_sequence.py
@@ -134,6 +134,91 @@ class TestPurchaseOrder(common.TransactionCase):
             "The Sequence is not copied properly",
         )
 
+    def test_purchase_order_line_sequence_with_section_note(self):
+        """
+            Verify that the sequence is correctly assigned to the move associated
+            with the purchase order line it references.
+        """
+        po = self._create_purchase_order()
+        self.PurchaseOrderLine.create(
+            {
+                "name": "Section 1",
+                "display_type": "line_section",
+                "order_id": po.id,
+                "product_qty": 0,
+            }
+        )
+        self.PurchaseOrderLine.create(
+            {
+                "name": self.product_id_1.name,
+                "product_id": self.product_id_1.id,
+                "product_qty": 15.0,
+                "product_uom": self.product_id_1.uom_po_id.id,
+                "price_unit": 150.0,
+                "date_planned": datetime.today().strftime(
+                    DEFAULT_SERVER_DATETIME_FORMAT
+                ),
+                "order_id": po.id,
+            }
+        )
+        self.PurchaseOrderLine.create(
+            {
+                "name": "Note 1",
+                "display_type": "line_note",
+                "order_id": po.id,
+                "product_qty": 0,
+            }
+        )
+        self.PurchaseOrderLine.create(
+            {
+                "name": self.product_id_2.name,
+                "product_id": self.product_id_2.id,
+                "product_qty": 1.0,
+                "product_uom": self.product_id_2.uom_po_id.id,
+                "price_unit": 50.0,
+                "date_planned": datetime.today().strftime(
+                    DEFAULT_SERVER_DATETIME_FORMAT
+                ),
+                "order_id": po.id,
+            }
+        )
+        po.button_confirm()
+
+        moves = po.picking_ids[0].move_ids_without_package
+        self.assertNotEquals(len(po.order_line), len(moves))
+
+        for move in moves:
+            self.assertEqual(move.sequence, move.purchase_line_id.sequence)
+
+    def test_write_purchase_order_line(self):
+        po = self._create_purchase_order()
+        po.button_confirm()
+
+        po.write(
+            {
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product_id_2.name,
+                            "product_id": self.product_id_2.id,
+                            "product_qty": 2,
+                            "product_uom": self.product_id_2.uom_id.id,
+                            "price_unit": 30,
+                            "date_planned": datetime.today().strftime(
+                                DEFAULT_SERVER_DATETIME_FORMAT
+                            ),
+                        },
+                    )
+                ]
+            }
+        )
+
+        moves = po.picking_ids[0].move_ids_without_package
+        for move in moves:
+            self.assertEqual(move.sequence, move.purchase_line_id.sequence)
+
     def test_invoice_sequence(self):
 
         po = self._create_purchase_order()


### PR DESCRIPTION
Assign sequence correctly to the move associated with the purchase order line it references when there are sections or notes in the purchase order.