### PR TITLE
[16.0][FIX]purchase_manual_delivery: qty compute fixes

### DIFF
--- a/purchase_manual_delivery/models/purchase_order.py
+++ b/purchase_manual_delivery/models/purchase_order.py
@@ -57,6 +57,7 @@ class PurchaseOrderLine(models.Model):
         "move_ids.state",
         "move_ids.location_id",
         "move_ids.location_dest_id",
+        "product_uom_qty",
     )
     def _compute_existing_qty(self):
         for line in self:
@@ -92,10 +93,13 @@ class PurchaseOrderLine(models.Model):
                             move.product_uom_qty, line.product_uom
                         )
             line.existing_qty = total
-            if float_compare(
-                line.product_qty,
-                line.existing_qty,
-                precision_digits=precision_digits,
+            if (
+                float_compare(
+                    line.product_qty,
+                    line.existing_qty,
+                    precision_digits=precision_digits,
+                )
+                == 1
             ):
                 line.pending_to_receive = True
             else:


### PR DESCRIPTION
Fixes the following 2 errors:
1. _compute_existing_qty not recomputed when changing product_uom_qty
2. Line is shown as pending_to_receive when existing_qty is higher than product_uom_qty

How-to replicate 2.:
1. Login as admin
2. Go to "Purchase"
3. Create a new one
4. Add any "Vendor" and set "Purchase manual delivery" to True
5. Add any product with "Quantity" = 5
6. Save and "Confirm order"
7. Click "Create incoming shipment"
8. Change "Quantity to 4"
9. Click "Create and view picking"
10. Change value of "Done" to 6 (any amount higher than the original expected (product_uom_qty) is fine)
11. Validate and go back to the Purchase Order
12. The Purchase Order Line is now highlighted blue because its value for pending_to_receive is True