### PR TITLE
[16.0][FIX] purchase_manual_delivery: fix return on button_confirm_manual

### DIFF
--- a/purchase_manual_delivery/models/purchase_order.py
+++ b/purchase_manual_delivery/models/purchase_order.py
@@ -23,8 +23,9 @@ class PurchaseOrder(models.Model):
                 order.pending_to_receive = False
 
     def button_confirm_manual(self):
-        super(PurchaseOrder, self.with_context(manual_delivery=True)).button_confirm()
-        return
+        return super(
+            PurchaseOrder, self.with_context(manual_delivery=True)
+        ).button_confirm()
 
     def _create_picking(self):
         if self.env.context.get("manual_delivery", False) and self.manual_delivery:


### PR DESCRIPTION
When creating alternatives on purchase orders, and trying to confirm one, the wizard for managing alternatives "purchase_requisition_alternative_warning" was not displayed due to the return of button_confirm_manual.
