### PR TITLE
[17.0][FIX] purchase_request: hide currency_id field in purchase request form view

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -202,7 +202,7 @@
                                 </tree>
                             </field>
                             <group class="oe_subtotal_footer oe_right">
-                                <field name="currency_id" column_invisible="1" />
+                                <field name="currency_id" invisible="1" />
                                 <div class="oe_subtotal_footer_separator oe_inline">
                                     <label for="estimated_cost" />
                                 </div>


### PR DESCRIPTION
This PR hides the currency_id field from the purchase request form, ensuring that it is not visible or editable by users.