### PR TITLE
[16.0][IMP] purchase_requisition_tier_validation: avoid error editing alternative

### DIFF
--- a/purchase_requisition_tier_validation/models/__init__.py
+++ b/purchase_requisition_tier_validation/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import purchase_requisition
 from . import tier_definition
+from . import tier_validation

--- a/purchase_requisition_tier_validation/models/tier_validation.py
+++ b/purchase_requisition_tier_validation/models/tier_validation.py
@@ -1,0 +1,12 @@
+from odoo import api, models
+
+
+class TierValidation(models.AbstractModel):
+    _inherit = "tier.validation"
+
+    @api.model
+    def _get_under_validation_exceptions(self):
+        """Extend for more field exceptions."""
+        res = super()._get_under_validation_exceptions()
+        res.append("purchase_group_id")
+        return res


### PR DESCRIPTION
Before this commit:
- Install  purchase_requisition and purchase_tier_validation
- Create a Tier Validation for purchase model
- Create an order and an alternative
- Request for validation for one of the purchase order
- Try to edit (and save) the alternative order
- You will get a ValidationError: "The operation is under validation."

After this commit:
- You could edit the alternative (that is not under validation) without problem

