### PR TITLE
[17.0][FIX] purchase_security: specify @api.onchange

### DIFF
--- a/purchase_security/models/purchase_order.py
+++ b/purchase_security/models/purchase_order.py
@@ -38,6 +38,7 @@ class PurchaseOrder(models.Model):
         for record in self:
             record.team_id = record.user_id.purchase_team_ids[:1] or first_team
 
+    @api.onchange("partner_id")
     def onchange_partner_id(self):
         res = super().onchange_partner_id()
         if self.partner_id:


### PR DESCRIPTION
Specify `@api.onchange` on `onchange_partner_id()`, because without it, the native onchange isn't triggered (I don't know why) and some fields like `fiscal_position_id` and `payment_term_id` are never updated.

Others modules of purchase-workflow inherit `onchange_partner_id()` and set its onchange like this:
```@api.onchange("partner_id")```
Since the native one is:
```@api.onchange('partner_id', 'company_id')```
I honestly don't know why (excepted for "purchase_order_type", which divide them between two methods).

This issue is reproducible on runboat, but you need to use the "baseonly" database. If you install some modules like "purchase_partner_incoterm", it will work again.

I'm open to any better way to solve this issue.