### PR TITLE
[15.0][FIX] purchase_request: fallback to current user when creating

### DIFF
--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -62,7 +62,7 @@ class StockMove(models.Model):
                             "purchase request has been cancelled/deleted. "
                             "Check if an action is needed."
                         ),
-                        "user_id": pr_line.product_id.responsible_id.id,
+                        "user_id": pr_line.product_id.responsible_id.id or self.env.uid,
                         "res_id": pr_line.request_id.id,
                         "res_model_id": self.env.ref(
                             "purchase_request.model_purchase_request"


### PR DESCRIPTION
mail activity in purchase request upon purchase order cancellation. This prevent mileading error to users that try to cancel the RFQ/PO

![mail_activity_error](https://github.com/OCA/purchase-workflow/assets/19620251/db158d8e-c87a-44b5-a0b8-3ed132be77c7)


cc @ForgeFlow