### PR TITLE
[17.0][IMP] purchase_security: allow to open the form view from the editable tree view

### DIFF
--- a/purchase_security/models/purchase_team.py
+++ b/purchase_security/models/purchase_team.py
@@ -19,3 +19,24 @@ class PurchaseTeam(models.Model):
         column2="res_users_id",
         string="Purchase Users",
     )
+
+    def open_form_view(self):
+        """Allow to open the form view from the editable tree view.
+
+        The main reason to use the form view is to manage the team members
+        of larger teams. The many2many_avatar_user widget in the tree view
+        does not allow to remove some of the users if ellipsis ('+3') is
+        triggered in the widget.
+        """
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "purchase_security.action_purchase_team_display"
+        )
+        action.update(
+            {
+                "res_id": self.id,
+                "view_mode": "form",
+                "views": [(False, "form")],
+            }
+        )
+        return action

--- a/purchase_security/views/purchase_team_views.xml
+++ b/purchase_security/views/purchase_team_views.xml
@@ -80,6 +80,12 @@
                     widget="many2many_avatar_user"
                     domain="[('share', '=', False)]"
                 />
+                <button
+                    icon="fa-pencil"
+                    name="open_form_view"
+                    type="object"
+                    title="Open Form View"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
The main reason to use the form view is to manage the team members of larger teams. The many2many_avatar_user widget in the tree view does not allow to remove some of the users if ellipsis ('+3') is triggered in the widget.