### PR TITLE
[13.0] purchase_discount: use force company to select the seller

### DIFF
--- a/purchase_discount/models/stock_rule.py
+++ b/purchase_discount/models/stock_rule.py
@@ -16,7 +16,7 @@ class StockRule(models.Model):
         date = None
         if po.date_order:
             date = po.date_order.date()
-        seller = product_id._select_seller(
+        seller = product_id.with_context(force_company=company_id.id)._select_seller(
             partner_id=values["supplier"].name,
             quantity=product_qty,
             date=date,


### PR DESCRIPTION
Currently, the selection of the seller don't take to correct company

https://github.com/odoo/odoo/blob/13.0/addons/purchase_stock/models/stock_rule.py#L216