### PR TITLE
[15.0][FIX] purchase_discount: ocb compatibility

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -65,6 +65,8 @@ class PurchaseOrderLine(models.Model):
         HACK: This is needed while https://github.com/odoo/odoo/pull/29983
         is not merged.
         """
+        if hasattr(self.env, "ocb"):
+            return super()._get_stock_move_price_unit()
         # Use 'skip_update_price_unit' context key to avoid infinite
         # recursion. Updating the price_unit field here triggers the
         # 'write' method of 'purchase.order.line' in stock_account

--- a/purchase_discount/models/stock_move.py
+++ b/purchase_discount/models/stock_move.py
@@ -20,6 +20,8 @@ class StockMove(models.Model):
         HACK: This is needed while https://github.com/odoo/odoo/pull/29983
         is not merged.
         """
+        if hasattr(self.env, "ocb"):
+            return super()._get_price_unit()
         price_unit = False
         po_line = self.purchase_line_id
         if po_line and self.product_id == po_line.product_id:


### PR DESCRIPTION
- fw of https://github.com/OCA/purchase-workflow/pull/2021

Since 21a01c303347b8b80d0ffa555ed72e680c251e76 we already have proper hooks in OCB so we don't need to do nasty hacks, but we need to keep compatibility with both Odoo and OCB.

- useful when https://github.com/OCA/OCB/pull/1192 is merged

cc @Tecnativa TT45385