### PR TITLE
[17.0][IMP] purchase_request: split field 'Quantity in RFQ or PO' into purchased_qty and rfq_qty fields

### DIFF
--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -5,12 +5,14 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 _STATES = [
-    ("draft", "Draft"),
-    ("to_approve", "To be approved"),
+    ("draft", "RFQ"),
+    ("sent", "RFQ Sent"),
+    ("to_approve", "To Approve"),
     ("approved", "Approved"),
-    ("in_progress", "In progress"),
-    ("done", "Done"),
-    ("rejected", "Rejected"),
+    ("partially", "Partially Purchased"),
+    ("purchase", "Purchased"),
+    ("done", "Locked"),
+    ("cancel", "Cancelled"),
 ]
 
 
@@ -91,7 +93,12 @@ class PurchaseRequestLine(models.Model):
     cancelled = fields.Boolean(readonly=True, default=False, copy=False)
 
     purchased_qty = fields.Float(
-        string="RFQ/PO Qty",
+        string="Purchased Quantity",
+        digits="Product Unit of Measure",
+        compute="_compute_purchased_qty",
+    )
+    rfq_qty = fields.Float(
+        string="RFQ Quantity",
         digits="Product Unit of Measure",
         compute="_compute_purchased_qty",
     )
@@ -107,9 +114,7 @@ class PurchaseRequestLine(models.Model):
     purchase_state = fields.Selection(
         compute="_compute_purchase_state",
         string="Purchase Status",
-        selection=lambda self: self.env["purchase.order"]
-        ._fields["state"]
-        ._description_selection(self.env),
+        selection=_STATES,
         store=True,
     )
     move_dest_ids = fields.One2many(
@@ -300,31 +305,41 @@ class PurchaseRequestLine(models.Model):
 
     def _compute_purchased_qty(self):
         for rec in self:
-            rec.purchased_qty = 0.0
-            for line in rec.purchase_lines.filtered(lambda x: x.state != "cancel"):
-                if rec.product_uom_id and line.product_uom != rec.product_uom_id:
-                    rec.purchased_qty += line.product_uom._compute_quantity(
-                        line.product_qty, rec.product_uom_id
-                    )
-                else:
-                    rec.purchased_qty += line.product_qty
+            purchased_lines = rec.purchase_lines.filtered(
+                lambda pol: pol.state in ["purchase", "done"]
+            )
+            rfq_lines = rec.purchase_lines - purchased_lines
+            rec.purchased_qty = sum(
+                pol.product_uom._compute_quantity(pol.product_qty, rec.product_uom_id)
+                for pol in purchased_lines
+            )
+            rec.rfq_qty = sum(
+                pol.product_uom._compute_quantity(pol.product_qty, rec.product_uom_id)
+                for pol in rfq_lines
+            )
 
     @api.depends("purchase_lines.state", "purchase_lines.order_id.state")
     def _compute_purchase_state(self):
         for rec in self:
             temp_purchase_state = False
             if rec.purchase_lines:
-                if any(po_line.state == "done" for po_line in rec.purchase_lines):
-                    temp_purchase_state = "done"
-                elif all(po_line.state == "cancel" for po_line in rec.purchase_lines):
-                    temp_purchase_state = "cancel"
-                elif any(po_line.state == "purchase" for po_line in rec.purchase_lines):
-                    temp_purchase_state = "purchase"
+                if any([po_line.state == "done" for po_line in rec.purchase_lines]):
+                    temp_purchase_state = (
+                        "done" if rec.purchased_qty >= rec.product_qty else "partially"
+                    )
                 elif any(
-                    po_line.state == "to approve" for po_line in rec.purchase_lines
+                    [po_line.state == "purchase" for po_line in rec.purchase_lines]
+                ):
+                    temp_purchase_state = (
+                        "purchase"
+                        if rec.purchased_qty >= rec.product_qty
+                        else "partially"
+                    )
+                elif any(
+                    [po_line.state == "to approve" for po_line in rec.purchase_lines]
                 ):
                     temp_purchase_state = "to approve"
-                elif any(po_line.state == "sent" for po_line in rec.purchase_lines):
+                elif any([po_line.state == "sent" for po_line in rec.purchase_lines]):
                     temp_purchase_state = "sent"
                 elif all(
                     po_line.state in ("draft", "cancel")
@@ -361,7 +376,7 @@ class PurchaseRequestLine(models.Model):
         rl_qty = 0.0
         # Recompute quantity by adding existing running procurements.
         if new_pr_line:
-            rl_qty = po_line.product_uom_qty
+            rl_qty = po_line.product_qty
         else:
             for prl in po_line.purchase_request_lines:
                 for alloc in prl.purchase_request_allocation_ids:

--- a/purchase_request/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request/tests/test_purchase_request_to_rfq.py
@@ -235,10 +235,16 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
                 item.onchange_product_id()
         wiz_id.make_purchase_order()
         self.assertEqual(
-            purchase_request_line1.purchased_qty, 1.0, "Should be a quantity of 1"
+            purchase_request_line1.rfq_qty, 1.0, "Quantity in RFQ should be 1"
         )
         self.assertEqual(
-            purchase_request_line2.purchased_qty, 1.0, "Should be a quantity of 1"
+            purchase_request_line2.rfq_qty, 1.0, "Quantity in RFQ should be 1"
+        )
+        purchase_request_line1.purchase_lines.order_id.print_quotation()
+        purchase_request_line1.purchase_lines.order_id.button_confirm()
+        purchase_request_line1._compute_purchased_qty()
+        self.assertEqual(
+            purchase_request_line1.purchased_qty, 1.0, "Purchased quantity should be 1"
         )
 
     def test_purchase_request_to_purchase_rfq_multiple_PO_purchaseUoM(self):

--- a/purchase_request/views/purchase_request_line_view.xml
+++ b/purchase_request/views/purchase_request_line_view.xml
@@ -25,6 +25,7 @@
                 <field name="date_required" />
                 <field name="estimated_cost" widget="monetary" />
                 <field name="currency_id" column_invisible="1" />
+                <field name="rfq_qty" />
                 <field name="purchased_qty" />
                 <field
                     name="purchase_state"
@@ -152,6 +153,7 @@
                     <notebook>
                         <page name="purchase_lines" string="Purchase Order Lines">
                             <group>
+                                <field name="rfq_qty" />
                                 <field name="purchased_qty" />
                                 <field name="purchase_state" />
                             </group>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -189,6 +189,7 @@
                                     <field name="currency_id" column_invisible="1" />
                                     <field name="cancelled" column_invisible="1" />
                                     <field name="is_editable" column_invisible="1" />
+                                    <field name="rfq_qty" />
                                     <field name="purchased_qty" />
                                     <field
                                         name="purchase_state"

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -259,7 +259,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                 po_line.purchase_request_lines = [(4, line.id)]
                 po_line.move_dest_ids |= line.move_dest_ids
                 po_line_product_uom_qty = po_line.product_uom._compute_quantity(
-                    po_line.product_uom_qty, alloc_uom
+                    po_line.product_qty, alloc_uom
                 )
                 wizard_product_uom_qty = wizard_uom._compute_quantity(
                     item.product_qty, alloc_uom
@@ -272,7 +272,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                     po_line_data["name"] = item.name
                 po_line = po_line_obj.create(po_line_data)
                 po_line_product_uom_qty = po_line.product_uom._compute_quantity(
-                    po_line.product_uom_qty, alloc_uom
+                    po_line.product_qty, alloc_uom
                 )
                 wizard_product_uom_qty = wizard_uom._compute_quantity(
                     item.product_qty, alloc_uom


### PR DESCRIPTION
Features in this PR:

- Split field purchased_qty (Quantity in RFQ or PO) into purchased_qty and rfq_qty. And add it to views.

- Improve state of purchase request line to have more specific info. 
- Add to the compute method of the purchase request line state the dependence on quantities (i.e.: A purchase request line is not done if the purchase order quantities are less than de purchase request line quantities)