### PR TITLE
[16.0][IMP] purchase_blanket_order: show invoice information in bo form view

### DIFF
--- a/purchase_blanket_order/views/purchase_blanket_order_views.xml
+++ b/purchase_blanket_order/views/purchase_blanket_order_views.xml
@@ -100,7 +100,6 @@
                                 options='{"always_reload": True}'
                             />
                             <field name="partner_ref" />
-                            <field name="payment_term_id" />
                         </group>
                         <group name="group_top_right">
                             <field
@@ -196,6 +195,23 @@
                                 placeholder="Setup default terms and conditions in your company settings."
                             />
                             <div class="oe_clear" />
+                        </page>
+                        <page name="other_info" string="Other Information">
+                            <group
+                                name="invoice_information"
+                                string="Invoice Information"
+                            >
+                                <field
+                                    name="payment_term_id"
+                                    attrs="{'readonly': [('state', '=', 'done')]}"
+                                    options="{'no_create': True}"
+                                />
+                                <field
+                                    name="fiscal_position_id"
+                                    options="{'no_create': True}"
+                                    attrs="{'readonly': [('state', '=', 'done')]}"
+                                />
+                            </group>
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
This information may be usefull to be easily checked. (As it was already existing)
Also moving payment terms here to match purchase order view.

@ForgeFlow