### PR TITLE
[16.0][FIX] purchase_return: restore display_type logic on purchase return orders

### DIFF
--- a/purchase_return/__manifest__.py
+++ b/purchase_return/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Purchase Return",
     "summary": "Manage return orders.",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "category": "Purchases",
     "website": "https://github.com/OCA/purchase-workflow",
     "author": "ForgeFlow, Odoo Community Association (OCA)",

--- a/purchase_return/migrations/16.0.1.0.2/post-migration.py
+++ b/purchase_return/migrations/16.0.1.0.2/post-migration.py
@@ -1,0 +1,13 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE purchase_return_order_line
+        SET display_type = NULL
+        WHERE display_type = 'product'
+        """,
+    )

--- a/purchase_return/models/purchase_return_order.py
+++ b/purchase_return/models/purchase_return_order.py
@@ -45,17 +45,13 @@ class PurchaseOrderReturn(models.Model):
 
             if any(
                 not float_is_zero(line.qty_to_invoice, precision_digits=precision)
-                for line in order.order_line.filtered(
-                    lambda l: l.display_type == "product"
-                )
+                for line in order.order_line.filtered(lambda l: not l.display_type)
             ):
                 order.invoice_status = "to invoice"
             elif (
                 all(
                     float_is_zero(line.qty_to_invoice, precision_digits=precision)
-                    for line in order.order_line.filtered(
-                        lambda l: l.display_type == "product"
-                    )
+                    for line in order.order_line.filtered(lambda l: not l.display_type)
                 )
                 and order.invoice_ids
             ):

--- a/purchase_return/static/description/index.html
+++ b/purchase_return/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -434,9 +433,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/purchase_return/tests/test_purchase_return_order.py
+++ b/purchase_return/tests/test_purchase_return_order.py
@@ -78,7 +78,6 @@ class TestPurchaseReturnOrder(AccountTestInvoicingCommon):
                 "order_id": purchase_return_order.id,
                 "refund_only": True,
                 "taxes_id": False,
-                "display_type": "product",
             }
         )
         self.assertEqual(purchase_return_order.invoice_status, "no")
@@ -116,7 +115,6 @@ class TestPurchaseReturnOrder(AccountTestInvoicingCommon):
                 "order_id": purchase_return_order.id,
                 "refund_only": False,
                 "taxes_id": False,
-                "display_type": "product",
             }
         )
         self.assertEqual(purchase_return_order.invoice_status, "no")
@@ -148,7 +146,6 @@ class TestPurchaseReturnOrder(AccountTestInvoicingCommon):
                 "order_id": purchase_return_order.id,
                 "refund_only": True,
                 "taxes_id": False,
-                "display_type": "product",
             }
         )
         self.assertEqual(purchase_return_order.state, "draft")
@@ -226,7 +223,6 @@ class TestPurchaseReturnOrder(AccountTestInvoicingCommon):
                 "order_id": purchase_return_order.id,
                 "refund_only": False,
                 "taxes_id": False,
-                "display_type": "product",
             }
         )
         purchase_return_order.button_confirm()
@@ -277,7 +273,6 @@ class TestPurchaseReturnOrder(AccountTestInvoicingCommon):
                         "refund_only": False,
                         "taxes_id": False,
                         "company_id": company_b.id,
-                        "display_type": "product",
                     }
                 )
             )

--- a/purchase_return/tests/test_purchase_return_order_line.py
+++ b/purchase_return/tests/test_purchase_return_order_line.py
@@ -74,7 +74,6 @@ class TestPurchaseReturnOrderLine(AccountTestInvoicingCommon):
                 "order_id": purchase_return_order.id,
                 "refund_only": True,
                 "taxes_id": False,
-                "display_type": "product",
             }
         )
         price_subtotal = po_line.product_qty * self.product_order.list_price

--- a/purchase_return/views/purchase_views.xml
+++ b/purchase_return/views/purchase_views.xml
@@ -223,7 +223,6 @@
                                         <create
                                             name="add_product_control"
                                             string="Add a product"
-                                            context="{'default_display_type': 'product'}"
                                         />
                                         <create
                                             name="add_section_control"
@@ -255,7 +254,7 @@
                                         name="product_id"
                                         attrs="{
                                             'readonly': [('state', 'in', ('purchase', 'to approve','done', 'cancel'))],
-                                            'required': [('display_type', '=', 'product')],
+                                            'required': [('display_type', '=', False)],
                                         }"
                                         context="{'partner_id':parent.partner_id, 'quantity':product_qty,'uom':product_uom, 'company_id': parent.company_id}"
                                         force_save="1"


### PR DESCRIPTION
On migration commit a new display_type was introduced, 'product', but logic was not fully adapted and I was having issues when printing purchase return order report or when creating a refund. I have also added a migration script in order to restore those lines with display_type = 'product'.