### PR TITLE
[IMP] purch_stock_pack: add test for multi packagings

### DIFF
--- a/purchase_stock_packaging/models/__init__.py
+++ b/purchase_stock_packaging/models/__init__.py
@@ -1,1 +1,2 @@
 from . import purchase_order_line
+from . import stock_rule

--- a/purchase_stock_packaging/models/stock_rule.py
+++ b/purchase_stock_packaging/models/stock_rule.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Akretion (<http://www.akretion.com>).
+# @author David BEAL <david.beal@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    @api.model
+    def _get_procurements_to_merge_groupby(self, procurement):
+        return (
+            procurement.values.get("product_packaging_id"),
+            super()._get_procurements_to_merge_groupby(procurement),
+        )

--- a/purchase_stock_packaging/readme/USAGE.rst
+++ b/purchase_stock_packaging/readme/USAGE.rst
@@ -1,4 +1,4 @@
 * For instance, create a sale order with a route that trigger make to order stock rules (and a purchase order).
 * On that sale order, force using a product packaging that would not be the
-  default one for the filled in qunatity.
+  default one for the filled in quantity. It supports several packagings in purchase line
 * The purchase order line created should use the same product packaging.

--- a/purchase_stock_packaging/tests/test_purchase_packaging.py
+++ b/purchase_stock_packaging/tests/test_purchase_packaging.py
@@ -47,6 +47,40 @@ class TestPurchasePackaging(TransactionCase):
         self.assertTrue(lines_after.product_packaging_id)
         self.assertEqual(lines_after.product_packaging_id, self.packaging)
 
+    def test_2_packagings_from_procurement(self):
+        # Check of packagings is well passed from procurement to purchase lines
+        lines_before = self.line_obj.search([])
+        procur1 = self.env["procurement.group"].create({"name": "Test1"})
+        procur2 = self.env["procurement.group"].create({"name": "Test2"})
+        self.env["procurement.group"].run(
+            [
+                procur1.Procurement(
+                    self.product,
+                    5.0,
+                    self.product.uom_id,
+                    self.warehouse.lot_stock_id,
+                    "Product",
+                    "Product",
+                    company_id=self.env.company,
+                    values={"product_packaging_id": self.packaging},
+                ),
+                procur2.Procurement(
+                    self.product,
+                    24.0,
+                    self.product.uom_id,
+                    self.warehouse.lot_stock_id,
+                    "Product",
+                    "Product",
+                    company_id=self.env.company,
+                    values={"product_packaging_id": self.packaging_12},
+                ),
+            ]
+        )
+        lines_after = self.line_obj.search([]) - lines_before
+        self.assertEqual(len(lines_after), 2)
+        self.assertTrue(lines_after[0].product_packaging_id)
+        self.assertTrue(lines_after[1].product_packaging_id)
+
     def test_purchase_packaging_from_move(self):
         # Check of packaging is well passed from stock move to procurement,
         # then to purchase line and does not take default one


### PR DESCRIPTION
Scenario that I want implement.

When 2 kind of packaging are used in sale line (mimic by procurement group here), purchase should be set with the same packagings 

