### PR TITLE
[IMP] purchase_discount: allow hiding discount column

### DIFF
--- a/purchase_discount/views/purchase_discount_view.xml
+++ b/purchase_discount/views/purchase_discount_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="purchase.purchase_order_line_form2" />
         <field name="arch" type="xml">
             <field name="price_unit" position="after">
-                <field name="discount" />
+                <field name="discount" optional="show" />
             </field>
         </field>
     </record>
@@ -16,7 +16,7 @@
         <field name="inherit_id" ref="purchase.purchase_order_line_tree" />
         <field name="arch" type="xml">
             <field name="price_unit" position="after">
-                <field name="discount" />
+                <field name="discount" optional="show" />
             </field>
         </field>
     </record>
@@ -31,6 +31,7 @@
             >
                 <field
                     name="discount"
+                    optional="show"
                     attrs="{'readonly': [('qty_invoiced', '!=', 0)]}"
                 />
             </xpath>
@@ -40,6 +41,7 @@
             >
                 <field
                     name="discount"
+                    optional="show"
                     attrs="{'readonly': [('qty_invoiced', '!=', 0)]}"
                 />
             </xpath>


### PR DESCRIPTION
Still displayed by default, but it can be hidden now:

![flameshot_2023-11-03_11-09](https://github.com/OCA/purchase-workflow/assets/973709/f91851c5-d78b-44fe-a29f-181e7d879f56)


Fixes https://github.com/OCA/purchase-workflow/issues/2067.

@moduon MT-4081