### PR TITLE
[15.0][IMP] purchase_blanket_order: avoid overwrite context in views inherited

### DIFF
--- a/purchase_blanket_order/__manifest__.py
+++ b/purchase_blanket_order/__manifest__.py
@@ -8,7 +8,11 @@
     "version": "15.0.1.3.1",
     "website": "https://github.com/OCA/purchase-workflow",
     "summary": "Purchase Blanket Orders",
-    "depends": ["purchase", "web_action_conditionable"],
+    "depends": [
+        "purchase",
+        "web_action_conditionable",
+        "base_view_inheritance_extension",
+    ],
     "data": [
         "security/ir.model.access.csv",
         "security/security.xml",

--- a/purchase_blanket_order/views/purchase_order_views.xml
+++ b/purchase_blanket_order/views/purchase_order_views.xml
@@ -17,7 +17,10 @@
                 />
             </xpath>
             <field name="order_line" position="attributes">
-                <attribute name="context">{'from_purchase_order': True}</attribute>
+                <attribute
+                    name="context"
+                    operation="update"
+                >{'from_purchase_order': True}</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Forwardport of https://github.com/OCA/purchase-workflow/pull/2031