### PR TITLE
[15.0][FIX] purchase_stock_secondary_unit: fix tests

### DIFF
--- a/purchase_stock_secondary_unit/tests/test_purchase_stock_secondary_unit.py
+++ b/purchase_stock_secondary_unit/tests/test_purchase_stock_secondary_unit.py
@@ -89,6 +89,8 @@ class TestPurchaseStockSecondaryUnit(TransactionCase):
             picking.move_lines.secondary_uom_id, self.secondary_product_uom
         )
         self.assertEqual(picking.move_lines.product_uom_qty, 15.0)
+        # Create stock.move.line with stock.move data
+        picking.action_set_quantities_to_reservation()
         # Assigned move line
         self.assertEqual(picking.move_line_ids.secondary_uom_qty, 3.0)
         self.assertEqual(


### PR DESCRIPTION
When trying to check if the stock.move.line has the quantities to match the new demand, these moves hasn't been created yet. If we want to check if the stock.move.line gets the values correctly from the stock.move we should firstly assign the quantity.

Supersedes #2103

@sergio-teruel @ForgeFlow