### PR TITLE
[IMP] Purchase order total weight volume in UOM company

### DIFF
--- a/purchase_order_weight_volume/report/purchase_report_templates.xml
+++ b/purchase_order_weight_volume/report/purchase_report_templates.xml
@@ -14,14 +14,14 @@
                             <td><strong>Total Weight</strong></td>
                             <td class="text-right">
                                 <span t-field="o.total_weight" />
-                                <span t-field="o.weight_uom_name" />
+                                <span t-field="o.total_weight_uom_id" />
                             </td>
                         </tr>
                         <tr t-if="o.display_total_volume_in_report">
                             <td><strong>Total Volume</strong></td>
                             <td class="text-right">
                                 <span t-field="o.total_volume" />
-                                <span t-field="o.volume_uom_name" />
+                                <span t-field="o.total_volume_uom_id" />
                             </td>
                         </tr>
                     </table>
@@ -49,11 +49,11 @@
         <xpath expr="//span[@t-field='order_line.product_qty']/.." position="before">
             <td t-if="o.display_total_weight_in_report" class="text-right">
                 <span t-field="order_line.line_weight" />
-                <span t-field="order_line.order_id.weight_uom_name" />
+                <span t-field="order_line.order_id.total_weight_uom_id" />
             </td>
             <td t-if="o.display_total_volume_in_report" class="text-right">
                 <span t-field="order_line.line_volume" />
-                <span t-field="order_line.order_id.volume_uom_name" />
+                <span t-field="order_line.order_id.total_volume_uom_id" />
             </td>
         </xpath>
     </template>
@@ -71,14 +71,14 @@
                             <td><strong>Total Weight</strong></td>
                             <td class="text-right">
                                 <span t-field="o.total_weight" />
-                                <span t-field="o.weight_uom_name" />
+                                <span t-field="o.total_weight_uom_id" />
                             </td>
                         </tr>
                         <tr t-if="o.display_total_volume_in_report">
                             <td><strong>Total Volume</strong></td>
                             <td class="text-right">
                                 <span t-field="o.total_volume" />
-                                <span t-field="o.volume_uom_name" />
+                                <span t-field="o.total_volume_uom_id" />
                             </td>
                         </tr>
                     </table>
@@ -106,11 +106,11 @@
         <xpath expr="//span[@t-field='line.product_qty']/.." position="before">
             <td t-if="o.display_total_weight_in_report" class="text-right">
                 <span t-field="line.line_weight" />
-                <span t-field="line.order_id.weight_uom_name" />
+                <span t-field="line.order_id.total_weight_uom_id" />
             </td>
             <td t-if="o.display_total_volume_in_report" class="text-right">
                 <span t-field="line.line_volume" />
-                <span t-field="line.order_id.volume_uom_name" />
+                <span t-field="line.order_id.total_volume_uom_id" />
             </td>
         </xpath>
     </template>

--- a/purchase_order_weight_volume/tests/test_purchase_order_weight_volume.py
+++ b/purchase_order_weight_volume/tests/test_purchase_order_weight_volume.py
@@ -80,26 +80,26 @@ class TestPurchaseOrderWeightVolume(TransactionCase):
     @classmethod
     def _prepare_uom(cls):
         # Configure weight in kg
-        cls.env["ir.config_parameter"].sudo().set_param("product.weight_in_lbs", 0)
-
         cls.product_uom_kgm = cls.env.ref("uom.product_uom_kgm")
-
-        # Configure volume in m3
         cls.env["ir.config_parameter"].sudo().set_param(
-            "product.volume_in_cubic_feet", 0
+            "product_default_weight_uom_id", cls.product_uom_kgm.id
         )
 
+        # Configure volume in m3
         cls.product_uom_cubic_meter = cls.env.ref("uom.product_uom_cubic_meter")
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "product_default_volume_uom_id", cls.product_uom_cubic_meter.id
+        )
 
     def test_purchase_order_weight_volume(self):
         po = self._create_purchase(self.line_products)
 
         # Purchase Order
         self.assertEqual(po.total_weight, self.total_weight)
-        self.assertEqual(po.weight_uom_name, self.product_uom_kgm.name)
+        self.assertEqual(po.total_weight_uom_id, self.product_uom_kgm)
 
         self.assertEqual(po.total_volume, self.total_volume)
-        self.assertEqual(po.volume_uom_name, self.product_uom_cubic_meter.name)
+        self.assertEqual(po.total_volume_uom_id, self.product_uom_cubic_meter)
 
         # Purchase Order Line
         for line in po.order_line:

