### PR TITLE
[FIX]purchase_discount:Bad behaviour with currency

### DIFF
--- a/purchase_discount/__manifest__.py
+++ b/purchase_discount/__manifest__.py
@@ -24,4 +24,3 @@
     "installable": True,
     "images": ["images/purchase_discount.png"],
 }
-

--- a/purchase_discount/__manifest__.py
+++ b/purchase_discount/__manifest__.py
@@ -24,3 +24,4 @@
     "installable": True,
     "images": ["images/purchase_discount.png"],
 }
+

--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -53,11 +53,10 @@ class PurchaseOrderLine(models.Model):
         :return: Unit price after discount(s).
         """
         self.ensure_one()
-        price_unit=self._get_stock_move_price_unit()
+        price_unit = self._get_stock_move_price_unit()
         if self.discount:
             return price_unit * (1 - self.discount / 100)
         return price_unit
-
 
     def _compute_price_unit_and_date_planned_and_name(self):
         """Get also the discount from the seller. Unfortunately, this requires to

--- a/purchase_discount/static/description/index.html
+++ b/purchase_discount/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION
I made this PR because when purchase order has a different currency than company, when you edit the purchase order line price (with order in state "purchase"), in picking do not refresh correctly price_unit, because the older behavoiur didn`t contemplate currency.

Besides of this, i think the super call of method _get_stock_move_price_unit don`t  have sense any more, in fact, it has this comment:
HACK: This is needed while https://github.com/odoo/odoo/pull/29983 is not merged.
That PR is merged since 5 years.

Thank you!