### PR TITLE
[16.0][FIX] product_main_seller: correct import of pre_init_hook

### DIFF
--- a/product_main_seller/migrations/16.0.1.0.0/pre-migration.py
+++ b/product_main_seller/migrations/16.0.1.0.0/pre-migration.py
@@ -4,7 +4,8 @@
 
 from openupgradelib import openupgrade
 
-from ..hooks import pre_init_hook
+# pylint: disable=W8150
+from odoo.addons.product_main_seller import pre_init_hook
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
to prevent the error 'ImportError: attempted relative import with no known parent package'

Note: similar to other OCA modules. for exemple : https://github.com/OCA/credit-control/blob/16.0/partner_risk_insurance/migrations/16.0.3.0.1/pre-migration.py
