### PR TITLE
[15.0][FIX] purchase_request: activity assigned user upon procurement cancellation

### DIFF
--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -54,6 +54,14 @@ class StockMove(models.Model):
                 except ValueError:
                     activity_type_id = False
                 pr_line = move.created_purchase_request_line_id
+                if pr_line.product_id.responsible_id:
+                    activity_user = pr_line.product_id.responsible_id
+                elif pr_line.request_id.assigned_to:
+                    activity_user = pr_line.request_id.assigned_to
+                elif move.picking_id.user_id:
+                    activity_user = move.picking_id.user_id
+                else:
+                    activity_user = self.env.user
                 self.env["mail.activity"].sudo().create(
                     {
                         "activity_type_id": activity_type_id,
@@ -62,7 +70,7 @@ class StockMove(models.Model):
                             "purchase request has been cancelled/deleted. "
                             "Check if an action is needed."
                         ),
-                        "user_id": pr_line.product_id.responsible_id.id,
+                        "user_id": activity_user.id,
                         "res_id": pr_line.request_id.id,
                         "res_model_id": self.env.ref(
                             "purchase_request.model_purchase_request"


### PR DESCRIPTION
Create a MTO sales order with a product that has purchase request activated in the routes section and has no responsible. Confirm the SO. Cancel the SO. The system fails because it tries to create a mail activity for the responsible of the product.
![mail_activity_error](https://github.com/OCA/purchase-workflow/assets/19620251/9dc358dc-68e6-4b0a-be9c-5d5f66959a65)


I keep the criteria in case there is a responsible (that also matches Odoo standard activity for purchases), then I choose the responsible of the purchase request, otherwise I choose the user that cancelled the sales order.

cc @ForgeFlow