### PR TITLE
[14.0][FIX] purchase_order_type: sequence depending on date ranges

### DIFF
--- a/purchase_order_type/models/purchase_order.py
+++ b/purchase_order_type/models/purchase_order.py
@@ -42,7 +42,9 @@ class PurchaseOrder(models.Model):
         if vals.get("name", "/") == "/" and vals.get("order_type"):
             purchase_type = self.env["purchase.order.type"].browse(vals["order_type"])
             if purchase_type.sequence_id:
-                vals["name"] = purchase_type.sequence_id.next_by_id()
+                vals["name"] = purchase_type.sequence_id.next_by_id(
+                    sequence_date=vals.get("date_order")
+                )
         return super().create(vals)
 
     @api.constrains("company_id")


### PR DESCRIPTION
Custom sequence for an order type wasn't take in account date ranges during order creation, this fix it.

Fw-port of #2113 