### PR TITLE
[15.0][IMP] purchase_discount: remove discount compute hacks

### DIFF
--- a/purchase_discount/models/stock_move.py
+++ b/purchase_discount/models/stock_move.py
@@ -11,26 +11,3 @@ class StockMove(models.Model):
         if self.env.context.get("skip_update_price_unit") and values.get("price_unit"):
             values.pop("price_unit")
         return super().write(values)
-
-    def _get_price_unit(self):
-        """Get correct price with discount replacing current price_unit
-        value before calling super and restoring it later for assuring
-        maximum inheritability.
-
-        HACK: This is needed while https://github.com/odoo/odoo/pull/29983
-        is not merged.
-        """
-        if hasattr(self.env, "ocb"):
-            return super()._get_price_unit()
-        price_unit = False
-        po_line = self.purchase_line_id
-        if po_line and self.product_id == po_line.product_id:
-            price = po_line._get_discounted_price_unit()
-            if price != po_line.price_unit:
-                # Only change value if it's different
-                price_unit = po_line.price_unit
-                po_line.price_unit = price
-        res = super()._get_price_unit()
-        if price_unit:
-            po_line.price_unit = price_unit
-        return res


### PR DESCRIPTION
As https://github.com/odoo/odoo/commit/1040381a89766d7f020e61a1b29e5392616379db is finally accepted, we can get rid of the previous discount computation hacks.

cc @Tecnativa TT45385

review @pedrobaeza @victoralmau 