### PR TITLE
[16.0][FIX] purchase_manual_delivery: manual delivery with double validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,17 +36,17 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
-            include: "purchase_security,purchase_order_qty_change_no_recompute"
+            include: "purchase_security,purchase_order_qty_change_no_recompute,purchase_manual_delivery"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
-            include: "purchase_security,purchase_order_qty_change_no_recompute"
+            include: "purchase_security,purchase_order_qty_change_no_recompute,purchase_manual_delivery"
             name: test with OCB
             makepot: "true"
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
-            exclude: "purchase_security,purchase_order_qty_change_no_recompute"
+            exclude: "purchase_security,purchase_order_qty_change_no_recompute,purchase_manual_delivery"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
-            exclude: "purchase_security,purchase_order_qty_change_no_recompute"
+            exclude: "purchase_security,purchase_order_qty_change_no_recompute,purchase_manual_delivery"
             name: test with OCB
             makepot: "true"
     services:

--- a/purchase_manual_delivery/models/purchase_order.py
+++ b/purchase_manual_delivery/models/purchase_order.py
@@ -27,6 +27,11 @@ class PurchaseOrder(models.Model):
             PurchaseOrder, self.with_context(manual_delivery=True)
         ).button_confirm()
 
+    def button_approve(self, force=False):
+        if self.manual_delivery:
+            self = self.with_context(manual_delivery=True)
+        return super(PurchaseOrder, self).button_approve(force=force)
+
     def _create_picking(self):
         if self.env.context.get("manual_delivery", False) and self.manual_delivery:
             # We do not want to create the picking when confirming the order


### PR DESCRIPTION
When "Purchase Order Approval" is enabled and the PO exceeds the Minimum Amount, the manual delivery is not applied at the moment that the PO is approved.
This PR fixes this case.
