### PR TITLE
[15.0][IMP] purchase_request: set requested_by to SO confirmer and set approver to False

### DIFF
--- a/purchase_request/models/stock_rule.py
+++ b/purchase_request/models/stock_rule.py
@@ -41,6 +41,8 @@ class StockRule(models.Model):
             "company_id": values["company_id"].id,
             "picking_type_id": self.picking_type_id.id,
             "group_id": group_id or False,
+            "requested_by": self.env.context.get("uid", self.env.uid),
+            "assigned_to": False,
         }
 
     @api.model


### PR DESCRIPTION
This commit related to purchase_request include the following improvements.
- Assigns the 'requested_by' field to the sale order confirmer.
- Leaves the 'assigned_to' field empty".
    
