### PR TITLE
[IMP] purchase_request: post messages only if a message content is returned

### DIFF
--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -179,9 +179,10 @@ class PurchaseOrderLine(models.Model):
                 message = self._purchase_request_confirm_done_message_content(
                     message_data
                 )
-                alloc.purchase_request_line_id.request_id.message_post(
-                    body=message, subtype_id=self.env.ref("mail.mt_comment").id
-                )
+                if message:
+                    alloc.purchase_request_line_id.request_id.message_post(
+                        body=message, subtype_id=self.env.ref("mail.mt_comment").id
+                    )
 
                 alloc.purchase_request_line_id._compute_qty()
         return True

--- a/purchase_request/models/stock_move_line.py
+++ b/purchase_request/models/stock_move_line.py
@@ -106,17 +106,19 @@ class StockMoveLine(models.Model):
                     message = self._purchase_request_confirm_done_message_content(
                         message_data
                     )
-                    request.message_post(
-                        body=message, subtype_id=self.env.ref("mail.mt_comment").id
-                    )
+                    if message:
+                        request.message_post(
+                            body=message, subtype_id=self.env.ref("mail.mt_comment").id
+                        )
 
                     picking_message = self._picking_confirm_done_message_content(
                         message_data
                     )
-                    ml.move_id.picking_id.message_post(
-                        body=picking_message,
-                        subtype_id=self.env.ref("mail.mt_comment").id,
-                    )
+                    if picking_message:
+                        ml.move_id.picking_id.message_post(
+                            body=picking_message,
+                            subtype_id=self.env.ref("mail.mt_comment").id,
+                        )
 
                 allocation._compute_open_product_qty()
 


### PR DESCRIPTION
This change allows to avoid messages sending by overriding the message-preparation functions.
