### PR TITLE
[16.0][IMP] purchase_order_line_menu: New views and stored fields

### DIFF
--- a/purchase_order_line_menu/__manifest__.py
+++ b/purchase_order_line_menu/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2021 Open Source Integrators
+# Copyright (C) 2023 Moduon Team
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
@@ -14,6 +15,6 @@
         "views/purchase_order_line_views.xml",
     ],
     "installable": True,
-    "maintainer": "dreispt",
+    "maintainer": ["dreispt", "Shide", "EmilioPascual"],
     "development_status": "Beta",
 }

--- a/purchase_order_line_menu/models/__init__.py
+++ b/purchase_order_line_menu/models/__init__.py
@@ -1,4 +1,3 @@
-# Copyright (C) 2021 Open Source Integrators
 # Copyright (C) 2023 Moduon Team
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from . import models
+from . import purchase_order_line

--- a/purchase_order_line_menu/models/purchase_order_line.py
+++ b/purchase_order_line_menu/models/purchase_order_line.py
@@ -1,0 +1,18 @@
+# Copyright 2023 Moduon Team
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    invoice_status = fields.Selection(
+        related="order_id.invoice_status",
+        readonly=True,
+        store=True,
+        index=True,
+    )
+    date_order = fields.Datetime(
+        store=True,
+        index=True,
+    )

--- a/purchase_order_line_menu/readme/CONTRIBUTORS.rst
+++ b/purchase_order_line_menu/readme/CONTRIBUTORS.rst
@@ -3,3 +3,9 @@
   * Daniel Reis <dreis@opensourceintegrators.com>
   * Freni Patel <fpatel@opensourceintegrators.com>
   * Murtaza Mithaiwala <mmithaiwala@opensourceintegrators.com>
+
+  * `Moduon Team <https://moduon.team>`:
+
+    * Eduardo de Miguel <edu@moduon.team>
+    * Emilio Pascual <emilio@moduon.team>
+    * Rafael Blasco <rblasco@moduon.team>

--- a/purchase_order_line_menu/readme/DESCRIPTION.rst
+++ b/purchase_order_line_menu/readme/DESCRIPTION.rst
@@ -1,1 +1,1 @@
-Adds a menu item to list all Purchase Order lines.
+Adds a menu item and some views to navigate through Purchase Order lines.

--- a/purchase_order_line_menu/views/purchase_order_line_views.xml
+++ b/purchase_order_line_menu/views/purchase_order_line_views.xml
@@ -1,20 +1,165 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Moduon Team
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
+
+    <record id="purchase_order_line_tree" model="ir.ui.view">
+        <field name="name">purchase.order.line.tree</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_tree" />
+        <field name="mode">primary</field>
+        <field name="priority">17</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_id']" position="after">
+                <field name="state" optional="hide" />
+                <field name="invoice_status" optional="hide" />
+            </xpath>
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field name="product_type" optional="hide" />
+            </xpath>
+            <xpath expr="//field[@name='product_qty']" position="after">
+                <field name="qty_invoiced" optional="hide" />
+                <field name="qty_to_invoice" optional="hide" />
+                <field name="qty_received" optional="hide" />
+                <field name="qty_received_manual" optional="hide" />
+            </xpath>
+            <xpath expr="//field[@name='price_subtotal']" position="after">
+                <field name="taxes_id" widget="many2many_tags" optional="hide" />
+                <field
+                    name="price_tax"
+                    widget="monetary"
+                    optional="hide"
+                    sum="Price Tax"
+                />
+                <field name="price_total" optional="hide" sum="Price Total" />
+            </xpath>
+            <xpath expr="//field[@name='price_subtotal']" position="attributes">
+                <attribute name="sum">Price Subtotal</attribute>
+            </xpath>
+            <xpath expr="//field[@name='date_planned']" position="before">
+                <field name="date_order" optional="show" widget="date" />
+            </xpath>
+            <xpath expr="//tree" position="inside">
+                <field name="product_packaging_id" optional="hide" />
+            </xpath>
+            <xpath expr="//field[@name='name']" position="attributes">
+                <attribute name="optional">show</attribute>
+            </xpath>
+            <xpath expr="//field[@name='date_planned']" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </xpath>
+            <xpath expr="/tree" postion="inside">
+                <field
+                    name="invoice_lines"
+                    widget="many2many_tags"
+                    groups="account.group_account_invoice"
+                    optional="hide"
+                />
+            </xpath>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="view_purchase_order_line_pivot">
         <field name="name">purchase.order.line.pivot</field>
         <field name="model">purchase.order.line</field>
         <field name="arch" type="xml">
             <pivot string="Order Lines" sample="1">
                 <field name="product_id" type="row" />
