### PR TITLE
[16.0][UPD] purchase_manual_delivery: do not show incoming shipment button 

### DIFF
--- a/purchase_manual_delivery/__manifest__.py
+++ b/purchase_manual_delivery/__manifest__.py
@@ -8,7 +8,7 @@
         and adds the ability to manually generate them as the supplier confirms
         the different purchase order lines.
     """,
-    "version": "16.0.1.1.4",
+    "version": "16.0.1.1.5",
     "license": "AGPL-3",
     "author": "ForgeFlow S.L.," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",

--- a/purchase_manual_delivery/views/purchase_order_views.xml
+++ b/purchase_manual_delivery/views/purchase_order_views.xml
@@ -13,7 +13,7 @@
                     string="Create Incoming Shipment"
                     type="action"
                     class="btn-primary"
-                    attrs="{'invisible': ['|', ('state', '!=', 'purchase'), ('pending_to_receive', '=', False)]}"
+                    attrs="{'invisible': ['|', '|', ('state', '!=', 'purchase'), ('pending_to_receive', '=', False), ('manual_delivery', '=', False)]}"
                 />
             </xpath>
             <button id="draft_confirm" position="attributes">


### PR DESCRIPTION
purchase_manual_delivery: Hide 'create incoming shipment' button when the purchase order is not configured for manual delivery.