### PR TITLE
[16.0][FIX] purchase_request: default payment_terms when create RFQ

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -128,6 +128,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         data = {
             "origin": origin,
             "partner_id": self.supplier_id.id,
+            "payment_term_id": self.supplier_id.property_supplier_payment_term_id.id,
             "fiscal_position_id": supplier.property_account_position_id
             and supplier.property_account_position_id.id
             or False,


### PR DESCRIPTION
Cherry-pick from https://github.com/OCA/purchase-workflow/pull/1992