### PR TITLE
[FIX] purchase_manual_currency: Calculate Total (Currency Name) with order date

### DIFF
--- a/purchase_manual_currency/models/purchase.py
+++ b/purchase_manual_currency/models/purchase.py
@@ -68,7 +68,7 @@ class PurchaseOrder(models.Model):
                     rec.amount_total,
                     rec.company_currency_id,
                     rec.company_id,
-                    fields.Date.today(),
+                    rec.date_order or fields.Date.context_today(rec),
                 )
 
     def _get_label_currency_name(self):
@@ -93,7 +93,7 @@ class PurchaseOrder(models.Model):
 
     @api.onchange("manual_currency", "type_currency", "currency_id", "date_order")
     def _onchange_currency_change_rate(self):
-        today = fields.Date.today()
+        today = fields.Date.context_today(self)
         company_currency = self.env.company.currency_id
         amount_currency = company_currency._get_conversion_rate(
             company_currency,

--- a/purchase_manual_currency/models/purchase_order_line.py
+++ b/purchase_manual_currency/models/purchase_order_line.py
@@ -44,5 +44,5 @@ class PurchaseOrderLine(models.Model):
                         rec.price_subtotal,
                         rec.company_currency_id,
                         rec.company_id,
-                        fields.Date.today(),
+                        rec.order_id.date_order or fields.Date.context_today(rec),
                     )


### PR DESCRIPTION
This PR fixed calculate Subtotal and Total with order date
![Selection_3716](https://github.com/OCA/purchase-workflow/assets/24691983/708523af-8b11-4544-ac8b-657778c0f548)
