### PR TITLE
[15.0][FIX] purchase_delivery_split_date: do not create empty pickings

### DIFF
--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -44,7 +44,10 @@ class PurchaseOrderLine(models.Model):
         moves = self.env["stock.move"]
         # Group the order lines by group key
         order_lines = sorted(
-            self.filtered(lambda l: not l.display_type),
+            self.filtered(
+                lambda l: not l.display_type
+                and l.product_id.type in ["product", "consu"]
+            ),
             key=lambda l: self._get_sorted_keys(l),
         )
         date_groups = groupby(


### PR DESCRIPTION
When there was a grouping key (aka a date_planned) that only corresponds
to PO lines that are services, a picking was created and left empty.