### PR TITLE
[16.0][IMP] purchase_request: make mail sending optional forward port

### DIFF
--- a/purchase_request/__manifest__.py
+++ b/purchase_request/__manifest__.py
@@ -23,6 +23,7 @@
         "views/purchase_request_report.xml",
         "views/product_template.xml",
         "views/purchase_order_view.xml",
+        "views/res_config_settings.xml",
         "views/stock_move_views.xml",
         "views/stock_picking_views.xml",
     ],

--- a/purchase_request/models/__init__.py
+++ b/purchase_request/models/__init__.py
@@ -9,3 +9,5 @@ from . import product_template
 from . import purchase_order
 from . import stock_move
 from . import stock_move_line
+from . import res_config_settings
+from . import res_company

--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -173,15 +173,17 @@ class PurchaseOrderLine(models.Model):
                     qty_left = 0
                 alloc.write({"allocated_product_qty": allocated_product_qty})
 
-                message_data = self._prepare_request_message_data(
-                    alloc, alloc.purchase_request_line_id, allocated_product_qty
-                )
-                message = self._purchase_request_confirm_done_message_content(
-                    message_data
-                )
-                alloc.purchase_request_line_id.request_id.message_post(
-                    body=message, subtype_id=self.env.ref("mail.mt_comment").id
-                )
+                send_mail = self.env.user.company_id.notify_request_allocations
+                if send_mail:
+                    message_data = self._prepare_request_message_data(
+                        alloc, alloc.purchase_request_line_id, allocated_product_qty
+                    )
+                    message = self._purchase_request_confirm_done_message_content(
+                        message_data
+                    )
+                    alloc.purchase_request_line_id.request_id.message_post(
+                        body=message, subtype_id=self.env.ref("mail.mt_comment").id
+                    )
 
                 alloc.purchase_request_line_id._compute_qty()
         return True

--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -122,11 +122,18 @@ class PurchaseRequestAllocation(models.Model):
     def _notify_allocation(self, allocated_qty):
         if not allocated_qty:
             return
-        for allocation in self:
-            request = allocation.purchase_request_line_id.request_id
-            po_line = allocation.purchase_line_id
-            message_data = self._prepare_message_data(po_line, request, allocated_qty)
-            message = self._purchase_request_confirm_done_message_content(message_data)
-            request.message_post(
-                body=message, subtype_id=self.env.ref("mail.mt_comment").id
-            )
+
+        send_mail = self.env.user.company_id.notify_request_allocations
+        if send_mail:
+            for allocation in self:
+                request = allocation.purchase_request_line_id.request_id
+                po_line = allocation.purchase_line_id
+                message_data = self._prepare_message_data(
+                    po_line, request, allocated_qty
+                )
+                message = self._purchase_request_confirm_done_message_content(
+                    message_data
+                )
+                request.message_post(
+                    body=message, subtype_id=self.env.ref("mail.mt_comment").id
+                )

--- a/purchase_request/models/res_company.py
+++ b/purchase_request/models/res_company.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Camptocamp
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.Model):
+    _inherit = "res.company"
+
+    notify_request_allocations = fields.Boolean(
+        string="Send emails on confirmaion",
+        default=True,
+    )

--- a/purchase_request/models/res_config_settings.py
+++ b/purchase_request/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Camptocamp
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    notify_request_allocations = fields.Boolean(
+        related="company_id.notify_request_allocations",
+        string="Send emails with request confirmaion",
+        readonly=False,
+    )

--- a/purchase_request/models/stock_move_line.py
+++ b/purchase_request/models/stock_move_line.py
@@ -99,7 +99,9 @@ class StockMoveLine(models.Model):
                     )
 
                 request = allocation.purchase_request_line_id.request_id
-                if allocated_qty:
+                send_mail = request.company_id.notify_request_allocations
+
+                if allocated_qty and send_mail:
                     message_data = self._prepare_message_data(
                         ml, request, allocated_qty
                     )

--- a/purchase_request/readme/CONFIGURE.rst
+++ b/purchase_request/readme/CONFIGURE.rst
@@ -7,3 +7,6 @@ To configure the product follow this steps:
 With this configuration, whenever a procurement order is created and the supply
 rule selected is 'Buy' the application will create a Purchase Request instead
 of a Purchase Order.
+
+When a delivery for purchase request is confirmed, a notification to followers is generated.
+You can control this with the flag "Notify followers on request allocation" in stock general settings

--- a/purchase_request/views/res_config_settings.xml
+++ b/purchase_request/views/res_config_settings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="model">res.config.settings</field>
+        <field name="arch" type="xml">
+            <div id="stock_move_email" position="after">
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="notify_request_allocations" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label
+                            for="notify_request_allocations"
+                            string="Request mail options"
+                        />
+                        <div class="text-muted">
+                            Notify followers on request allocation
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Port email config setting for purchase_request

https://github.com/OCA/purchase-workflow/pull/1544

Minimal forward port of functionality for 16 to allow for upgrading the module between 14->16 without failures

Purchase request is really different between the versions....