### PR TITLE
[16.0][FIX] purchase_discount: Don't call _select_seller without product

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -88,7 +88,7 @@ class PurchaseOrderLine(models.Model):
         selected one.
         """
         res = super()._compute_price_unit_and_date_planned_and_name()
-        for line in self:
+        for line in self.filtered("product_id"):
             seller = line.product_id._select_seller(
                 partner_id=line.partner_id,
                 quantity=line.product_qty,

--- a/purchase_discount/tests/test_purchase_discount.py
+++ b/purchase_discount/tests/test_purchase_discount.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, TransactionCase
 
 
 class TestPurchaseOrder(TransactionCase):
@@ -108,6 +108,15 @@ class TestPurchaseOrder(TransactionCase):
                 "price_unit": 10.0,
             }
         )
+        cls.po_line_4 = po_model.create(
+            {
+                "order_id": cls.purchase_order.id,
+                "display_type": "line_section",
+                "name": "Test Section",
+                "product_qty": 0.0,
+                "product_uom_qty": 0.0,
+            }
+        )
 
     def test_purchase_order_vals(self):
         self.assertEqual(self.po_line_1.price_subtotal, 5.0)
@@ -168,6 +177,12 @@ class TestPurchaseOrder(TransactionCase):
         )
         self.assertEqual(rec.price_total, 5)
         self.assertEqual(rec.discount, 50)
+
+    def test_no_product(self):
+        purchase_form = Form(self.purchase_order)
+        with purchase_form.order_line.edit(3) as line:
+            line.product_qty = 0.0
+        self.assertEqual(self.po_line_4.discount, 0.0)
 
     def test_invoice(self):
         invoice = self.env["account.move"].new(


### PR DESCRIPTION
An example of failed job :

https://github.com/OCA/account-invoicing/actions/runs/6297612620/job/17094885728?pr=1562