### PR TITLE
[FIX] [16.0] purchase_allowed_product: Improve UX

### DIFF
--- a/purchase_allowed_product/README.rst
+++ b/purchase_allowed_product/README.rst
@@ -74,6 +74,8 @@ Contributors
 
   * Darius Žižys
 
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/purchase_allowed_product/models/account_move.py
+++ b/purchase_allowed_product/models/account_move.py
@@ -1,9 +1,18 @@
 # © 2016 Chafique DELLI @ Akretion
+# Copyright 2024 Moduon Team S.L. <info@moduon.team>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import api, models
 
 
 class AccountMove(models.Model):
     _inherit = ["account.move", "supplied.product.mixin"]
     _name = "account.move"
+
+    @api.onchange("invoice_vendor_bill_id")
+    def _onchange_invoice_vendor_bill(self):
+        if self.invoice_vendor_bill_id:
+            self.use_only_supplied_product = (
+                self.invoice_vendor_bill_id.use_only_supplied_product
+            )
+        return super()._onchange_invoice_vendor_bill()

--- a/purchase_allowed_product/models/purchase_order.py
+++ b/purchase_allowed_product/models/purchase_order.py
@@ -1,4 +1,5 @@
 # © 2017 Today Mourad EL HADJ MIMOUNE @ Akretion
+# Copyright 2024 Moduon Team S.L. <info@moduon.team>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models
@@ -7,3 +8,9 @@ from odoo import models
 class PurchaseOrder(models.Model):
     _inherit = ["purchase.order", "supplied.product.mixin"]
     _name = "purchase.order"
+
+    def _prepare_invoice(self):
+        self.ensure_one()
+        invoice_vals = super()._prepare_invoice()
+        invoice_vals["use_only_supplied_product"] = self.use_only_supplied_product
+        return invoice_vals

--- a/purchase_allowed_product/models/supplied_product_mixin.py
+++ b/purchase_allowed_product/models/supplied_product_mixin.py
@@ -1,4 +1,5 @@
 # © 2017 Today Mourad EL HADJ MIMOUNE @ Akretion
+# Copyright 2024 Moduon Team S.L. <info@moduon.team>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
@@ -10,13 +11,17 @@ class SuppliedProductMixin(models.AbstractModel):
 
     use_only_supplied_product = fields.Boolean(
         string="Use only allowed products",
+        compute="_compute_partner_id_supplied_product",
+        store=True,
+        readonly=False,
         help="If checked, only the products provided by this supplier "
         "will be shown.",
     )
 
-    @api.onchange("partner_id")
-    def _onchange_partner_id_supplied_product(self):
-        self.use_only_supplied_product = (
-            self.partner_id.use_only_supplied_product
-            or self.partner_id.commercial_partner_id.use_only_supplied_product
-        )
+    @api.depends("partner_id")
+    def _compute_partner_id_supplied_product(self):
+        for record in self:
+            record.use_only_supplied_product = (
+                record.partner_id.use_only_supplied_product
+                or record.partner_id.commercial_partner_id.use_only_supplied_product
+            )

--- a/purchase_allowed_product/readme/CONTRIBUTORS.rst
+++ b/purchase_allowed_product/readme/CONTRIBUTORS.rst
@@ -9,3 +9,5 @@
 * `Via laurea <https://www.vialaurea.com>`__:
 
   * Darius Žižys
+
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)

--- a/purchase_allowed_product/static/description/index.html
+++ b/purchase_allowed_product/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -419,6 +418,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Darius Žižys</li>
 </ul>
 </li>
+<li>Eduardo de Miguel (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/purchase_allowed_product/views/account_move_views.xml
+++ b/purchase_allowed_product/views/account_move_views.xml
@@ -4,18 +4,13 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <field name="invoice_line_ids" position="before">
+            <xpath expr="//field[@name='partner_id']/.." position="inside">
                 <field
                     name="use_only_supplied_product"
                     attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('move_type', 'not in', ('in_invoice', 'in_refund', 'in_receipt'))]}"
-                    class="oe_edit_only"
+                    widget="boolean_toggle"
                 />
-                <label
-                    for="use_only_supplied_product"
-                    attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('move_type', 'not in', ('in_invoice', 'in_refund', 'in_receipt'))]}"
-                    class="oe_edit_only"
-                />
-            </field>
+            </xpath>
             <xpath
                 expr="//field[@name='invoice_line_ids']/tree/field[@name='product_id']"
                 position="attributes"

--- a/purchase_allowed_product/views/purchase_order_views.xml
+++ b/purchase_allowed_product/views/purchase_order_views.xml
@@ -4,18 +4,13 @@
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
-            <field name="order_line" position="before">
+            <xpath expr="//field[@name='partner_id']/.." position="inside">
                 <field
                     name="use_only_supplied_product"
                     attrs="{'invisible': [('state', 'not in', ('draft', 'sent'))]}"
-                    class="oe_edit_only"
+                    widget="boolean_toggle"
                 />
-                <label
-                    for="use_only_supplied_product"
-                    attrs="{'invisible': [('state', 'not in', ('draft', 'sent'))]}"
-                    class="oe_edit_only"
-                />
-            </field>
+            </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='product_id']"
                 position="attributes"

--- a/purchase_allowed_product/views/purchase_order_views.xml
+++ b/purchase_allowed_product/views/purchase_order_views.xml
@@ -5,11 +5,7 @@
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']/.." position="inside">
-                <field
-                    name="use_only_supplied_product"
-                    attrs="{'invisible': [('state', 'not in', ('draft', 'sent'))]}"
-                    widget="boolean_toggle"
-                />
+                <field name="use_only_supplied_product" widget="boolean_toggle" />
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='product_id']"

--- a/purchase_allowed_product/views/res_partner_views.xml
+++ b/purchase_allowed_product/views/res_partner_views.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
             <group name="purchase" position="inside">
-                <field name="use_only_supplied_product" />
+                <field name="use_only_supplied_product" widget="boolean_toggle" />
             </group>
         </field>
     </record>


### PR DESCRIPTION
- Improved UX: Move field to the partner group of the form. Lines (purchase and move) has more space to see more content
- Make use_only_supplied_product field computed, stored and not readonly
- Propagation of use_only_supplied_product field to invoices
- `use_only_supplied_product` field always visible on Purchase Orders (check comments)

https://www.loom.com/share/6987c27348134673a7cae67c8ca43920?sid=7d980b6f-0917-4f7e-973c-1dac484d423e

MT-4264 @moduon @rafaelbn @fcvalgar @Gelojr plz review :)