### PR TITLE
[15.0][IMP] purchase_order_product_recommendation_secondary_unit: make the secondary unit and secondary quantity fields optional

### DIFF
--- a/purchase_order_product_recommendation_secondary_unit/wizards/purchase_order_recommendation_view.xml
+++ b/purchase_order_product_recommendation_secondary_unit/wizards/purchase_order_recommendation_view.xml
@@ -9,10 +9,11 @@
         />
         <field name="arch" type="xml">
             <field name="units_included" position="before">
-                <field name="secondary_uom_id" />
+                <field name="secondary_uom_id" optional="show" />
                 <field
                     name="secondary_uom_qty"
                     attrs="{'invisible': [('secondary_uom_id', '=', False)]}"
+                    optional="show"
                 />
             </field>
         </field>


### PR DESCRIPTION
cc @tecnativa TT49686

@CarlosRoca13 @sergio-teruel please review