### PR TITLE
[16.0] [FIX] purchase_advance_payment : use commercial_partner_id for payment

### DIFF
--- a/purchase_advance_payment/wizard/purchase_advance_payment_wizard.py
+++ b/purchase_advance_payment/wizard/purchase_advance_payment_wizard.py
@@ -92,7 +92,7 @@ class AccountVoucherWizardPurchase(models.TransientModel):
         self.currency_amount = amount_advance
 
     def _prepare_payment_vals(self, purchase):
-        partner_id = purchase.partner_id.id
+        partner_id = purchase.partner_id.commercial_partner_id.id
         return {
             "date": self.date,
             "amount": self.amount_advance,


### PR DESCRIPTION
When making a PO to a children's contact, this module use the PO partner_id for the payment's partner which is not consistant with the invoice that will use the commercial partner resulting in the payment beeing not available as open balance on the invoice.

It's fixed by using the commercial_partner_id on the payment.