### PR TITLE
[16.0][IMP] purchase_manual_delivery: more specific menu name

### DIFF
--- a/purchase_manual_delivery/views/purchase_order_views.xml
+++ b/purchase_manual_delivery/views/purchase_order_views.xml
@@ -110,7 +110,7 @@
     </record>
 
     <record id="action_order_line_delivery_tree" model="ir.actions.act_window">
-        <field name="name">Purchase Order Lines</field>
+        <field name="name">Purchase Manual Receipt</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">purchase.order.line</field>
         <field name="view_mode">tree,form</field>


### PR DESCRIPTION
To avoid confusions when used with https://github.com/OCA/purchase-workflow/blob/16.0/purchase_order_line_menu