### PR TITLE
[IMP] purchase_order_weight_volume store total weight volume store

### DIFF
--- a/purchase_order_weight_volume/models/purchase_order.py
+++ b/purchase_order_weight_volume/models/purchase_order.py
@@ -26,15 +26,22 @@ class PurchaseOrder(models.Model):
     total_weight = fields.Float(
         compute="_compute_total_physical_properties",
         digits="Stock Weight",
+        store=True,
     )
     total_volume = fields.Float(
-        compute="_compute_total_physical_properties", digits="Volume"
+        compute="_compute_total_physical_properties",
+        digits="Volume",
+        store=True,
     )
     total_weight_uom_id = fields.Many2one(
-        "uom.uom", compute="_compute_total_physical_properties"
+        "uom.uom",
+        compute="_compute_total_physical_properties",
+        store=True,
     )
     total_volume_uom_id = fields.Many2one(
-        "uom.uom", compute="_compute_total_physical_properties"
+        "uom.uom",
+        compute="_compute_total_physical_properties",
+        store=True,
     )
     display_total_weight_in_report = fields.Boolean(
         "Display Weight in Report", default=True


### PR DESCRIPTION
### Context

Often we need to search or apply a domain on the fields total weight and volume. To do it we need to store  the field.

Also if we store those values we keep the right value in the PO even if the configuration of the product change in time.