### PR TITLE
[15.0][FIX] purchase_discount: allow creating without product_tmpl_id

### DIFF
--- a/purchase_discount/models/product_supplierinfo.py
+++ b/purchase_discount/models/product_supplierinfo.py
@@ -28,7 +28,7 @@ class ProductSupplierInfo(models.Model):
         """Insert discount (or others) from context from purchase.order's
         _add_supplier_to_product method"""
         for vals in vals_list:
-            product_tmpl_id = vals["product_tmpl_id"]
+            product_tmpl_id = vals.get("product_tmpl_id")
             po_line_map = self.env.context.get("po_line_map", {})
             if product_tmpl_id in po_line_map:
                 po_line = po_line_map[product_tmpl_id]

--- a/purchase_discount/tests/test_product_supplierinfo_discount.py
+++ b/purchase_discount/tests/test_product_supplierinfo_discount.py
@@ -27,10 +27,10 @@ class TestProductSupplierinfoDiscount(TransactionCase):
             {
                 "min_qty": 10.0,
                 "name": cls.partner_3.id,
-                "product_tmpl_id": cls.product.product_tmpl_id.id,
                 "discount": 20,
             }
         )
+        cls.supplierinfo2["product_tmpl_id"] = cls.product.product_tmpl_id
         cls.purchase_order = cls.env["purchase.order"].create(
             {"partner_id": cls.partner_3.id}
         )


### PR DESCRIPTION
Previous code was expecting a non-required field to be passed always. Now it's more resilient.

@moduon MT-1075