### PR TITLE
[13.0][IMP] purchase_blanket_order: avoid overwrite context in views inherited

### DIFF
--- a/purchase_blanket_order/__manifest__.py
+++ b/purchase_blanket_order/__manifest__.py
@@ -8,7 +8,11 @@
     "version": "13.0.2.3.0",
     "website": "https://github.com/OCA/purchase-workflow",
     "summary": "Purchase Blanket Orders",
-    "depends": ["purchase", "web_action_conditionable"],
+    "depends": [
+        "purchase",
+        "web_action_conditionable",
+        "base_view_inheritance_extension",
+    ],
     "data": [
         "security/ir.model.access.csv",
         "security/security.xml",

--- a/purchase_blanket_order/views/purchase_order_views.xml
+++ b/purchase_blanket_order/views/purchase_order_views.xml
@@ -14,7 +14,11 @@
                 />
             </field>
             <field name="order_line" position="attributes">
-                <attribute name="context">{'from_purchase_order': True}</attribute>
+                <attribute
+                    name="context"
+                    operation="python_dict"
+                    key="from_purchase_order"
+                >True</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Change the method of writing the context in the field order_line to avoid overwriting.


@ForgeFlow