### PR TITLE
[16.0][IMP] purchase_order_line_menu: Remove form in action

### DIFF
--- a/purchase_order_line_menu/views/purchase_order_line_views.xml
+++ b/purchase_order_line_menu/views/purchase_order_line_views.xml
@@ -154,7 +154,7 @@
         <field name="name">Purchase Order Lines</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">purchase.order.line</field>
-        <field name="view_mode">tree,form,pivot</field>
+        <field name="view_mode">tree,pivot</field>
         <field
             name="search_view_id"
             ref="purchase_order_line_menu.purchase_order_line_search"


### PR DESCRIPTION
Cherry-pick https://github.com/OCA/purchase-workflow/pull/1845/commits/863b1dbab393a4957d1dece771aed6adb08d55b0 from pr https://github.com/OCA/purchase-workflow/pull/1845
Overwrite behaviour in pr: https://github.com/OCA/purchase-workflow/pull/1971.
 