### PR TITLE
[15.0][FIX] purchase_delivery_split_date: prevent error when adding a PO line on confirmed POs

### DIFF
--- a/purchase_delivery_split_date/models/purchase.py
+++ b/purchase_delivery_split_date/models/purchase.py
@@ -132,7 +132,7 @@ class PurchaseOrder(models.Model):
                             continue
                         if (
                             move.picking_id.scheduled_date.date() != date_key
-                            or pickings_by_date[date_key] != move.picking_id
+                            or pickings_by_date.get(date_key) != move.picking_id
                         ):
                             if date_key not in pickings_by_date:
                                 copy_vals = line._first_picking_copy_vals(key, line)


### PR DESCRIPTION
I reproduced it by using the purchase request module to add a new line on an existing PO using the flag:
"Merge on PO lines with equal Scheduled Date"

![image](https://github.com/user-attachments/assets/3639628f-78a2-494f-a175-12b597132b22)


cc @ForgeFlow