### PR TITLE
[15.0][FIX] purchase_representative: allow to get the representative in MRP

### DIFF
--- a/purchase_representative/models/stock_rule.py
+++ b/purchase_representative/models/stock_rule.py
@@ -9,7 +9,9 @@ class StockRule(models.Model):
 
     def _run_buy(self, procurements):
         for procurement, _rule in procurements:
-            procurement.values["propagate_create_uid"] = self.env.uid
+            procurement.values["propagate_create_uid"] = self._context.get(
+                "uid", self.env.uid
+            )
         return super()._run_buy(procurements)
 
     def _prepare_purchase_order(self, company_id, origins, values):


### PR DESCRIPTION
This PR fixes the following issue:

Steps to reproduce:

- Configure raw material as MTO.
- Create a mrp.production with that raw material.


Current behavior:
- The PO is created with representative Odoobot.

Expected behavior:
- The PO is created with the user that confirms the production


