### PR TITLE
[15.0][IMP] purchase_order_line_menu: added invoice line in tree view

### DIFF
--- a/purchase_order_line_menu/__manifest__.py
+++ b/purchase_order_line_menu/__manifest__.py
@@ -15,6 +15,6 @@
         "views/purchase_order_line_views.xml",
     ],
     "installable": True,
-    "maintainer": ["dreispt", "Shide"],
+    "maintainer": ["dreispt", "Shide", "EmilioPascual"],
     "development_status": "Beta",
 }

--- a/purchase_order_line_menu/readme/CONTRIBUTORS.rst
+++ b/purchase_order_line_menu/readme/CONTRIBUTORS.rst
@@ -6,3 +6,5 @@
 * `Moduon Team <https://moduon.team>`:
 
   * Eduardo de Miguel <edu@moduon.team>
+  * Emilio Pascual <emilio@moduon.team>
+  * Rafael Blasco <rblasco@moduon.team>

--- a/purchase_order_line_menu/views/purchase_order_line_views.xml
+++ b/purchase_order_line_menu/views/purchase_order_line_views.xml
@@ -55,6 +55,14 @@
             <xpath expr="//field[@name='date_planned']" position="attributes">
                 <attribute name="optional">hide</attribute>
             </xpath>
+            <xpath expr="/tree" postion="inside">
+                <field
+                    name="invoice_lines"
+                    widget="many2many_tags"
+                    groups="account.group_account_invoice"
+                    optional="hide"
+                />
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Added invoice lines in tree view

![image](https://github.com/OCA/purchase-workflow/assets/53056345/ada47498-1861-40c8-ad3a-7424b624cb69)


@moduon MT-2028 @rafaelbn