### PR TITLE
[15.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/purchase_receipt_expectation/__manifest__.py
+++ b/purchase_receipt_expectation/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Purchase Receipt Expectation",
     "version": "15.0.1.0.0",
     "category": "Purchase Management",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "license": "AGPL-3",
     "data": [

--- a/purchase_receipt_expectation_from_partner/__manifest__.py
+++ b/purchase_receipt_expectation_from_partner/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Purchase Receipt Expectation From Partner",
     "version": "15.0.1.0.0",
     "category": "Purchase Management",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "license": "AGPL-3",
     "data": [

--- a/purchase_receipt_expectation_manual/__manifest__.py
+++ b/purchase_receipt_expectation_manual/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Purchase Receipt Expectation - Manual",
     "version": "15.0.1.0.1",
     "category": "Purchase Management",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "license": "AGPL-3",
     "data": [

--- a/purchase_receipt_expectation_manual_split/__manifest__.py
+++ b/purchase_receipt_expectation_manual_split/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Purchase Receipt Expectation - Manual w/ Split",
     "version": "15.0.2.0.0",
     "category": "Purchase Management",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "license": "AGPL-3",
     "depends": [


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 15.0.