### PR TITLE
[16.0][FIX] purchase_advance_payment: use commercial partner

### DIFF
--- a/purchase_advance_payment/wizard/purchase_advance_payment_wizard.py
+++ b/purchase_advance_payment/wizard/purchase_advance_payment_wizard.py
@@ -92,7 +92,7 @@ class AccountVoucherWizardPurchase(models.TransientModel):
         self.currency_amount = amount_advance
 
     def _prepare_payment_vals(self, purchase):
-        partner_id = purchase.partner_id.id
+        partner_id = purchase.partner_id.commercial_partner_id.id
         return {
             "date": self.date,
             "amount": self.amount_advance,


### PR DESCRIPTION
The commercial partner is used as the partner of the payable journal items, therefore the payments from the bill will be created for the parent partner. The same should happen with advance payments, otherwise the advanced payments won't appear as options to reconcile when the bill is finally created.