### PR TITLE
[FIX] purchase_request: changes in report layout

### DIFF
--- a/purchase_request/reports/report_purchase_request.xml
+++ b/purchase_request/reports/report_purchase_request.xml
@@ -13,40 +13,42 @@
                             <span t-field="o.name" />
                         </h2>
                         <div class="row mt32 mb32">
-                            <div class="col-auto">
+                            <div class="col-2">
                                 <strong>Request Reference:</strong>
                                 <br />
                                 <span t-field="o.name" />
                             </div>
-                            <div class="col-auto">
+                            <div class="col-2">
                                 <strong>Creation Date:</strong>
                                 <br />
                                 <span t-field="o.date_start" />
                             </div>
-                            <div class="col-auto">
+                            <div class="col-2">
                                 <strong>Source:</strong>
                                 <br />
                                 <span t-field="o.origin" />
                             </div>
-                            <div class="col-auto">
-                                <strong>Description:</strong>
-                                <br />
-                                <span t-field="o.description" />
-                            </div>
-                            <div class="col-auto">
+                            <div class="col-2">
                                 <strong>Requested by:</strong>
                                 <br />
                                 <span t-field="o.requested_by" />
                             </div>
-                            <div class="col-auto">
+                            <div class="col-2">
                                 <strong>Assigned to:</strong>
                                 <br />
                                 <span t-field="o.assigned_to" />
                             </div>
-                            <div class="col-auto">
+                            <div class="col-2">
                                 <strong>Picking Type:</strong>
                                 <br />
                                 <span t-field="o.picking_type_id" />
+                            </div>
+                        </div>
+                        <div class="row mt32 mb32">
+                            <div class="col-12">
+                                <strong>Description:</strong>
+                                <br />
+                                <span t-field="o.description" />
                             </div>
                         </div>
                         <t t-if="o.line_ids">


### PR DESCRIPTION
Rectify the layout of the purchase request report to address issues with column widths. Modifications include adjusting the Bootstrap grid classes for each column:
- Request Reference, Creation Date, Source, Requested by, Assigned to, and Picking Type columns have been resized to col-2 to ensure uniformity and prevent overflow.
- Description column has been resized to col-12 to occupy the entire width, resolving readability issues caused by its previous narrow width.
This fix aims to provide a more coherent and user-friendly layout, enhancing the overall usability of the purchase request report.

**Note:** There is a Manual FP to this PR. Please find it [here](https://github.com/OCA/purchase-workflow/pull/2250).