### PR TITLE
[15.0][FIX] purchase_stock_return_request: `_for_xml_id()` retrieving action

### DIFF
--- a/purchase_stock_return_request/models/stock_return_request.py
+++ b/purchase_stock_return_request/models/stock_return_request.py
@@ -32,17 +32,18 @@ class StockReturnRequest(models.Model):
 
     def action_view_purchases(self):
         """Display returned purchases"""
-        action = self.env.ref("purchase.purchase_form_action")
-        result = action.read()[0]
-        result["context"] = {}
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "purchase.purchase_form_action"
+        )
+        action["context"] = {}
         purchases = self.mapped("purchase_order_ids")
         if len(purchases) != 1:
-            result["domain"] = "[('id', 'in', %s)]" % (purchases.ids)
+            action["domain"] = "[('id', 'in', %s)]" % (purchases.ids)
         else:
             res = self.env.ref("purchase.purchase_order_form", False)
-            result["views"] = [(res and res.id or False, "form")]
-            result["res_id"] = purchases.id
-        return result
+            action["views"] = [(res and res.id or False, "form")]
+            action["res_id"] = purchases.id
+        return action
 
     @api.model
     def _get_po_price_unit(self, move_line):

--- a/purchase_stock_return_request/tests/test_stock_return_request.py
+++ b/purchase_stock_return_request/tests/test_stock_return_request.py
@@ -115,3 +115,5 @@ class PurchaseReturnRequestCase(StockReturnRequestCase):
         self.assertAlmostEqual(
             sum(purchase_orders.mapped("order_line.qty_received")), 66.0
         )
+        action = self.return_request_supplier.action_view_purchases()
+        self.assertEqual(action["domain"], "[('id', 'in', %s)]" % purchase_orders.ids)


### PR DESCRIPTION
Normal users won't access purchases from a return request, this fix it.