### PR TITLE
[16.0][FIX] purchase_order_weight_volume: disable display on PO if settings display = False

### DIFF
--- a/purchase_order_weight_volume/models/purchase_order.py
+++ b/purchase_order_weight_volume/models/purchase_order.py
@@ -50,6 +50,25 @@ class PurchaseOrder(models.Model):
         "Display Volume in Report", default=True
     )
 
+    display_order_weight_in_po = fields.Boolean(
+        "Display Order Weight in PO",
+        compute="_compute_display_order",
+    )
+    display_order_volume_in_po = fields.Boolean(
+        "Display Order Volume in PO",
+        compute="_compute_display_order",
+    )
+
+    @api.depends("company_id")
+    def _compute_display_order(self):
+        for purchase in self:
+            self.display_order_weight_in_po = (
+                purchase.company_id.display_order_weight_in_po
+            )
+            self.display_order_volume_in_po = (
+                purchase.company_id.display_order_volume_in_po
+            )
+
     @api.depends("order_line.product_uom_qty", "order_line.product_id")
     def _compute_total_physical_properties(self):
         default_weight_uom = (

--- a/purchase_order_weight_volume/views/purchase_order_view.xml
+++ b/purchase_order_weight_volume/views/purchase_order_view.xml
@@ -20,11 +20,11 @@
                 <group class="oe_right">
                     <label
                         for="total_weight"
-                        attrs="{'invisible':[('total_weight_uom_id', '=', False)]}"
+                        attrs="{'invisible':['|',('total_weight_uom_id', '=', False),('display_order_weight_in_po', '=', False)]}"
                     />
                     <div
                         class="text-nowrap"
-                        attrs="{'invisible':[('total_weight_uom_id', '=', False)]}"
+                        attrs="{'invisible':['|',('total_weight_uom_id', '=', False),('display_order_weight_in_po', '=', False)]}"
                     >
                         <field name="total_weight" class="oe_inline" />
                         <span style="margin-left:3px;"><field
@@ -34,11 +34,11 @@
                     </div>
                     <label
                         for="total_volume"
-                        attrs="{'invisible':[('total_volume_uom_id', '=', False)]}"
+                        attrs="{'invisible':['|',('total_volume_uom_id', '=', False),('display_order_volume_in_po', '=', False)]}"
                     />
                     <div
                         class="text-nowrap"
-                        attrs="{'invisible':[('total_volume_uom_id', '=', False)]}"
+                        attrs="{'invisible':['|',('total_volume_uom_id', '=', False),('display_order_volume_in_po', '=', False)]}"
                     >
                         <field name="total_volume" class="oe_inline" />
                         <span style="margin-left:3px;"><field
@@ -51,6 +51,8 @@
             <field name="fiscal_position_id" position="after">
                 <field name="display_total_weight_in_report" />
                 <field name="display_total_volume_in_report" />
+                <field name="display_order_weight_in_po" invisible="1" />
+                <field name="display_order_volume_in_po" invisible="1" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This fix ensure that we don't show the fields and labels if the display settings is set to false 


