### PR TITLE
[14.0][FIX] purchase_stock_price_unit_sync: Change to the appropriate context used in purchase_discount v14

### DIFF
--- a/purchase_stock_price_unit_sync/models/purchase_order.py
+++ b/purchase_stock_price_unit_sync/models/purchase_order.py
@@ -14,7 +14,7 @@ class PurchaseOrderLine(models.Model):
             ("price_unit" in vals or "discount" in vals)
             and not self.env.context.get("skip_stock_price_unit_sync")
             # This context is present when the purchase_discount hack is being made
-            and not self.env.context.get("purchase_discount")
+            and not self.env.context.get("bypass_override_price_unit")
         ):
             self.stock_price_unit_sync()
         return res


### PR DESCRIPTION
Change to the appropriate context used in `purchase_discount` v14

This is only necessary in v14, in v13 the context was `purchase_discount` (https://github.com/OCA/purchase-workflow/blob/13.0/purchase_discount/models/purchase_order.py#L72C31-L72C48) and in v15 it is `skip_update_price_unit` (https://github.com/OCA/purchase-workflow/blob/15.0/purchase_discount/models/purchase_order.py#L72C34-L72C56).

Please @pedrobaeza can you review it?

@Tecnativa