### PR TITLE
[16.0][FIX]purchase_manual_delivery: pending in forecast

### DIFF
--- a/purchase_manual_delivery/__init__.py
+++ b/purchase_manual_delivery/__init__.py
@@ -1,2 +1,3 @@
 from . import models
+from . import report
 from . import wizard

--- a/purchase_manual_delivery/__manifest__.py
+++ b/purchase_manual_delivery/__manifest__.py
@@ -19,4 +19,9 @@
         "views/purchase_order_views.xml",
         "views/res_config_view.xml",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "purchase_manual_delivery/static/src/**/*",
+        ]
+    },
 }

--- a/purchase_manual_delivery/models/__init__.py
+++ b/purchase_manual_delivery/models/__init__.py
@@ -1,3 +1,4 @@
+from . import product_product
 from . import res_company
 from . import res_config
 from . import purchase_order

--- a/purchase_manual_delivery/models/product_product.py
+++ b/purchase_manual_delivery/models/product_product.py
@@ -1,0 +1,58 @@
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _get_pending_lines_domain(self, location_ids=False, warehouse_ids=False):
+        domain = self._get_lines_domain(location_ids, warehouse_ids)
+        for domain_part in domain:
+            if (
+                isinstance(domain_part, tuple)
+                and len(domain_part) == 3
+                and domain_part[0] == "state"
+            ):
+                domain_index = domain.index(domain_part)
+                domain[domain_index] = ("state", "in", ("purchase", "done"))
+                domain.insert(domain_index + 1, ("pending_to_receive", "=", True))
+                domain.insert(domain_index, "&")
+                break
+        return domain
+
+    def _get_quantity_in_progress(self, location_ids=False, warehouse_ids=False):
+        qty_by_product_location, qty_by_product_wh = super()._get_quantity_in_progress(
+            location_ids, warehouse_ids
+        )
+        domain = self._get_pending_lines_domain(location_ids, warehouse_ids)
+        groups = self.env["purchase.order.line"]._read_group(
+            domain,
+            [
+                "product_id",
+                "product_qty",
+                "order_id",
+                "product_uom",
+                "orderpoint_id",
+                "existing_qty",
+            ],
+            ["order_id", "product_id", "product_uom", "orderpoint_id"],
+            lazy=False,
+        )
+        for group in groups:
+            if group.get("orderpoint_id"):
+                location = (
+                    self.env["stock.warehouse.orderpoint"]
+                    .browse(group["orderpoint_id"][:1])
+                    .location_id
+                )
+            else:
+                order = self.env["purchase.order"].browse(group["order_id"][0])
+                location = order.picking_type_id.default_location_dest_id
+            product = self.env["product.product"].browse(group["product_id"][0])
+            uom = self.env["uom.uom"].browse(group["product_uom"][0])
+            product_qty = uom._compute_quantity(
+                group["product_qty"], product.uom_id, round=False
+            )
+            remaining_qty = product_qty - group["existing_qty"]
+            qty_by_product_location[(product.id, location.id)] += remaining_qty
+            qty_by_product_wh[(product.id, location.warehouse_id.id)] += remaining_qty
+        return qty_by_product_location, qty_by_product_wh

--- a/purchase_manual_delivery/report/__init__.py
+++ b/purchase_manual_delivery/report/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_forecasted

--- a/purchase_manual_delivery/report/stock_forecasted.py
+++ b/purchase_manual_delivery/report/stock_forecasted.py
@@ -1,0 +1,35 @@
+from odoo import models
+
+
+class ReplenishmentReport(models.AbstractModel):
+    _inherit = "report.stock.report_product_product_replenishment"
+
+    def _serialize_docs(
+        self, docs, product_template_ids=False, product_variant_ids=False
+    ):
+        res = super()._serialize_docs(docs, product_template_ids, product_variant_ids)
+        res["no_delivery_purchase_orders"] = docs["no_delivery_purchase_orders"].read(
+            fields=["id", "name"]
+        )
+        return res
+
+    def _compute_draft_quantity_count(
+        self, product_template_ids, product_variant_ids, wh_location_ids
+    ):
+        res = super()._compute_draft_quantity_count(
+            product_template_ids, product_variant_ids, wh_location_ids
+        )
+        domain = [
+            ("state", "in", ["purchase", "done"]),
+            ("pending_to_receive", "=", True),
+        ]
+        domain += self._product_domain(product_template_ids, product_variant_ids)
+        warehouse_id = self.env.context.get("warehouse", False)
+        if warehouse_id:
+            domain += [("order_id.picking_type_id.warehouse_id", "=", warehouse_id)]
+        po_lines = self.env["purchase.order.line"].search(domain)
+        in_sum = sum(po_lines.mapped(lambda po: po.product_qty - po.existing_qty))
+        res["no_delivery_purchase_qty"] = in_sum
+        res["no_delivery_purchase_orders"] = po_lines.mapped("order_id").sorted("name")
+        res["qty"]["in"] += in_sum
+        return res

--- a/purchase_manual_delivery/static/src/purchase_manual_delivery_forecasted/forecasted_details.xml
+++ b/purchase_manual_delivery/static/src/purchase_manual_delivery_forecasted/forecasted_details.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<templates id="template" xml:space="preserve">
+    <t
+        t-name="purchase_manual_delivery.ForecastedDetails"
+        owl="1"
+        t-inherit="stock.ForecastedDetails"
+        t-inherit-mode="extension"
+    >
+        <xpath expr="//tr[@name='draft_po_in']" position="after">
+            <tr t-if="props.docs.no_delivery_purchase_qty" name="no_delivery_in">
+                <td colspan="2"> Requests without delivery</td>
+                <td
+                    t-out="_formatFloat(props.docs.no_delivery_purchase_qty)"
+                    class="text-end"
+                />
+                <td>
+                    <t
+                        t-foreach="props.docs.no_delivery_purchase_orders"
+                        t-as="purchase_order"
+                        t-key="purchase_order_index"
+                    >
+                        <t t-if="purchase_order_index > 0"> | </t>
+                        <a
+                            t-attf-href="#"
+                            t-out="purchase_order.name"
+                            class="fw-bold"
+                            t-on-click.prevent="() => this.props.openView('purchase.order', 'form', purchase_order.id)"
+                        />
+                    </t>
+                </td>
+            </tr>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Purchase Order Lines that are pending to receive are not considered for stock forecast. Thus, the manual and automatic reordering of products can be done despite having already create a Purchase Order and surpassing the max quantity. Confirmed Purchase Orders with pending to receive Purchase Order Lines are now considered at the forecast and the forecast report.

How to replicate at the runboat:
Assumption: Manual Delivery is already enabled in the settings
1. Login as Admin
2. Go to Inventory/Configuration/Reordering Rules
3. Create a new Rule
4. Set "[E-COM10] Pedal bin" as Product, Min Quantity to 50 and Max Quantity to 100
5. The forecast should be 22
6. Click the button "Order once"
7. The forecast changed to 100
8. Click on the button "Forecast Report" for the product "[E-COM10] Pedal bin" and then on the Purchase Order that just got created
9. Confirm the Purchase Order
10. Go back to the "Reordering Rules" or the "Forecast Report"
The Purchase Order is no part of the forecast anymore. Therefore, the "Order Once" button is shown again and when automatic reordering would trigger as well. 