### PR TITLE
[IMP] purchase_request: transfer requested by user to purchase request

### DIFF
--- a/purchase_request/models/stock_rule.py
+++ b/purchase_request/models/stock_rule.py
@@ -41,6 +41,7 @@ class StockRule(models.Model):
             "company_id": values["company_id"].id,
             "picking_type_id": self.picking_type_id.id,
             "group_id": group_id or False,
+            "requested_by": self._context.get("uid", self.env.user.id),
         }
 
     @api.model


### PR DESCRIPTION
This PR improves the Purchase Request.

If another document is created and the product is configured as MTO and to create a purchase request.

It will create a purchase request, with odoobot as requested by.

With this change, the user will be passed to the Purchase Request