### PR TITLE
[16.0][IMP] purchase_packaging_level_qty store total_transport_qty

### DIFF
--- a/purchase_packaging_level_qty/models/purchase_order.py
+++ b/purchase_packaging_level_qty/models/purchase_order.py
@@ -4,12 +4,18 @@ from odoo import api, fields, models
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
-    total_transport_qty = fields.Char(
+    total_transport_qty = fields.Float(
         compute="_compute_total_transport_packaging_qty",
+        store=True,
     )
 
     transport_packaging_level_id = fields.Many2one(
-        "product.packaging.level", compute="_compute_purchase_transport_packaging_level"
+        "product.packaging.level",
+        compute="_compute_purchase_transport_packaging_level",
+    )
+
+    transport_packaging_level_total_qty = fields.Char(
+        compute="_compute_transport_packaging_level_total_qty",
     )
 
     def _compute_purchase_transport_packaging_level(self):
@@ -26,9 +32,18 @@ class PurchaseOrder(models.Model):
     def _compute_total_transport_packaging_qty(self):
         for order in self:
             if order.transport_packaging_level_id:
-                total_transport_qty = sum(order.mapped("order_line.transport_qty"))
-                order.total_transport_qty = "{} {}".format(
-                    total_transport_qty,
+                order.total_transport_qty = sum(
+                    order.mapped("order_line.transport_qty")
+                )
+            else:
+                order.total_transport_qty = False
+
+    @api.depends("total_transport_qty", "transport_packaging_level_id")
+    def _compute_transport_packaging_level_total_qty(self):
+        for order in self:
+            if order.transport_packaging_level_id:
+                order.transport_packaging_level_total_qty = "{} {}".format(
+                    order.total_transport_qty,
                     order.transport_packaging_level_id.name or "",
                 ).strip()
             else:

--- a/purchase_packaging_level_qty/tests/test_purchase_packaging_level_qty.py
+++ b/purchase_packaging_level_qty/tests/test_purchase_packaging_level_qty.py
@@ -57,6 +57,7 @@ class TestPurchasePackagingLevel(common.TransactionCase):
     def test_purchase_transport_packaging_level_enabled(self):
         self.config.purchase_packaging_level_id = False
         self.config.set_values()
+        self.assertFalse(self.purchase_order.transport_packaging_level_id)
         self.assertEqual(self.purchase_order.total_transport_qty, False)
 
     def test_purchase_packaging_level_qty(self):
@@ -68,8 +69,10 @@ class TestPurchasePackagingLevel(common.TransactionCase):
                 "product_qty": 1,
             }
         )
+        self.assertEqual(self.purchase_order.total_transport_qty, 0.0)
         self.assertEqual(
-            self.purchase_order.total_transport_qty, "0.0 Packaging Level 1 Test"
+            self.purchase_order.transport_packaging_level_total_qty,
+            "0.0 Packaging Level 1 Test",
         )
 
         self.env["purchase.order.line"].create(
@@ -100,5 +103,11 @@ class TestPurchasePackagingLevel(common.TransactionCase):
         )
         self.assertEqual(self.purchase_order.order_line[3].transport_qty, 2)
         self.assertEqual(
-            self.purchase_order.total_transport_qty, "3.25 Packaging Level 1 Test"
+            self.purchase_order.total_transport_qty,
+            3.25,
+        )
+
+        self.assertEqual(
+            self.purchase_order.transport_packaging_level_total_qty,
+            "3.25 Packaging Level 1 Test",
         )


### PR DESCRIPTION
We have a requirement where POs needs to be validated or not based on the total transport qty per packaging level.
=> For that we need to store the filed  `total_transport_qty`.