### PR TITLE
[17.0][FIX] purchase_delivery_split_date: do not create empty pickings

### DIFF
--- a/purchase_delivery_split_date/models/purchase_order_line.py
+++ b/purchase_delivery_split_date/models/purchase_order_line.py
@@ -44,7 +44,10 @@ class PurchaseOrderLine(models.Model):
         moves = self.env["stock.move"]
         # Group the order lines by group key
         order_lines = sorted(
-            self.filtered(lambda line: not line.display_type),
+            self.filtered(
+                lambda line: not line.display_type
+                and line.product_id.type in ["product", "consu"]
+            ),
             key=lambda line: self._get_sorted_keys(line),
         )
         date_groups = groupby(


### PR DESCRIPTION
When there was a grouping key (aka a date_planned) that only corresponds to PO lines that are services, a picking was created and left empty.

Fwport of #2332 