### PR TITLE
[FIX]purchase_discount:revert change

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -110,12 +110,8 @@ class PurchaseOrderLine(models.Model):
         self.discount = seller.discount
 
     def _prepare_account_move_line(self, move=False):
-        vals = super()._prepare_account_move_line(move)
-        if self.env["account.move.line"]._fields.get("discount1", False):
-            # OCA/account_invoice_triple_discount is installed
-            vals["discount1"] = self.discount
-        else:
-            vals["discount"] = self.discount
+        vals = super(PurchaseOrderLine, self)._prepare_account_move_line(move)
+        vals["discount"] = self.discount
         return vals
 
     @api.model


### PR DESCRIPTION
We create this commit because it enter in conflict with custom modules we have. field "discount1" exist in account.move.line for a diferent funcionality in our case.

We don´t need to merge.