### PR TITLE
[16.0][IMP] purchase_request: add 'In Progress' state

### DIFF
--- a/purchase_request/i18n/es.po
+++ b/purchase_request/i18n/es.po
@@ -556,6 +556,18 @@ msgid "If checked, some messages have a delivery error."
 msgstr "si está marcada, algunos mensajes tienen un error de entrega."
 
 #. module: purchase_request
+#: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_form
+#: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
+msgid "In Progress"
+msgstr "En Progreso"
+
+#. module: purchase_request
+#: model:ir.model.fields.selection,name:purchase_request.selection__purchase_request__state__in_progress
+msgid "In progress"
+msgstr "En Progreso"
+
+#. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request__is_editable
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request_line__is_editable
 msgid "Is Editable"
@@ -870,8 +882,8 @@ msgstr "La solicitud de compra %s ha sido completada"
 #. odoo-python
 #: code:addons/purchase_request/wizard/purchase_request_line_make_purchase_order.py:0
 #, python-format
-msgid "Purchase Request %s is not approved"
-msgstr "la solicitud de compra %s no ha sido aprobada"
+msgid "Purchase Request %s is not approved or in progress"
+msgstr "la solicitud de compra %s no ha sido aprobada ni está en progreso"
 
 #. module: purchase_request
 #: model:ir.model,name:purchase_request.model_purchase_request_allocation
@@ -1121,6 +1133,12 @@ msgstr "La solicitud se ha aprobado"
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
 msgid "Request is done"
 msgstr "Solicitud realizada"
+
+#. module: purchase_request
+#: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
+msgid "Request is in progress"
+msgstr "Solicitud en progreso"
 
 #. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search

--- a/purchase_request/i18n/purchase_request.pot
+++ b/purchase_request/i18n/purchase_request.pot
@@ -513,6 +513,18 @@ msgid "If checked, some messages have a delivery error."
 msgstr ""
 
 #. module: purchase_request
+#: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_form
+#: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
+msgid "In Progress"
+msgstr ""
+
+#. module: purchase_request
+#: model:ir.model.fields.selection,name:purchase_request.selection__purchase_request__state__in_progress
+msgid "In progress"
+msgstr ""
+
+#. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request__is_editable
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request_line__is_editable
 msgid "Is Editable"
@@ -829,7 +841,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/purchase_request/wizard/purchase_request_line_make_purchase_order.py:0
 #, python-format
-msgid "Purchase Request %s is not approved"
+msgid "Purchase Request %s is not approved or in progress"
 msgstr ""
 
 #. module: purchase_request
@@ -1075,6 +1087,12 @@ msgstr ""
 #. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
 msgid "Request is done"
+msgstr ""
+
+#. module: purchase_request
+#: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
+msgid "Request is in progress"
 msgstr ""
 
 #. module: purchase_request

--- a/purchase_request/models/orderpoint.py
+++ b/purchase_request/models/orderpoint.py
@@ -11,7 +11,11 @@ class Orderpoint(models.Model):
         res = super(Orderpoint, self)._quantity_in_progress()
         for prline in self.env["purchase.request.line"].search(
             [
-                ("request_id.state", "in", ("draft", "approved", "to_approve")),
+                (
+                    "request_id.state",
+                    "in",
+                    ("draft", "approved", "to_approve", "in_progress"),
+                ),
                 ("orderpoint_id", "in", self.ids),
                 ("purchase_state", "=", False),
             ]

--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -8,8 +8,9 @@ _STATES = [
     ("draft", "Draft"),
     ("to_approve", "To be approved"),
     ("approved", "Approved"),
-    ("rejected", "Rejected"),
+    ("in_progress", "In progress"),
     ("done", "Done"),
+    ("rejected", "Rejected"),
 ]
 
 
@@ -48,7 +49,13 @@ class PurchaseRequest(models.Model):
     @api.depends("state")
     def _compute_is_editable(self):
         for rec in self:
-            if rec.state in ("to_approve", "approved", "rejected", "done"):
+            if rec.state in (
+                "to_approve",
+                "approved",
+                "rejected",
+                "in_progress",
+                "done",
+            ):
                 rec.is_editable = False
             else:
                 rec.is_editable = True
@@ -283,6 +290,9 @@ class PurchaseRequest(models.Model):
     def button_rejected(self):
         self.mapped("line_ids").do_cancel()
         return self.write({"state": "rejected"})
+
+    def button_in_progress(self):
+        return self.write({"state": "in_progress"})
 
     def button_done(self):
         return self.write({"state": "done"})

--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -8,8 +8,9 @@ _STATES = [
     ("draft", "Draft"),
     ("to_approve", "To be approved"),
     ("approved", "Approved"),
-    ("rejected", "Rejected"),
+    ("in_progress", "In progress"),
     ("done", "Done"),
+    ("rejected", "Rejected"),
 ]
 
 
@@ -247,7 +248,13 @@ class PurchaseRequestLine(models.Model):
     )
     def _compute_is_editable(self):
         for rec in self:
