### PR TITLE
[12.0][FIX] purchase_open_qty refund from dropship

### DIFF
--- a/purchase_open_qty/models/purchase_order.py
+++ b/purchase_open_qty/models/purchase_order.py
@@ -41,8 +41,13 @@ class PurchaseOrderLine(models.Model):
                     lambda m: m.state == 'done'):
                 sign = 1
                 # in case of outgoing (refund) sign is inverted
-                if move.location_id.usage == 'internal' and \
-                        move.location_dest_id.usage != 'internal':
+                # also support particular case of refund from a supplier dropship
+                if (
+                    move.location_id.usage == 'internal'
+                    and move.location_dest_id.usage != 'internal'
+                    or move.location_id.usage == 'customer'
+                    and move.location_dest_id.usage == 'supplier'
+                ):
                     sign = -1
                 product_uom_qty = move.product_uom_qty * sign
                 if move.product_uom != line.product_uom:


### PR DESCRIPTION
How-to replicate:
- enable dropshipping
- create a stock.picking.type with `supplier` picking type and source location to Partner/Vendors Subcontracting, destination location to Partner/Vendors and the picking type refund to that created in the next step
- create a stock.picking.type with `supplier` picking type and source location to Partner/Vendors, destination location to Partner/Vendors Subcontracting and the picking type refund to that created in the previous step
- create a purchase order with the picking type of the previous step and a dropshipping address
- confirm the purchase order and receive the products (this will send the products from vendor to subcontractor)
- make a refund of the done picking

The qty_to_receive will be negative.

With this PR the qty_to_receive will be correct.
