### PR TITLE
[17.0][FIX] purchase_request: fix copying descriptions to new purchase order

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -42,7 +42,7 @@
                                 groups="!uom.group_uom"
                             />
                             <field name="product_uom_id" groups="uom.group_uom" />
-                            <field name="keep_description" widget="boolean_toggle" />
+                            <field name="keep_description" />
                         </tree>
                     </field>
                 </group>


### PR DESCRIPTION
**Impacted versions:**
Odoo17 Community

**Steps to reproduce:**
Open the wizard to Create an RFQ on a purchase request. Try changing the value of the field: keep_description (Copy descriptions to new PO) of the purchase.request.line.make.purchase.order.item transient model.

**Expected behavior:**
Allow the user to modify the value of the keep_description field of the wizard to create RFQ.

**Description of the issue/feature this PR addresses:**
Avoid using the boolean toggle widget, so that when the value of the field changes it doesn't try to save the record and doesn't generate the error.

**
![image](https://github.com/user-attachments/assets/2b614152-1e19-4c82-a1cc-ea2a03f6d940)
**