### PR TITLE
[13.0][FIX] purchase_landed_cost: Remove ondelete from one2many fields

### DIFF
--- a/purchase_landed_cost/models/purchase_cost_distribution.py
+++ b/purchase_landed_cost/models/purchase_cost_distribution.py
@@ -127,13 +127,11 @@ class PurchaseCostDistribution(models.Model):
     note = fields.Text(string="Documentation for this order")
     cost_lines = fields.One2many(
         comodel_name="purchase.cost.distribution.line",
-        ondelete="cascade",
         inverse_name="distribution",
         string="Distribution lines",
     )
     expense_lines = fields.One2many(
         comodel_name="purchase.cost.distribution.expense",
-        ondelete="cascade",
         inverse_name="distribution",
         string="Expenses",
         default=_expense_lines_default,


### PR DESCRIPTION
- Remove ondelete from one2many fields as are not used for these fields.
- In future versions, as it has set ondelete on one2many fields, appears warning in log message

@Tecnativa
TT46594
@pedrobaeza @chienandalu 