-            if rec.request_id.state in ("to_approve", "approved", "rejected", "done"):
+            if rec.request_id.state in (
+                "to_approve",
+                "approved",
+                "rejected",
+                "in_progress",
+                "done",
+            ):
                 rec.is_editable = False
             else:
                 rec.is_editable = True

--- a/purchase_request/tests/test_purchase_request.py
+++ b/purchase_request/tests/test_purchase_request.py
@@ -51,6 +51,19 @@ class TestPurchaseRequest(TransactionCase):
         self.assertEqual(purchase_request.is_editable, True, "Should be editable")
         self.assertEqual(purchase_request.state, "draft", "Should be in state draft")
         purchase_request.button_to_approve()
+        purchase_request.button_in_progress()
+        self.assertEqual(
+            purchase_request.state, "in_progress", "Should be in state in_progress"
+        )
+        self.assertEqual(purchase_request.is_editable, False, "Should not be editable")
+        with self.assertRaises(exceptions.UserError) as e:
+            purchase_request.unlink()
+        msg = "You cannot delete a purchase request which is not draft."
+        self.assertIn(msg, e.exception.args[0])
+        purchase_request.button_draft()
+        self.assertEqual(purchase_request.is_editable, True, "Should be editable")
+        self.assertEqual(purchase_request.state, "draft", "Should be in state draft")
+        purchase_request.button_to_approve()
         purchase_request.button_done()
         self.assertEqual(purchase_request.is_editable, False, "Should not be editable")
         with self.assertRaises(exceptions.UserError) as e:
@@ -268,6 +281,15 @@ class TestPurchaseRequest(TransactionCase):
 
         pr.button_to_approve()
         self.assertEqual(pr.state, "to_approve", "Should be in state to_approve")
