### PR TITLE
[13.0][FIX]purchase_origin_link_sale: properly get the SO from Source Document

### DIFF
--- a/purchase_origin_link_sale/models/purchase.py
+++ b/purchase_origin_link_sale/models/purchase.py
@@ -3,18 +3,23 @@
 
 from odoo import api, models
 
+SO_MODEL_NAME = "sale.order"
+
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
     def _selection_reference_model(self):
-        res = super()._selection_reference_model() + [("sale.order", "Sale Order")]
+        res = super()._selection_reference_model() + [(SO_MODEL_NAME, "Sale Order")]
         return res
 
     @api.depends(lambda x: x._get_depends_compute_source_doc_ref())
     def _compute_source_doc_ref(self):
         super()._compute_source_doc_ref()
-        for rec in self:
-            so = self.env["sale.order"].search([("name", "like", rec.origin)])
-            if len(so) == 1:
-                rec.origin_reference = "{},{}".format(so._name, so.id or 0)
+        for purchase in self:
+            if not purchase.origin_reference:
+                rel_sale = self.env[SO_MODEL_NAME].search(
+                    [("name", "=", purchase.origin)], limit=1
+                )
+                if rel_sale:
+                    purchase.origin_reference = "%s,%s" % (SO_MODEL_NAME, rel_sale.id)

--- a/purchase_origin_link_sale/readme/CONTRIBUTORS.rst
+++ b/purchase_origin_link_sale/readme/CONTRIBUTORS.rst
@@ -1,1 +1,3 @@
-* Judith Almoño <judith.almono@forgeflow.com>
+* ForgeFlow S.L.
+  * Judith Almoño <judith.almono@forgeflow.com>
+  * Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/purchase_origin_link_sale/readme/DESCRIPTION.rst
+++ b/purchase_origin_link_sale/readme/DESCRIPTION.rst
@@ -1,1 +1,1 @@
-This module adds a clickable link to Sale Orders on the Source Document of Purchase Orders. It depends on the base module: "purchase_origin_link"
+This module adds a clickable link to Sale Orders on the Source Document of Purchase Orders. It depends on the base module: *purchase_origin_link*


### PR DESCRIPTION
Before the change, the obtaining of the Sales Order was done in a way that could return several, the Source Document may only be clickable if it points to a single Sales Order.

cc @ForgeFlow