### PR TITLE
[14.0][FIX] use commercial_partner_id on prepare_payment_vals method

### DIFF
--- a/purchase_advance_payment/models/purchase_order.py
+++ b/purchase_advance_payment/models/purchase_order.py
@@ -83,12 +83,10 @@ class PurchaseOrder(models.Model):
             # Consider payments in related invoices.
             invoice_paid_amount = 0.0
             for inv in order.invoice_ids:
-                # use the reconciled payment amounts instead of the invoice
-                # amount_residual that also includes reconciled credit notes.
-                for payment in inv._get_reconciled_invoices_partials():
-                    if payment[2].journal_id.type != "purchase":
-                        invoice_paid_amount += payment[1]
-            amount_residual = order.amount_total - advance_amount - invoice_paid_amount
+                invoice_paid_amount += (
+                    inv.amount_total_signed - inv.amount_residual_signed
+                )
+            amount_residual = order.amount_total - advance_amount + invoice_paid_amount
             payment_state = "not_paid"
             if mls or order.invoice_ids:
                 has_due_amount = float_compare(

--- a/purchase_advance_payment/wizard/purchase_advance_payment_wizard.py
+++ b/purchase_advance_payment/wizard/purchase_advance_payment_wizard.py
@@ -93,7 +93,7 @@ class AccountVoucherWizardPurchase(models.TransientModel):
         self.currency_amount = amount_advance
 
     def _prepare_payment_vals(self, purchase):
-        partner_id = purchase.partner_id.id
+        partner_id = purchase.partner_id.commercial_partner_id.id
         return {
             "date": self.date,
             "amount": self.amount_advance,


### PR DESCRIPTION
- If partner_id is used when creating payment, invoice will not detect advance payment to reconcile. so replace by commercial_partner_id.
- code for invoice_paid_amount is not correct, just use amount_total and amount_residual to keep it simple !