### PR TITLE
[15.0][FIX] purchase_request: default payment_terms when create RFQ

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -126,6 +126,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         data = {
             "origin": origin,
             "partner_id": self.supplier_id.id,
+            "payment_term_id": self.supplier_id.property_supplier_payment_term_id.id,
             "fiscal_position_id": supplier.property_account_position_id
             and supplier.property_account_position_id.id
             or False,


### PR DESCRIPTION
Step to error
1. Create PR > Submit > Create RFQ
2. Select Supplier with there is payment terms in master data > Create RFQ
3. RFQ is created but Payment Term is no value (it should default from master supplier)