### PR TITLE
[FIX] purchase_quick: price_unit when qty_to_process is less than seller’s qty_min

### DIFF
--- a/purchase_quick/models/purchase_order.py
+++ b/purchase_quick/models/purchase_order.py
@@ -4,6 +4,8 @@
 # @author Pierrick Brun <pierrick.brun@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from collections import OrderedDict
+
 from odoo import _, models
 from odoo.exceptions import ValidationError
 
@@ -49,10 +51,13 @@ class PurchaseOrder(models.Model):
         return result
 
     def _get_quick_line_qty_vals(self, product):
-        return {
-            "product_uom": product.quick_uom_id.id,
-            "product_qty": product.qty_to_process,
-        }
+        return OrderedDict(
+            {
+                "product_id": None,
+                "product_uom": product.quick_uom_id.id,
+                "product_qty": product.qty_to_process,
+            }
+        )
 
     def _complete_quick_line_vals(self, vals, lines_key=""):
         # This params are need for playing correctly the onchange


### PR DESCRIPTION
There is a bug when entering in the purchase_quick window a qty_to_process lower than the qty_min of the vendor. 
When saving qty_to_process less than the supplier's qty_min from the assistant, the purchase line shows the supplier's price and not the standard_price, which is Odoo's default behavior when it does not find a pricelist for that supplier/product/min_qty.

**To reproduce the error:**
1. Create a pricelist for a product with minimum quantity greater than one.
2. Create a purchase.
3. Select the same partner of the pricelist created in step 1.
4. Click on ADD to open the tree view of the purchase_quick assistant.
5. Select the product of the tariff created in point 1 and enter the quantity to process = 1.

When you click on save changes and return to the purchase order, you can see that the unit_price of the purchase line is equal to the supplier's price instead of the standard_price of the product as expected.

We have discovered that this is caused by the order in which the onchanges are executed when a new line is added to the purchase order.
https://github.com/OCA/product-attribute/blob/41aed8baccd994ff684b2c6b25cd662956e016c6/base_product_mass_addition/models/product_mass_addition.py#L73

The order in which the onchanges are executed is very important.
https://github.com/OCA/server-tools/blob/cd2f828fed05a65aae0dc18eef26bc6f2eb31d39/onchange_helper/models/base.py#L29


In addition, we have added a test to check this case.
