### PR TITLE
[16.0][FIX] purchase_order_no_zero_price: Resolve conflict between configuration and locked state

### DIFF
--- a/purchase_order_no_zero_price/models/purchase_order_line.py
+++ b/purchase_order_no_zero_price/models/purchase_order_line.py
@@ -15,7 +15,7 @@ class PurchaseOrderLine(models.Model):
         # Also supports `purchase_triple_discount` module
         no_price_lines = self.filtered(
             lambda x: not x.display_type
-            and x.state not in ["draft", "done", "cancel"]
+            and x.state not in ["draft", "cancel"]
             and not x.price_unit
             # Allow zero price for 100% discounts:
             and getattr(x, "discount", 0.0) != 100.0


### PR DESCRIPTION
Testing with the **purchase_order_no_zero_price** module I have found a conflict between the purchases (Settings/Purchase/Orders/Lock Confirmed Orders) configuration and the locked state. When we have the "Lock Confirmed Orders" check marked, if we try to confirm a purchase order with lines at price 0, it confirms the order without showing the error message. But if you try to unlock said order, the error message will appear.

![1](https://github.com/OCA/purchase-workflow/assets/82393040/cdcfabd0-2a16-40b3-ac4a-ac50ef8d7b80)


https://github.com/OCA/purchase-workflow/assets/82393040/a00ade3f-c38a-42df-b5cb-269e7822ba56

To display the error, I request to remove the blocked state from the condition and in this way we control the problem. 