### PR TITLE
[FIX] purchase_fop_shipping: purchase fop should not block negative PO

### DIFF
--- a/purchase_fop_shipping/models/purchase.py
+++ b/purchase_fop_shipping/models/purchase.py
@@ -35,6 +35,12 @@ class PurchaseOrder(models.Model):
     def _compute_fop_shipping_reached(self):
         digit_precision = self.env["decimal.precision"].precision_get("Account")
         for record in self:
+            if (
+                float_compare(record.amount_total, 0, precision_digits=digit_precision)
+                < 0
+            ):
+                record.fop_reached = True
+                continue
             record.fop_reached = (
                 float_compare(
                     record.amount_total,

--- a/purchase_fop_shipping/tests/test_fop_shipping.py
+++ b/purchase_fop_shipping/tests/test_fop_shipping.py
@@ -64,3 +64,22 @@ class TestPurchaseOrder(TransactionCase):
         self.assertTrue(po.fop_reached)
         po.button_approve()
         self.assertEqual(po.state, "purchase")
+
+    def test_fop_shipping_negative(self):
+        po = self.Purchase.create({"partner_id": self.partner_3.id})
+        self.PurchaseLine.create(
+            {
+                "order_id": po.id,
+                "product_id": self.product_1.id,
+                "date_planned": fields.Datetime.now(),
+                "name": "Test",
+                "product_qty": 1.0,
+                "product_uom": self.product_1.uom_id.id,
+                "price_unit": -100.0,
+            }
+        )
+
+        self.assertTrue(po.fop_reached)
+
+        po.button_approve()
+        self.assertEqual(po.state, "purchase")


### PR DESCRIPTION
The exception that the PO cannot be below the FOP should not raise when the PO is negative as this is allowed.