### PR TITLE
[FIX] purchase_request: RFQ wizard copy description toggle

### DIFF
--- a/purchase_request/__manifest__.py
+++ b/purchase_request/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Purchase Request",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
-    "version": "17.0.1.1.1",
+    "version": "17.0.1.2.1",
     "summary": "Use this module to have notification of requirements of "
     "materials and/or external services and keep track of such "
     "requirements.",

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -42,7 +42,7 @@
                                 groups="!uom.group_uom"
                             />
                             <field name="product_uom_id" groups="uom.group_uom" />
-                            <field name="keep_description" widget="boolean_toggle" />
+                            <field name="keep_description" />
                         </tree>
                     </field>
                 </group>


### PR DESCRIPTION
When checking the "Copy description to Purchase Order" option on an approved Purchase Request, the system has a strange behavior in which it deletes the lines. By removing the toggle in the the boolean field "keep_description" in the wizard view it fixes the problem.