### PR TITLE
[15.0][ENH] purchase_deposit, add advance return option

### DIFF
--- a/purchase_deposit/README.rst
+++ b/purchase_deposit/README.rst
@@ -41,6 +41,7 @@ Normally, deposit will be used to create the 1st bill (as deposit).
 #. On confirmed purchase order, click Register Deposit button, wizard will open
 #. 2 type of deposit bill can be create 1) Down Payment (percentage) 2) Deposit Payment (fixed amount)
 #. Fill in the value and click Create bill or just create deposit.
+#. When create bill, there are 2 options to return advance amount, by proportional and in full.
 
 As deposit is created, when user click button "Create Bill" again in purchase order,
 the Vendor Bill will be created with deposit amount deducted.

--- a/purchase_deposit/__manifest__.py
+++ b/purchase_deposit/__manifest__.py
@@ -14,6 +14,7 @@
     "data": [
         "security/ir.model.access.csv",
         "wizard/purchase_make_invoice_advance_views.xml",
+        "wizard/purchase_advance_deduct_option_views.xml",
         "views/res_config_settings_views.xml",
         "views/purchase_view.xml",
     ],

--- a/purchase_deposit/models/__init__.py
+++ b/purchase_deposit/models/__init__.py
@@ -4,3 +4,4 @@
 
 from . import res_config_settings
 from . import purchase
+from . import account_move

--- a/purchase_deposit/models/account_move.py
+++ b/purchase_deposit/models/account_move.py
@@ -1,0 +1,26 @@
+# Copyright 2019 Elico Corp, Dominique K. <dominique.k@elico-corp.com.sg>
+# Copyright 2019 Ecosoft Co., Ltd., Kitti U. <kittiu@ecosoft.co.th>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        moves = super(AccountMove, self).create(vals_list)
+        if self.env.context.get("advance_deduct_option") == "proportional":
+            for move in moves:
+                inv_lines = move.invoice_line_ids.filtered(lambda x: x.quantity > 0)
+                adv_lines = move.invoice_line_ids.filtered(lambda x: x.quantity < 0)
+                inv_untaxed = sum(inv_lines.mapped("price_subtotal"))
+                purchases = inv_lines.mapped("purchase_line_id.order_id")
+                if purchases:
+                    prop = inv_untaxed / purchases.ensure_one().amount_untaxed
+                    for line in adv_lines:
+                        line.with_context(check_move_validity=False).write(
+                            {"quantity": max(-prop, line.quantity)}
+                        )
+        return moves

--- a/purchase_deposit/models/purchase.py
+++ b/purchase_deposit/models/purchase.py
@@ -2,7 +2,7 @@
 # Copyright 2019 Ecosoft Co., Ltd., Kitti U. <kittiu@ecosoft.co.th>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class PurchaseOrder(models.Model):
@@ -16,6 +16,21 @@ class PurchaseOrder(models.Model):
             for line in self.order_line.filtered(lambda l: not l.is_deposit)
         ]
         return super(PurchaseOrder, self).copy_data(default)
+
+    def action_create_invoice(self):
+        has_deposit = len(self.filtered("order_line.is_deposit")) > 0
+        if not has_deposit or self.env.context.get("advance_deduct_option"):
+            return super().action_create_invoice()
+        wizard = self.env.ref("purchase_deposit.view_purchase_advance_deduct_option")
+        return {
+            "name": _("Advance/Deposit Deduction Option"),
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "purchase.advance.deduct.option",
+            "views": [(wizard.id, "form")],
+            "view_id": wizard.id,
+            "target": "new",
+        }
 
 
 class PurchaseOrderLine(models.Model):

--- a/purchase_deposit/security/ir.model.access.csv
+++ b/purchase_deposit/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_purchase_advance_payment_inv,access_purchase_advance_payment_inv,model_purchase_advance_payment_inv,base.group_user,1,1,1,1
+access_purchase_advance_deduct_option,access_purchase_advance_deduct_option,model_purchase_advance_deduct_option,base.group_user,1,1,1,1

--- a/purchase_deposit/wizard/__init__.py
+++ b/purchase_deposit/wizard/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import purchase_make_invoice_advance
+from . import purchase_advance_deduct_option

--- a/purchase_deposit/wizard/purchase_advance_deduct_option.py
+++ b/purchase_deposit/wizard/purchase_advance_deduct_option.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Elico Corp, Dominique K. <dominique.k@elico-corp.com.sg>
+# Copyright 2019 Ecosoft Co., Ltd., Kitti U. <kittiu@ecosoft.co.th>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class PurchaseAdvanceReturnOption(models.TransientModel):
+    _name = "purchase.advance.deduct.option"
+    _description = "Select how to return advance in vendor bill"
+
+    advance_deduct_option = fields.Selection(
+        [
+            ("proportional", "Deduct Deposit Proportionally"),
+            ("full", "Deduct Full Deposit (Standard)"),
+        ],
+        string="Advance/Deposit Deduction Option",
+        default="proportional",
+        required=True,
+    )
+
+    def create_invoice(self):
+        self.ensure_one()
+        order = (
+            self.env["purchase.order"]
+            .browse(self._context.get("active_id"))
+            .with_context(
+                create_bill=self._context.get("create_bill"),
+                advance_deduct_option=self.advance_deduct_option,
+            )
+        )
+        return order.sudo().action_create_invoice()

--- a/purchase_deposit/wizard/purchase_advance_deduct_option_views.xml
+++ b/purchase_deposit/wizard/purchase_advance_deduct_option_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_purchase_advance_deduct_option" model="ir.ui.view">
+        <field name="name">Advance/Deposit Deduction Option</field>
+        <field name="model">purchase.advance.deduct.option</field>
+        <field name="arch" type="xml">
+            <form string="Invoice Purchases Order">
+                <group>
+                    <field
+                        name="advance_deduct_option"
+                        class="oe_inline"
+                        widget="radio"
+                    />
+                </group>
+                <footer>
+                    <button
+                        name="create_invoice"
+                        string="Create and View bill"
+                        type="object"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record
+        id="action_view_purchase_advance_deduct_option"
+        model="ir.actions.act_window"
+    >
+        <field name="name">Advance/Deposit Deduction Option</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">purchase.advance.deduct.option</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
Currently, for PO with Deposit. 1st Invoice is Deposit, and 2nd Invoice will return "full" deposit regard less if it is a partial invoice.
This enhancement, allow user to choose how to return deposit in invoices that follows 1) Proportional 2) Full (standard)

Clicking Create Bill on PO with Deposit will show this,

![image](https://github.com/OCA/purchase-workflow/assets/1973598/194f3059-1f1c-43e6-b949-4358fd4362be)

If user choose to return in proportion,

![image](https://github.com/OCA/purchase-workflow/assets/1973598/2759eba8-6b96-47ee-be53-8c88bb4e6f63)
