### PR TITLE
[16.0][FIX] purchase_order_owner

### DIFF
--- a/purchase_order_owner/models/purchase_order.py
+++ b/purchase_order_owner/models/purchase_order.py
@@ -18,6 +18,17 @@ class PurchaseOrder(models.Model):
         "incoming stock picking.",
     )
 
+    def button_confirm(self):
+        """For subcontracting orders
+        Without this, the downstream component demands may misjudge the available
+        quantities with owner consideration.
+        """
+        # TODO: Double-check if the logic is optimal
+        for order in self:
+            order = order.with_context(owner_id=order.owner_id.id)
+            super(PurchaseOrder, order).button_confirm()
+        return True
+
     def _prepare_picking(self):
         res = super()._prepare_picking()
         res["owner_id"] = self.owner_id.id


### PR DESCRIPTION
This fix PR addresses the issue in the downstream component where available quantities are sometimes misjudged due to ownership considerations in subcontracting.

@qrtl