### PR TITLE
[FIX]_request: Add products only in draft state

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -156,7 +156,7 @@
                     </group>
                     <notebook>
                         <page string="Products">
-                            <field name="line_ids">
+                            <field name="line_ids" attrs="{'readonly': [('state', '!=', 'draft')]}">
                                 <tree
                                     decoration-muted="cancelled == True"
                                     editable="bottom"

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -156,7 +156,10 @@
                     </group>
                     <notebook>
                         <page string="Products">
-                            <field name="line_ids" attrs="{'readonly': [('state', '!=', 'draft')]}">
+                            <field
+                                name="line_ids"
+                                attrs="{'readonly': [('state', '!=', 'draft')]}"
+                            >
                                 <tree
                                     decoration-muted="cancelled == True"
                                     editable="bottom"


### PR DESCRIPTION
Hi!
I made this pr because in v16 its possible to add productos in approved state, thats functionally bad because if Request it's approved, is because a person approved the products aggregated before, if you change lines, the logical thing would be to approve again.

In v13 this works more or less good, because it didn't let you add productos in approved state.

I made only editable lines when is in "draft" state, maybe it's too prohibitive, what do you think?