### PR TITLE
[FIX] purchase_merge: add _description to purchase.merge.automatic.wizard

### DIFF
--- a/purchase_merge/wizard/purchase_merge.py
+++ b/purchase_merge/wizard/purchase_merge.py
@@ -15,6 +15,7 @@ class MergePurchaseAutomatic(models.TransientModel):
     """
 
     _name = "purchase.merge.automatic.wizard"
+    _description = "Purchase Merge Automatic Wizard"
 
     purchase_ids = fields.Many2many(
         comodel_name="purchase.order",


### PR DESCRIPTION
Warning is shown for not defining the _description parameter.

![Selección_1096](https://github.com/user-attachments/assets/0035787f-1d6e-4bf0-a643-392af91ff747)
