### PR TITLE
[15.0][FIX] purchase_stock_secondary_unit: Tests. Secondary_uom_qty is like as qty_done in sml's

### DIFF
--- a/purchase_stock_secondary_unit/tests/test_purchase_stock_secondary_unit.py
+++ b/purchase_stock_secondary_unit/tests/test_purchase_stock_secondary_unit.py
@@ -90,7 +90,7 @@ class TestPurchaseStockSecondaryUnit(TransactionCase):
         )
         self.assertEqual(picking.move_lines.product_uom_qty, 15.0)
         # Assigned move line
-        self.assertEqual(picking.move_line_ids.secondary_uom_qty, 3.0)
+        self.assertEqual(picking.move_line_ids.secondary_uom_qty, 0.0)
         self.assertEqual(
             picking.move_line_ids.secondary_uom_id, self.secondary_product_uom
         )


### PR DESCRIPTION
cc @Tecnativa 

ping @carlosdauden @CarlosRoca13 

Depends on:

- [x] https://github.com/OCA/stock-logistics-warehouse/pull/1606