### PR TITLE
[ADD] purchase_request: improve ui interface.

### DIFF
--- a/purchase_request/views/purchase_request_line_view.xml
+++ b/purchase_request/views/purchase_request_line_view.xml
@@ -12,6 +12,14 @@
                 decoration-muted="cancelled == True"
                 decoration-info="request_state in ('draft', 'to_approve')"
             >
+                <header>
+                    <button
+                        name="%(action_purchase_request_line_make_purchase_order)d"
+                        string="Create RFQ"
+                        type="action"
+                        class="oe_highlight"
+                    />
+                </header>
                 <field name="request_id" />
                 <field
                     name="request_state"
@@ -46,7 +54,8 @@
                 />
                 <field
                     name="analytic_tag_ids"
-                    groups="analytic.group_analytic_accounting"
+                    groups="analytic.group_analytic_tags"
+                    widget="many2many_tags"
                 />
                 <field name="supplier_id" />
                 <field
@@ -68,6 +77,13 @@
         <field name="arch" type="xml">
             <form string="Purchase Request Line" create="false" duplicate="false">
                 <header>
+                    <button
+                        name="%(action_purchase_request_line_make_purchase_order)d"
+                        string="Create RFQ"
+                        type="action"
+                        class="oe_highlight"
+                        attrs="{'invisible': [('request_state', '!=', 'approved')]}"
+                    />
                     <field name="request_state" widget="statusbar" />
                 </header>
                 <sheet>
@@ -135,8 +151,9 @@
                             />
                             <field
                                 name="analytic_tag_ids"
-                                groups="analytic.group_analytic_accounting"
+                                groups="analytic.group_analytic_tags"
                                 attrs="{'readonly': [('is_editable','=', False)]}"
+                                widget="many2many_tags"
                             />
                             <field
                                 name="date_required"
@@ -587,8 +604,9 @@
                             />
                         <field
                                 name="analytic_tag_ids"
-                                groups="analytic.group_analytic_accounting"
+                                groups="analytic.group_analytic_tags"
                                 attrs="{'readonly': [('is_editable','=', False)]}"
+                                widget="many2many_tags"
                             />
                         <field
                                 name="date_required"

--- a/purchase_request/views/purchase_request_report.xml
+++ b/purchase_request/views/purchase_request_report.xml
@@ -8,5 +8,7 @@
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">purchase_request.report_purchase_request</field>
         <field name="report_file">purchase_request.report_purchase_request</field>
+        <field name="binding_model_id" ref="purchase_request.model_purchase_request" />
+        <field name="binding_type">report</field>
     </record>
 </odoo>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -182,7 +182,7 @@
                                     />
                                     <field
                                         name="analytic_tag_ids"
-                                        groups="analytic.group_analytic_accounting"
+                                        groups="analytic.group_analytic_tags"
                                         widget="many2many_tags"
                                     />
                                     <field name="date_required" />


### PR DESCRIPTION
- Add button to tree view of purchase request lines to allow generating RFQ without clicking in action button.
 
![image](https://github.com/OCA/purchase-workflow/assets/6758279/ee92a413-2a0a-46c1-bba9-ff55a7cc1efa)

- Define correct group to field analytic_tag_ids from group_analytic_accounting to group_analytic_tags. 
- Add button to form view of purchase request lines to allow generating RFQ without clicking in action button. 

![image](https://github.com/OCA/purchase-workflow/assets/6758279/93fa0e0c-ab83-4831-844b-46d081cf99b6)

- Allow to show the print button in purchase requests, the report existed, but it didn't have the binding model.

![image](https://github.com/OCA/purchase-workflow/assets/6758279/3ded9441-9d81-4f16-a445-557a76cc07ef)
