### PR TITLE
[17.0][IMP] purchase_request (Lines readonly if is_editable==False)

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -144,7 +144,7 @@
                     </group>
                     <notebook>
                         <page string="Products">
-                            <field name="line_ids">
+                            <field name="line_ids" readonly="is_editable == False">
                                 <tree
                                     decoration-muted="cancelled == True"
                                     editable="bottom"


### PR DESCRIPTION
Majority of the fields are readonly once the PR gets approved except the product lines which can be edited even though the PR was approved or done. This PR adds the same readonly="is_editable == False" that the other fields use on the form to the line_ids to not allow modifications once the PR is approved/done.