### PR TITLE
[15.0][FIX] purchase_request: use module specific subtypes

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -157,6 +157,19 @@ class PurchaseRequest(models.Model):
         store=True,
     )
 
+    def _track_subtype(self, init_values):
+        if self:
+            record = self[0]
+            if "state" in init_values and record.state == "to_approve":
+                return self.env.ref("purchase_request.mt_request_to_approve")
+            elif "state" in init_values and record.state == "approved":
+                return self.env.ref("purchase_request.mt_request_approved")
+            elif "state" in init_values and record.state == "rejected":
+                return self.env.ref("purchase_request.mt_request_rejected")
+            elif "state" in init_values and record.state == "done":
+                return self.env.ref("purchase_request.mt_request_done")
+        return super()._track_subtype(init_values)
+
     @api.depends("line_ids", "line_ids.estimated_cost")
     def _compute_estimated_cost(self):
         for rec in self:

--- a/purchase_request/tests/test_purchase_request.py
+++ b/purchase_request/tests/test_purchase_request.py
@@ -242,3 +242,15 @@ class TestPurchaseRequest(TransactionCase):
         pr.button_draft()
         self.assertEqual(pr.state, "draft", "Should be in state draft")
         pr_lines.unlink()
+
+    def test_tracking(self):
+        """Tests Purchase Request tracking.
+        changes on status should use the proper mail subtypes"""
+        purchase_request = self.purchase_request
+        purchase_request.message_subscribe(
+            partner_ids=[self.env.ref("base.user_demo").partner_id.id]
+        )
+        purchase_request.button_to_approve()
+        subtype = purchase_request._track_subtype({"state": "to_approve"})
+        to_approve_subtype = self.env.ref("purchase_request.mt_request_to_approve")
+        self.assertEqual(subtype, to_approve_subtype)


### PR DESCRIPTION
Currently changes on status is using the Notes subtype instead the specific defined ones in this module.

Before:
![image](https://github.com/user-attachments/assets/49f9b815-366a-472b-9f5e-c25f7fb76e83)



After:

![image](https://github.com/user-attachments/assets/74152988-3e08-46d9-8b77-c052b25ea78f)

cc @ForgeFlow @HviorForgeFlow 
