### PR TITLE
[15.0][IMP] purchase_tier_validation: Add decoration to purchase tree view when orders have been rejected or approved.

### DIFF
--- a/purchase_tier_validation/views/purchase_order_view.xml
+++ b/purchase_tier_validation/views/purchase_order_view.xml
@@ -24,4 +24,21 @@
             </filter>
         </field>
     </record>
+    <record id="purchase_order_kpis_tree" model="ir.ui.view">
+        <field name="name">purchase.order.inherit.purchase.order.tree</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_kpis_tree" />
+        <field name="arch" type="xml">
+            <tree position="inside">
+                <field
+                    name="validation_status"
+                    widget="badge"
+                    optional="hide"
+                    decoration-info="validation_status == 'pending'"
+                    decoration-danger="validation_status == 'rejected'"
+                    decoration-success="validation_status == 'validated'"
+                />
+            </tree>
+        </field>
+    </record>
 </odoo>

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo_test_helper


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/purchase-workflow/pull/1440

Add decoration to purchase tree view when orders have been rejected or approved.

![ejemplo-v14](https://github.com/OCA/purchase-workflow/assets/4117568/2ce7ac2e-ed19-40b0-b99c-cd9661bc6e02)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT33369