### PR TITLE
[15.0][FIX] sale_purchase_secondary_unit: When a so is cancelled the secondary_uom_qty on po lines is not updated

### DIFF
--- a/sale_purchase_secondary_unit/models/sale_order.py
+++ b/sale_purchase_secondary_unit/models/sale_order.py
@@ -5,6 +5,17 @@
 from odoo import models
 
 
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def action_cancel(self):
+        # When a SO linked to a purchase order is cancelled we must update the
+        # secondary_uom_qty on po line
+        return super(
+            SaleOrder, self.with_context(cancelled_so_lines=self.order_line.ids)
+        ).action_cancel()
+
+
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 

--- a/sale_purchase_secondary_unit/models/stock_rule.py
+++ b/sale_purchase_secondary_unit/models/stock_rule.py
@@ -42,7 +42,10 @@ class StockRule(models.Model):
             moves = self.env["stock.move"].browse(
                 list(moves_dest._rollup_move_dests(set()))
             )
-            sale_lines = moves.mapped("sale_line_id")
+            cancelled_so_lines = self.env.context.get("cancelled_so_lines", [])
+            sale_lines = moves.mapped("sale_line_id").filtered(
+                lambda ln: ln.id not in cancelled_so_lines
+            )
             vals["secondary_uom_qty"] = sum(sale_lines.mapped("secondary_uom_qty"))
         return vals
 


### PR DESCRIPTION
…ary_uom_qty on po lines is not updated

cc @Tecnativa TT45601

ping @carlosdauden @CarlosRoca13 
