### PR TITLE
[15.0][FIX] purchase_request: not allow to edit an approved purchase request

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -101,9 +101,10 @@ class PurchaseRequest(models.Model):
         comodel_name="purchase.request.line",
         inverse_name="request_id",
         string="Products to Purchase",
-        readonly=False,
+        readonly=True,
         copy=True,
         tracking=True,
+        states={"draft": [("readonly", False)]},
     )
     product_id = fields.Many2one(
         comodel_name="product.product",


### PR DESCRIPTION
This commit fixes the the following issue.

- Create a purchase request with some products and send it to approval
- The manager approves the purchase request.
- After the approval the user can add new products to the request and can abuse