### PR TITLE
[15.0][FIX] purchase_stock_price_unit_sync: Apply sudo() to avoid access errors when accessing stock.valuation.layer

### DIFF
--- a/purchase_stock_price_unit_sync/models/purchase_order.py
+++ b/purchase_stock_price_unit_sync/models/purchase_order.py
@@ -33,6 +33,7 @@ class PurchaseOrderLine(models.Model):
                 bom_type="phantom",
             ):
                 continue
+            line.move_ids.write({"price_unit": line._get_stock_move_price_unit()})
             line.move_ids.mapped("stock_valuation_layer_ids").filtered(
                 # Filter children SVLs (like landed cost)
                 lambda x: not x.stock_valuation_layer_id

--- a/purchase_stock_price_unit_sync/models/purchase_order.py
+++ b/purchase_stock_price_unit_sync/models/purchase_order.py
@@ -10,8 +10,11 @@ class PurchaseOrderLine(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if ("price_unit" in vals or "discount" in vals) and (
-            not self.env.context.get("skip_stock_price_unit_sync")
+        if (
+            ("price_unit" in vals or "discount" in vals)
+            and not self.env.context.get("skip_stock_price_unit_sync")
+            # This context is present when the purchase_discount hack is being made
+            and not self.env.context.get("skip_update_price_unit")
         ):
             self.stock_price_unit_sync()
         return res

--- a/purchase_stock_price_unit_sync/tests/test_purchase_stock_price_unit_sync.py
+++ b/purchase_stock_price_unit_sync/tests/test_purchase_stock_price_unit_sync.py
@@ -1,14 +1,25 @@
 # Copyright 2019 Tecnativa - Carlos Dauden
 # Copyright 2019 Tecnativa - Sergio Teruel
+# Copyright 2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, new_test_user, users
 
 
 class TestProductCostPriceAvcoSync(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                mail_create_nolog=True,
+                mail_create_nosubscribe=True,
+                mail_notrack=True,
+                no_reset_password=True,
+                tracking_disable=True,
+            )
+        )
         cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
         cls.product_category = cls.env["product.category"].create(
             {
@@ -45,13 +56,19 @@ class TestProductCostPriceAvcoSync(TransactionCase):
                 ],
             }
         )
+        new_test_user(
+            cls.env, login="test-purchase-user", groups="purchase.group_purchase_user"
+        )
 
+    @users("test-purchase-user")
     def test_sync_cost_price(self):
+        self.order = self.order.with_user(self.env.user)
         self.order.button_confirm()
         picking = self.order.picking_ids[:1]
         move = picking.move_lines[:1]
         move.quantity_done = move.product_uom_qty
         picking._action_done()
-        self.assertAlmostEqual(move.stock_valuation_layer_ids[:1].unit_cost, 8.0, 2)
+        svl = move.sudo().stock_valuation_layer_ids[:1]
+        self.assertAlmostEqual(svl.unit_cost, 8.0, 2)
         self.order.order_line[:1].price_unit = 6.0
-        self.assertAlmostEqual(move.stock_valuation_layer_ids[:1].unit_cost, 6.0, 2)
+        self.assertAlmostEqual(svl.unit_cost, 6.0, 2)


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/purchase-workflow/pull/1997 + https://github.com/OCA/purchase-workflow/pull/1480 + https://github.com/OCA/purchase-workflow/pull/1991

Apply `sudo()` to avoid access errors when accessing `stock.valuation.layer`

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT45036