### PR TITLE
[16.0][FIX]purchase_manual_delivery: uom fixes

### DIFF
--- a/purchase_manual_delivery/models/purchase_order.py
+++ b/purchase_manual_delivery/models/purchase_order.py
@@ -93,7 +93,7 @@ class PurchaseOrderLine(models.Model):
                         )
             line.existing_qty = total
             if float_compare(
-                line.product_uom_qty,
+                line.product_qty,
                 line.existing_qty,
                 precision_digits=precision_digits,
             ):

--- a/purchase_manual_delivery/wizard/create_manual_stock_picking.py
+++ b/purchase_manual_delivery/wizard/create_manual_stock_picking.py
@@ -236,9 +236,13 @@ class CreateManualStockPickingWizardLine(models.TransientModel):
             for val in line._prepare_stock_moves(picking):
                 if val.get("product_uom_qty", False):
                     # CHECK ME: We can receive more than one move
+                    product_uom = (
+                        self.env["uom.uom"].browse(val.get("product_uom", 0))
+                        or line.product_uom
+                    )
                     val["product_uom_qty"] = line.product_uom._compute_quantity(
                         line.qty,
-                        line.product_uom,
+                        product_uom,
                         rounding_method="HALF-UP",
                     )
                 if (


### PR DESCRIPTION
Fixed issues when uom_id and uom_po_id of a product are different.
Error 1. Comparison for Purchase Order Line pending to receive now uses the product quantity that uses the uom of the Purchase Order Line.
Error 2. When creating the Stock Move the quantity is now computed into the uom of the Stock Move

How to replicate at the runboat:
Assumption: Manual Delivery is already enabled in the settings
1. Login as Admin
2. Go to "Settings/Inventory/Products"
3. Enable "Units of Measure"
4. Go to "Inventory/Products/Products"
5. Create a new Product
6. Enter any name (For example "Cable"
7. Change "Unit of Measure" to "km"
8. Change "Purchase UoM" to "m"
9. Save the Produce
10. Go to "Purchase/Orders/Purchase Orders"
11. Create a new Purchase Order
12. Enter any "Vendor"
13. Add the newly created Product
14. Change the "Quantity" to "5"
15. Save and confirm the Purchase Order
16. Click "Create incoming shipment"
17. Change "Quantity" to "4"
18. Click "Create and View Picking"
19. The Demand is shown as 4 with UoM as "km". However, the UoM selected at the Purchase Order and the wizard to create the incoming shipment was "m" -> Receipt is 4 km instead of 4 m (Error 2.)
20. Validate the Receipt and go back to the Purchase Order
21. The "Existing Quantity" is 4000 instead of 4 (Reason is at step 19.)
22. Create a new Purchase Order with the same Product and Quantity as 5000
23. Confirm the Purchase Order
24. Click "Create incoming shipment"
25. Set "Quantity" to "5" (So that the Existing Quantity will be the same as the needed Quantity
26. Validate the Receipt and go back to the Purchase Order
27. The Purchase Order Line is marked as "Pending to Receive" despite that the "Existing Quantity" is the same as "Quantity" (Error 1.) -> Because for the comparison if "Pending to Receive" the wrong Product Quantity is taken into consideration
