### PR TITLE
[IMP] purchase_request: add UTC time to scheduled_date

### DIFF
--- a/purchase_request/tests/test_purchase_request_to_rfq.py
+++ b/purchase_request/tests/test_purchase_request_to_rfq.py
@@ -1,6 +1,8 @@
 # Copyright 2018-2019 ForgeFlow, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 
+import pytz
+
 from odoo import SUPERUSER_ID
 from odoo.tests import common
 
@@ -331,9 +333,10 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
         ).create(vals)
         wiz_id.make_purchase_order()
         # The planned date is taken from the request, not from the supplier
+        user_tz = pytz.timezone(self.env.user.tz or "UTC")
         self.assertEqual(
             purchase_request_line1.date_required.day,
-            purchase_request_line1.purchase_lines.date_planned.day,
+            purchase_request_line1.purchase_lines.date_planned.astimezone(user_tz).day,
         )
         po = purchase_request_line1.purchase_lines[0].order_id
         # Create Purchase Request


### PR DESCRIPTION
FP for: https://github.com/OCA/purchase-workflow/pull/1863

Reply error: (Make sure you have different timezone)
- Create a purchase request and request line
- Create a RFQ from Request line (wizard)
Field "Expected arrival" (date_planned) has a wrong date

![image](https://github.com/OCA/purchase-workflow/assets/90717087/fc0f3b45-8c62-4f39-b6c1-47b55af0f189)
