### PR TITLE
[IMP] purchase_merge: Update chatter message

### DIFF
--- a/purchase_merge/wizard/purchase_merge.py
+++ b/purchase_merge/wizard/purchase_merge.py
@@ -164,7 +164,7 @@ class MergePurchaseAutomatic(models.TransientModel):
         """
         subject = "Merge purchase order"
         body = _(
-            "This purchase order lines have been merged {way} : {po_names}",
+            "This purchase order lines have been merged %(way)s : %(po_names)s",
             way=way,
             po_names=" ,".join(po_name),
         )


### PR DESCRIPTION
### Module

purchase_merge

### Describe the bug

The message on chatter is not well formatted when two pos' are merging

### To Reproduce

1. Select two equal po
2. Merge
3. Check chatter

(image from runboat OCA)

![image](https://github.com/OCA/purchase-workflow/assets/134701949/f42eced8-070a-4cf8-9623-d1221ddc1404)

![image](https://github.com/OCA/purchase-workflow/assets/134701949/5b7b6e60-caff-4643-89df-0c25f1c0f871)

![image](https://github.com/OCA/purchase-workflow/assets/134701949/b133e9b9-0aee-4fe3-b65f-aa5e54357a76)

![Captura desde 2024-07-05 14-50-22](https://github.com/OCA/purchase-workflow/assets/134701949/f1f0e48c-55b4-4b04-a4ec-81beec31080d)

**Affected versions:**

16.0

**Additional context**

The problem will be resolved with this change