--- a/purchase_order_weight_volume/views/purchase_order_view.xml
+++ b/purchase_order_weight_volume/views/purchase_order_view.xml
@@ -13,35 +13,40 @@
                 <field name="line_weight" optional="hide" />
                 <field name="line_volume" optional="hide" />
             </xpath>
-            <xpath expr="//field[@name='tax_totals']" position="after">
-                <label
-                    for="total_weight"
-                    attrs="{'invisible':[('weight_uom_name', '=', '')]}"
-                />
-                <div
-                    class="text-nowrap"
-                    attrs="{'invisible':[('weight_uom_name', '=', '')]}"
-                >
-                    <field name="total_weight" class="oe_inline" />
-                    <span style="margin-left:3px;"><field
-                            name="weight_uom_name"
-                            class="oe_inline"
-                        /></span>
-                </div>
-                <label
-                    for="total_volume"
-                    attrs="{'invisible':[('volume_uom_name', '=', '')]}"
-                />
-                <div
-                    class="text-nowrap"
-                    attrs="{'invisible':[('volume_uom_name', '=', '')]}"
-                >
-                    <field name="total_volume" class="oe_inline" />
-                    <span style="margin-left:3px;"><field
-                            name="volume_uom_name"
-                            class="oe_inline"
-                        /></span>
-                </div>
+            <xpath
+                expr="//field[@name='tax_totals']/parent::group[last()]/parent::group[last()]"
+                position="after"
+            >
+                <group class="oe_right">
+                    <label
+                        for="total_weight"
+                        attrs="{'invisible':[('total_weight_uom_id', '=', False)]}"
+                    />
+                    <div
+                        class="text-nowrap"
+                        attrs="{'invisible':[('total_weight_uom_id', '=', False)]}"
+                    >
+                        <field name="total_weight" class="oe_inline" />
+                        <span style="margin-left:3px;"><field
+                                name="total_weight_uom_id"
+                                class="oe_inline pull-right"
+                            /></span>
+                    </div>
+                    <label
+                        for="total_volume"
+                        attrs="{'invisible':[('total_volume_uom_id', '=', False)]}"
+                    />
+                    <div
+                        class="text-nowrap"
+                        attrs="{'invisible':[('total_volume_uom_id', '=', False)]}"
+                    >
+                        <field name="total_volume" class="oe_inline" />
+                        <span style="margin-left:3px;"><field
+                                name="total_volume_uom_id"
+                                class="oe_inline pull-right"
+                            /></span>
+                    </div>
+                </group>
             </xpath>
             <field name="fiscal_position_id" position="after">
                 <field name="display_total_weight_in_report" />


### PR DESCRIPTION
### Context
`line_volume` is always in company uom as `line.product_id.volume` is in company uom

```
    @api.depends("product_uom_qty", "product_id")
    def _compute_line_physical_properties(self):
        for line in self:
            line.line_weight = line.product_id.weight * line.product_uom_qty
            line.line_volume = line.product_id.volume * line.product_uom_qty 
```
https://github.com/OCA/purchase-workflow/blob/07de3b3ca6ee00aa2c793e36e9bb040669eea047/purchase_order_weight_volume/models/purchase_order.py#L20

The total volume is the sum of  `line_volume`. That is working well.

But the total volume is shown only if the char field `volume_uom_name` is populated and all the products have the same uom:
    volume_uom_name = fields.Char(compute="_compute_total_physical_properties")

https://github.com/OCA/purchase-workflow/blob/07de3b3ca6ee00aa2c793e36e9bb040669eea047/purchase_order_weight_volume/views/purchase_order_view.xml#L33C30-L33C39

 
When PO lines have several volume UOMs the total is hidden 

```
            if po.company_id.display_order_volume_in_po:
                volume_uoms = po.mapped("order_line.product_id.volume_uom_name")
                if len(volume_uoms) > 0:
                    same_volume_uom = all(el == volume_uoms[0] for el in volume_uoms)
                    if same_volume_uom:
                        po.total_volume = sum(po.mapped("order_line.line_volume"))
                        po.volume_uom_name = volume_uoms[0]
```
 

### Proposal:

The PO total volume should be shown and calculated if the company setting  `product_default_volume_uom_id` is defined.

Also some fixing done on the view presentation:
![image](https://github.com/OCA/purchase-workflow/assets/67733397/c7205ae2-d472-4736-9a65-2f65abaec42a)

