### PR TITLE
[FIX] purchase_discount: allow creating without product_tmpl_id

### DIFF
--- a/purchase_discount/tests/test_product_supplierinfo_discount.py
+++ b/purchase_discount/tests/test_product_supplierinfo_discount.py
@@ -30,10 +30,12 @@ class TestProductSupplierinfoDiscount(TransactionCase):
             {
                 "min_qty": 10.0,
                 "partner_id": cls.partner_3.id,
-                "product_tmpl_id": cls.product.product_tmpl_id.id,
                 "discount": 20,
             }
         )
+        # Assign it later this value for testing that the record
+        # creation is not failing without this field
+        cls.supplierinfo2["product_tmpl_id"] = cls.product.product_tmpl_id
         cls.purchase_order = cls.env["purchase.order"].create(
             {"partner_id": cls.partner_3.id}
         )


### PR DESCRIPTION
Previous code was expecting a non-required field to be passed always. Now it's more resilient.

@moduon MT-1075 fwport-of https://github.com/OCA/purchase-workflow/pull/2079