### PR TITLE
[16.0][FIX] purchase_allowed_product: use correct field name

### DIFF
--- a/purchase_allowed_product/models/product_supplierinfo.py
+++ b/purchase_allowed_product/models/product_supplierinfo.py
@@ -7,4 +7,5 @@ from odoo import fields, models
 class ProductSupplierinfo(models.Model):
     _inherit = "product.supplierinfo"
 
-    name = fields.Many2one("res.partner", index=True)
+    # Index partner_id
+    partner_id = fields.Many2one(index=True)


### PR DESCRIPTION
In V16 the field is renamed to partner_id in Odoo (https://github.com/odoo/odoo/blob/5941629609977512829e30b3ccd7ad376bc2b71b/addons/product/models/product_supplierinfo.py#L29)

CC @pedrobaeza @HaraldPanten @angelgarciadelachica