### PR TITLE
[16.0][IMP] purchase_blanket_order: Code refactor

### DIFF
--- a/purchase_blanket_order/tests/test_purchase_order.py
+++ b/purchase_blanket_order/tests/test_purchase_order.py
@@ -4,56 +4,58 @@ from datetime import date, timedelta
 
 from odoo import fields
 from odoo.exceptions import ValidationError
-from odoo.tests import common
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestPurchaseOrder(common.TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.blanket_order_obj = self.env["purchase.blanket.order"]
-        self.blanket_order_line_obj = self.env["purchase.blanket.order.line"]
-        self.purchase_order_obj = self.env["purchase.order"]
-        self.purchase_order_line_obj = self.env["purchase.order.line"]
+class TestPurchaseOrder(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.blanket_order_obj = cls.env["purchase.blanket.order"]
+        cls.blanket_order_line_obj = cls.env["purchase.blanket.order.line"]
+        cls.purchase_order_obj = cls.env["purchase.order"]
+        cls.purchase_order_line_obj = cls.env["purchase.order.line"]
 
-        self.partner = self.env["res.partner"].create(
+        cls.partner = cls.env["res.partner"].create(
             {"name": "TEST SUPPLIER", "supplier_rank": 1}
         )
-        self.partner_2 = self.env["res.partner"].create(
+        cls.partner_2 = cls.env["res.partner"].create(
             {"name": "TEST SUPPLIER 2", "supplier_rank": 2}
         )
-        self.payment_term = self.env.ref("account.account_payment_term_30days")
+        cls.payment_term = cls.env.ref("account.account_payment_term_30days")
 
         # Seller IDS
-        seller = self.env["product.supplierinfo"].create(
-            {"partner_id": self.partner.id, "price": 30.0}
+        seller = cls.env["product.supplierinfo"].create(
+            {"partner_id": cls.partner.id, "price": 30.0}
         )
 
-        self.product = self.env["product.product"].create(
+        cls.product = cls.env["product.product"].create(
             {
                 "name": "Demo",
-                "categ_id": self.env.ref("product.product_category_1").id,
+                "categ_id": cls.env.ref("product.product_category_1").id,
                 "standard_price": 35.0,
                 "seller_ids": [(6, 0, [seller.id])],
                 "type": "consu",
-                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
                 "default_code": "PROD_DEL01",
             }
         )
-        self.product_2 = self.env["product.product"].create(
+        cls.product_2 = cls.env["product.product"].create(
             {
                 "name": "Demo 2",
-                "categ_id": self.env.ref("product.product_category_1").id,
+                "categ_id": cls.env.ref("product.product_category_1").id,
                 "standard_price": 35.0,
                 "seller_ids": [(6, 0, [seller.id])],
                 "type": "consu",
-                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
                 "default_code": "PROD_DEL02",
             }
         )
-        self.validity = date.today() + timedelta(days=365)
-        self.date_schedule_1 = date.today() + timedelta(days=10)
-        self.date_schedule_2 = date.today() + timedelta(days=20)
-        self.currency_test = self.env["res.currency"].create(
+        cls.validity = date.today() + timedelta(days=365)
+        cls.date_schedule_1 = date.today() + timedelta(days=10)
+        cls.date_schedule_2 = date.today() + timedelta(days=20)
+        cls.currency_test = cls.env["res.currency"].create(
             {"name": "Test Currency", "symbol": "T"}
         )
 
@@ -161,7 +163,7 @@ class TestPurchaseOrder(common.TransactionCase):
         po_line.onchange_product_id()
         self.assertEqual(po_line._get_eligible_bo_lines(), bo_lines)
         bo_line_assigned = self.blanket_order_line_obj.search(
-            [("date_schedule", "=", fields.Date.to_string(self.date_schedule_1))]
+            [("date_schedule", "=", date.today())]
         )
         self.assertEqual(po_line.blanket_order_line, bo_line_assigned)
 

--- a/purchase_only_by_packaging/models/purchase_order_line.py
+++ b/purchase_only_by_packaging/models/purchase_order_line.py
@@ -50,3 +50,13 @@ class PurchaseOrderLine(models.Model):
     @api.onchange("product_qty")
     def _onchange_product_qty(self):
         self._force_qty_with_package()
+
+    @api.depends("product_packaging_id")
+    def _compute_product_qty(self):
+        res = super()._compute_product_qty()
+        for item in self.filtered(lambda x: x.product_packaging_id):
+            old_qty = item.product_qty
+            item.product_qty = item.product_id._convert_packaging_qty(
+                old_qty, item.product_uom, packaging=item.product_packaging_id
+            )
+        return res

--- a/purchase_only_by_packaging/tests/test_purchase_only_by_packaging.py
+++ b/purchase_only_by_packaging/tests/test_purchase_only_by_packaging.py
@@ -49,11 +49,11 @@ class TestSaleProductByPackagingOnly(Common):
         """
         self.product.purchase_only_by_packaging = True
         packaging = self.packaging_tu
-        self.order_line.product_packaging_id = packaging
         # For this step, the qty is not forced on the packaging
         # But the warning will be raise because the value of packaging qty is
         # not integer package
         with self.assertRaises(ValidationError):
+            self.order_line.product_packaging_id = packaging
             self.order_line.product_packaging_qty = 0.6
             self.assertAlmostEqual(
                 self.order_line.product_qty, 12, places=self.precision


### PR DESCRIPTION
Related to https://github.com/OCA/purchase-workflow/pull/2193

Changes done:
- [x] Removed constrains from `date_planned`. Implemented `_compute_date_planned()` to avoid inconsistencies.
- [x] Set `blanket_order_line` field as compute store.
- [x] Removed onchange_product_id().
- [x] Removed `_compute_price_unit_and_date_planned_and_name()`.
- [x] Simplify `onchange_blanket_order_line()`
- [x] Improve `_get_assigned_bo_line()`
- [x] Change to `setUpClass()` in tests
- [x] `purchase_only_by_packaging`: Improve `_compute_product_qty()` to be compatible with `purchase_blanket_order`

@Tecnativa