### PR TITLE
[FIX] purchase_request: fix datetime from request to order 

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -176,7 +176,8 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         # Suggest the supplier min qty as it's done in Odoo core
         min_qty = item.line_id._get_supplier_min_qty(product, po.partner_id)
         qty = max(qty, min_qty)
-        date_required = item.line_id.date_required
+        date_required = fields.Datetime.to_datetime(item.line_id.date_required)
+        context_date = fields.Datetime.context_timestamp(self, date_required)
         vals = {
             "name": product.name,
             "order_id": po.id,
@@ -186,9 +187,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             "product_qty": qty,
             "account_analytic_id": item.line_id.analytic_account_id.id,
             "purchase_request_lines": [(4, item.line_id.id)],
-            "date_planned": datetime(
-                date_required.year, date_required.month, date_required.day
-            ),
+            "date_planned": date_required - context_date.utcoffset(),
             "move_dest_ids": [(4, x.id) for x in item.line_id.move_dest_ids],
         }
         if item.line_id.analytic_tag_ids:
@@ -303,10 +302,9 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             po_line._onchange_quantity()
             # The onchange quantity is altering the scheduled date of the PO
             # lines. We do not want that:
-            date_required = item.line_id.date_required
-            po_line.date_planned = datetime(
-                date_required.year, date_required.month, date_required.day
-            )
+            date_required = fields.Datetime.to_datetime(item.line_id.date_required)
+            context_date = fields.Datetime.context_timestamp(self, date_required)
+            po_line.date_planned = date_required - context_date.utcoffset()
             res.append(purchase.id)
 
         return {


### PR DESCRIPTION
This PR fixes an issue that pass an incorrect date to the deadline to the purchase order.

Steps to reproduce:

Configure Odoo and your OS in a timezone different from UTC. For example, I'm in México (UTC-6).

Create a purchase request and define required date at 30-07-2023.

Then create a purchase order from the purchase request.

The scheduled date for the purchase order line is 29-07-2023 18:00:00 

With this change, the date now will be 30-07-2023 00:00:00