### PR TITLE
[16.0][FIX] purchase_only_by_packaging: Rename method _convert_purchase_packaging_qty

### DIFF
--- a/purchase_only_by_packaging/models/product_product.py
+++ b/purchase_only_by_packaging/models/product_product.py
@@ -32,7 +32,7 @@ class ProductProduct(models.Model):
                     purchasable_pkgs.sorted(lambda p: p.qty)
                 ).qty
 
-    def _convert_packaging_qty(self, qty, uom, packaging):
+    def _convert_purchase_packaging_qty(self, qty, uom, packaging):
         """
         Convert the given qty with given UoM to the packaging uom.
         To do that, first transform the qty to the reference UoM and then

--- a/purchase_only_by_packaging/models/purchase_order_line.py
+++ b/purchase_only_by_packaging/models/purchase_order_line.py
@@ -41,7 +41,7 @@ class PurchaseOrderLine(models.Model):
         :return:
         """
         self.ensure_one()
-        qty = self.product_id._convert_packaging_qty(
+        qty = self.product_id._convert_purchase_packaging_qty(
             self.product_qty, self.product_uom, packaging=self.product_packaging_id
         )
         self.product_qty = qty


### PR DESCRIPTION
Method name is in conflict with the one defined in sale-workflow

https://github.com/OCA/sale-workflow/blob/67c92980bd0592584f3dba2e06632a52dfba1b93/sell_only_by_packaging/models/product_product.py#L33