### PR TITLE
[14.0][FIX] purchase_order_type: preserve order type when matches company

### DIFF
--- a/purchase_order_type/models/purchase_order.py
+++ b/purchase_order_type/models/purchase_order.py
@@ -64,4 +64,8 @@ class PurchaseOrder(models.Model):
 
     @api.onchange("company_id")
     def _onchange_company(self):
-        self.order_type = self._default_order_type()
+        if not self.order_type or (
+            self.order_type
+            and self.order_type.company_id not in [self.company_id, False]
+        ):
+            self.order_type = self._default_order_type()

--- a/purchase_order_type/tests/test_purchase_order_type.py
+++ b/purchase_order_type/tests/test_purchase_order_type.py
@@ -75,6 +75,9 @@ class TestPurchaseOrderType(common.SavepointCase):
         order.onchange_partner_id()
         self.assertEqual(order.order_type, self.type2)
         order._onchange_company()
+        self.assertEqual(order.order_type, self.type2)
+        order.write({"order_type": False})
+        order._onchange_company()
         self.assertEqual(order.order_type, order._default_order_type())
 
     def test_purchase_order_type_company_error(self):


### PR DESCRIPTION
Before this fix, when onchange event for `company_id` was fired, type for purchase order was always set, then sometimes overwritten, even if former order type was compatible with the new company.

This causes an incompatibility with e.g. `purchase_order_type_dashboard`. When PO creation form is accessed coming from PO dashboard, selected order type was actually ignored, because `onchange` for company was fired and order type overwritten. This fixes it.