+        with self.assertRaises(exceptions.UserError) as e:
+            pr_lines.unlink()
+        msg = (
+            "You can only delete a purchase request line "
+            "if the purchase request is in draft state."
+        )
+        self.assertIn(msg, e.exception.args[0])
+        pr.button_in_progress()
+        self.assertEqual(pr.state, "in_progress", "Should be in state in_progress")
         with self.assertRaises(exceptions.UserError) as e:
             pr_lines.unlink()
         msg = (

--- a/purchase_request/views/purchase_request_line_view.xml
+++ b/purchase_request/views/purchase_request_line_view.xml
@@ -16,7 +16,7 @@
                 <field
                     name="request_state"
                     widget="badge"
-                    decoration-success="request_state in ('done', 'approved')"
+                    decoration-success="request_state in ('done', 'approved', 'in_progress')"
                     decoration-info="request_state in ('draft', 'to_approve')"
                     decoration-danger="request_state == 'rejected'"
                 />
@@ -67,7 +67,11 @@
         <field name="arch" type="xml">
             <form string="Purchase Request Line" create="false" duplicate="false">
                 <header>
-                    <field name="request_state" widget="statusbar" />
+                    <field
+                        name="request_state"
+                        widget="statusbar"
+                        statusbar_visible="draft,to_approve,approved,done,in_progress"
+                    />
                 </header>
                 <sheet>
                     <h1>
@@ -266,6 +270,12 @@
                     string="Rejected"
                     domain="[('request_state','=','rejected')]"
                     help="Request is rejected"
+                />
+                <filter
+                    name="request_state_in_progress"
+                    string="In Progress"
+                    domain="[('request_state','=','in_progress')]"
+                    help="Request is in progress"
                 />
                 <filter
                     name="assigned_to_me"

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -10,7 +10,7 @@
                 <header>
                     <button
                         name="button_draft"
-                        states="to_approve,approved,rejected,done"
+                        states="to_approve,approved,rejected,in_progress,done"
                         string="Reset"
                         type="object"
                         groups="purchase_request.group_purchase_request_manager"
@@ -31,14 +31,21 @@
                         groups="purchase_request.group_purchase_request_manager"
                     />
                     <button
-                        name="%(action_purchase_request_line_make_purchase_order)d"
+                        name="button_in_progress"
                         states="approved"
+                        string="In Progress"
+                        type="object"
+                        groups="purchase_request.group_purchase_request_manager"
+                    />
+                    <button
+                        name="%(action_purchase_request_line_make_purchase_order)d"
+                        states="approved,in_progress"
                         string="Create RFQ"
                         type="action"
                     />
                     <button
                         name="button_done"
-                        states="approved"
+                        states="approved,in_progress"
                         string="Done"
                         type="object"
                         class="oe_highlight"
@@ -46,7 +53,7 @@
                     />
                     <button
                         name="button_rejected"
-                        states="to_approve,approved"
+                        states="to_approve,approved,in_progress"
                         string="Reject"
                         type="object"
                         groups="purchase_request.group_purchase_request_manager"
@@ -54,7 +61,7 @@
                     <field
                         name="state"
                         widget="statusbar"
-                        statusbar_visible="draft,to_approve,approved,done,rejected"
+                        statusbar_visible="draft,to_approve,approved,done,in_progress"
                         statusbar_colors='{"approved":"blue"}'
                     />
                 </header>
@@ -267,7 +274,7 @@
                 <field
                     name="state"
                     widget="badge"
-                    decoration-success="state in ('done', 'approved')"
+                    decoration-success="state in ('done', 'approved', 'in_progress')"
                     decoration-muted="state == 'draft'"
                     decoration-warning="state == 'to_approve'"
                     decoration-danger="state == 'rejected'"
@@ -308,6 +315,12 @@
                     string="Approved"
                     domain="[('state','=','approved')]"
                     help="Request is approved"
+                />
+                <filter
+                    name="state_in_progress"
+                    string="In Progress"
+                    domain="[('state','=','in_progress')]"
+                    help="Request is in progress"
                 />
                 <filter
                     name="state_rejected"

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -54,9 +54,10 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         for line in self.env["purchase.request.line"].browse(request_line_ids):
             if line.request_id.state == "done":
                 raise UserError(_("The purchase has already been completed."))
-            if line.request_id.state != "approved":
+            if line.request_id.state not in ["approved", "in_progress"]:
                 raise UserError(
-                    _("Purchase Request %s is not approved") % line.request_id.name
+                    _("Purchase Request %s is not approved or in progress")
+                    % line.request_id.name
                 )
 
             if line.purchase_state == "done":
@@ -289,6 +290,8 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             )
             res.append(purchase.id)
 
+        purchase_requests = self.item_ids.mapped("request_id")
+        purchase_requests.button_in_progress()
         return {
             "domain": [("id", "in", res)],
             "name": _("RFQ"),


### PR DESCRIPTION
This improvement add a new state 'In Progress' to Purchase Requests. 

It can be useful for users in charge of managing Purchase Requests and creating their respective RFQs, to know if they have started processing that Purchase Request's related purchases or if it's still pending, once approved.

A Purchase Request can be set to the 'In Progress' state manually, but it also is set automatically when the first RFQ is created or assigned to the Purchase Request.