### PR TITLE
[15.0][IMP] purchase_open_qty: add purchase_order_line_menu dependency

### DIFF
--- a/purchase_open_qty/__manifest__.py
+++ b/purchase_open_qty/__manifest__.py
@@ -10,7 +10,10 @@
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "category": "Purchases",
-    "depends": ["purchase_stock"],
+    "depends": [
+        "purchase_stock",
+        "purchase_order_line_menu",
+    ],
     "data": ["views/purchase_view.xml"],
     "pre_init_hook": "pre_init_hook",
     "license": "AGPL-3",

--- a/purchase_open_qty/static/description/index.html
+++ b/purchase_open_qty/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/purchase_open_qty/views/purchase_view.xml
+++ b/purchase_open_qty/views/purchase_view.xml
@@ -27,13 +27,13 @@
     <!-- Show open quantities fields wherever the tree view is used -->
     <record model="ir.ui.view" id="view_purchase_order_line_tree">
         <field name="model">purchase.order.line</field>
-        <field name="inherit_id" ref="purchase.purchase_order_line_tree" />
+        <field
+            name="inherit_id"
+            ref="purchase_order_line_menu.purchase_order_line_tree"
+        />
         <field name="arch" type="xml">
-            <field name="product_qty" position="after">
+            <field name="qty_received" position="before">
                 <field name="qty_to_receive" optional="hide" />
-                <field name="qty_received" optional="hide" />
-                <field name="qty_to_invoice" optional="hide" />
-                <field name="qty_invoiced" optional="hide" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
If the purchase_order_line_menu and purchase_open_qty modules are installed, they both add the same fields to the purchase_order_line_tree view inheritance. This dependency avoids declaring duplicate fields.

@ForgeFlow 