### PR TITLE
[15.0][FIX] purchase_quick:  fix CI error test 

### DIFF
--- a/purchase_default_terms_conditions/tests/test_purchase_order.py
+++ b/purchase_default_terms_conditions/tests/test_purchase_order.py
@@ -38,6 +38,7 @@ class TestPurchase(AccountTestInvoicingCommon):
             .create(
                 {
                     "partner_id": self.partner_a.id,
+                    "company_id": self.company_data["company"].id,
                 }
             )
         )
@@ -54,6 +55,7 @@ class TestPurchase(AccountTestInvoicingCommon):
                 "price_unit": self.product_order.list_price,
                 "order_id": purchase_order.id,
                 "taxes_id": False,
+                "company_id": self.company_data["company"].id,
             }
         )
 

--- a/purchase_quick/models/purchase_order.py
+++ b/purchase_quick/models/purchase_order.py
@@ -66,10 +66,12 @@ class PurchaseOrder(models.Model):
             "partner_id": self.partner_id.id,
         }
         vals_to_add.update(vals)
-        vals = vals_to_add
-        return super(PurchaseOrder, self)._complete_quick_line_vals(
-            vals, lines_key="order_line"
+        vals = super(PurchaseOrder, self)._complete_quick_line_vals(
+            vals_to_add, lines_key="order_line"
         )
+        skip_play_onchanges_vals = {"company_id": self.company_id.id}
+        vals.update(skip_play_onchanges_vals)
+        return vals
 
     def _add_quick_line(self, product, lines_key=""):
         return super(PurchaseOrder, self)._add_quick_line(

--- a/purchase_quick/tests/test_quick_purchase.py
+++ b/purchase_quick/tests/test_quick_purchase.py
@@ -22,7 +22,11 @@ class TestQuickPurchase(TransactionCase):
 
     @classmethod
     def _setUpBasicSaleOrder(cls):
-        vals = {"partner_id": cls.partner.id}
+        vals = {
+            "partner_id": cls.partner.id,
+            "company_id": cls.user.company_id.id,
+            "user_id": cls.user.id,
+        }
         if hasattr(cls.env["purchase.order"], "order_type"):
             vals["order_type"] = cls.env.ref("purchase_order_type.po_type_blanket").id
         cls.po = cls.env["purchase.order"].create(vals)
@@ -199,7 +203,13 @@ class TestQuickPurchase(TransactionCase):
         While in the quick purchase interface, a purchaser with no edit rights
         on product.product can still edit product.product quick quantities
         """
-        po = self.env["purchase.order"].create({"partner_id": self.partner.id})
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.user.company_id.id,
+                "user_id": self.user.id,
+            }
+        )
         ctx = {
             "parent_id": po.id,
             "parent_model": "purchase.order",


### PR DESCRIPTION
Doing some test on the top of https://github.com/OCA/purchase-workflow/pull/2280