### PR TITLE
[16.0][FIX] purchase_order_type: sequence depending on date ranges

### DIFF
--- a/purchase_order_type/models/purchase_order.py
+++ b/purchase_order_type/models/purchase_order.py
@@ -46,7 +46,9 @@ class PurchaseOrder(models.Model):
                     values["order_type"]
                 )
                 if purchase_type.sequence_id:
-                    values["name"] = purchase_type.sequence_id.next_by_id()
+                    values["name"] = purchase_type.sequence_id.next_by_id(
+                        sequence_date=values.get("date_order")
+                    )
         return super().create(vals_list)
 
     @api.constrains("company_id")


### PR DESCRIPTION
Custom sequence for an order type wasn't take in account date ranges during order creation, this fix it.

Fw-port of #2113 