### PR TITLE
[FIX] purchase_discount : transmits correctly discount value to account.move.line, if account_invoice_triple_discount is installed.

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -110,8 +110,12 @@ class PurchaseOrderLine(models.Model):
         self.discount = seller.discount
 
     def _prepare_account_move_line(self, move=False):
-        vals = super(PurchaseOrderLine, self)._prepare_account_move_line(move)
-        vals["discount"] = self.discount
+        vals = super()._prepare_account_move_line(move)
+        if self.env["account.move.line"]._fields.get("discount1", False):
+            # OCA/account_invoice_triple_discount is installed
+            vals["discount1"] = self.discount
+        else:
+            vals["discount"] = self.discount
         return vals
 
     @api.model


### PR DESCRIPTION
Adapt purchase_discount to pending refactoring done in account_invoice_triple_discount.

(See refactoring https://github.com/OCA/account-invoicing/pull/1638)

Note : this PR should be merged before https://github.com/OCA/account-invoicing/pull/1638.

CC : @grindtildeath