### PR TITLE
[12.0][FIX] purchase_request: do_transfer() -> action_done()

### DIFF
--- a/purchase_request/models/stock_picking.py
+++ b/purchase_request/models/stock_picking.py
@@ -31,8 +31,8 @@ class StockPicking(models.Model):
         return message
 
     @api.multi
-    def do_transfer(self):
-        super(StockPicking, self).do_transfer()
+    def action_done(self):
+        super(StockPicking, self).action_done()
         request_obj = self.env['purchase.request']
         for picking in self:
             requests_dict = {}


### PR DESCRIPTION
An oversight in the [migration to v12](https://github.com/OCA/purchase-workflow/pull/720).

See:
![Selection_2410](https://github.com/OCA/multi-company/assets/25005517/1c9eb4e5-b4f5-4ee0-a919-68490009a2b0)