### PR TITLE
[UPD] purchase_order_approved: Update purchase order states

### DIFF
--- a/purchase_order_approved/i18n/es.po
+++ b/purchase_order_approved/i18n/es.po
@@ -60,7 +60,7 @@ msgstr "Siempre"
 #. module: purchase_order_approved
 #: model:ir.model.fields.selection,name:purchase_order_approved.selection__purchase_order__state__approved
 msgid "Approved"
-msgstr "Aprovado"
+msgstr "Aprobado"
 
 #. module: purchase_order_approved
 #: model_terms:ir.ui.view,arch_db:purchase_order_approved.view_purchase_order_filter

--- a/purchase_order_approved/models/purchase_order.py
+++ b/purchase_order_approved/models/purchase_order.py
@@ -3,28 +3,18 @@
 
 from odoo import fields, models
 
+from odoo.addons.purchase.models.purchase import PurchaseOrder
+
+NEW_STATES = {
+    "approved": [("readonly", True)],
+}
+PurchaseOrder.READONLY_STATES.update(NEW_STATES)
+
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
-    state = fields.Selection(selection_add=[("approved", "Approved"), ("purchase",)])
-
-    READONLY_STATES = {
-        "purchase": [("readonly", True)],
-        "done": [("readonly", True)],
-        "cancel": [("readonly", True)],
-        "approved": [("readonly", True)],
-    }
-
-    # Update the readonly states:
-    origin = fields.Char(states=READONLY_STATES)
-    date_order = fields.Datetime(states=READONLY_STATES)
-    partner_id = fields.Many2one(states=READONLY_STATES)
-    dest_address_id = fields.Many2one(states=READONLY_STATES)
-    currency_id = fields.Many2one(states=READONLY_STATES)
-    order_line = fields.One2many(states=READONLY_STATES)
-    company_id = fields.Many2one(states=READONLY_STATES)
-    picking_type_id = fields.Many2one(states=READONLY_STATES)
+    state = fields.Selection(selection_add=[("approved", "Approved")])
 
     def button_release(self):
         return super(PurchaseOrder, self).button_approve()


### PR DESCRIPTION
### Module
purchase_order_approved

### Describe the bug
The way states are uploaded is incorrect, if another module wants to include more states this will generate conflicts.
Fields as partner_id will be able to be edited in any state, when this should happen only in specifics states. 

### Affected versions:

16.0