-                <field name="product_qty" type="col" />
+                <field name="date_order" type="col" />
                 <field name="price_subtotal" type="measure" />
             </pivot>
         </field>
     </record>
+
+    <record id="purchase_order_line_search" model="ir.ui.view">
+        <field name="name">purchase.order.line.search</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_search" />
+        <field name="mode">primary</field>
+        <field name="priority">999</field>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='hide_cancelled']" position="replace">
+                <filter
+                    name="flt_state_draft"
+                    string="RFQ"
+                    domain="[('state','=','draft')]"
+                />
+                <filter
+                    name="flt_state_sent"
+                    string="RFQ Sent"
+                    domain="[('state','=','sent')]"
+                />
+                <filter
+                    name="flt_state_to_approve"
+                    string="To Approve"
+                    domain="[('state','=','to_approve')]"
+                />
+                <filter
+                    name="flt_state_purchase"
+                    string="Purchase Order"
+                    domain="[('state','=','purchase')]"
+                />
+                <filter
+                    name="flt_state_done"
+                    string="Locked"
+                    domain="[('state','=','done')]"
+                />
+                <filter
+                    name="flt_state_cancel"
+                    string="Cancelled"
+                    domain="[('state','=','cancel')]"
+                />
+                <separator />
+                <filter
+                    name="flt_invoice_status_no"
+                    string="Nothing to Bill"
+                    domain="[('invoice_status','=','no')]"
+                />
+                <filter
+                    name="flt_invoice_status_to_invoice"
+                    string="Waiting Bills"
+                    domain="[('invoice_status','=','to invoice')]"
+                />
+                <filter
+                    name="flt_invoice_status_invoiced"
+                    string="Fully Billed"
+                    domain="[('invoice_status','=','invoiced')]"
+                />
+                <separator />
+                <filter name="flt_date_order" string="Order date" date="date_order" />
+                <separator />
+                <filter
+                    name="flt_date_planned"
+                    string="Planned date"
+                    date="date_planned"
+                />
+                <separator />
+            </xpath>
+            <xpath expr="//group" position="inside">
+                <filter
+                    name="groupby_invoice_status"
+                    string="Billing Status"
+                    context="{'group_by' : 'invoice_status'}"
+                />
+                <filter
+                    name="groupby_date_order"
+                    string="Order Date"
+                    context="{'group_by' : 'date_order'}"
+                />
+            </xpath>
+        </field>
+    </record>
+
     <record id="action_purchase_orders_lines" model="ir.actions.act_window">
         <field name="name">Purchase Order Lines</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">purchase.order.line</field>
-        <field name="view_mode">tree,pivot</field>
+        <field name="view_mode">tree,form,pivot</field>
+        <field
+            name="search_view_id"
+            ref="purchase_order_line_menu.purchase_order_line_search"
+        />
+        <field name="view_id" ref="purchase_order_line_menu.purchase_order_line_tree" />
     </record>
 
     <menuitem
@@ -24,6 +169,5 @@
         parent="purchase.menu_procurement_management"
         sequence="7"
     />
-
 
 </odoo>


### PR DESCRIPTION
New views and fields added to the purchase order line menu

MT-2028 @moduon @rafaelbn @dreispt please review

This is the fordward port of https://github.com/OCA/purchase-workflow/pull/1928 and https://github.com/OCA/purchase-workflow/pull/1964