### PR TITLE
[14.0][IMP] supplier_calendar: robustness

### DIFF
--- a/supplier_calendar/models/res_partner.py
+++ b/supplier_calendar/models/res_partner.py
@@ -31,6 +31,8 @@ class ResPartner(models.Model):
         :return: datetime: resulting date.
         """
         self.ensure_one()
+        if isinstance(delta, float):
+            delta = round(delta)
         if not isinstance(date_from, datetime):
             date_from = fields.Datetime.to_datetime(date_from)
         if delta == 0:


### PR DESCRIPTION
when delta argument is a float `plan_days` method can return unexpected False result. This can lead to silent errors. Therefore we ensure that delta is a integer in the helper.

Backport #2255 
