### PR TITLE
[13.0][FIX] purchase_order_line_sequence: sort the order lines before resetting their sequence

### DIFF
--- a/purchase_order_line_sequence/models/purchase.py
+++ b/purchase_order_line_sequence/models/purchase.py
@@ -48,7 +48,8 @@ class PurchaseOrder(models.Model):
     def _reset_sequence(self):
         for rec in self:
             current_sequence = 1
-            for line in rec.order_line:
+            order_lines = sorted(rec.order_line, key=lambda l: l.sequence)
+            for line in order_lines:
                 line.sequence = current_sequence
                 current_sequence += 1
 


### PR DESCRIPTION
Fix the error preventing the movement of order lines. Previously, the sequence reset was based on the ID instead of the desired sequence order. 