### PR TITLE
[15.0][FIX] purchase_order_secondary_unit: Error when user try to select a secondary uom without product in sale order line

### DIFF
--- a/purchase_order_secondary_unit/views/purchase_order_views.xml
+++ b/purchase_order_secondary_unit/views/purchase_order_views.xml
@@ -20,9 +20,9 @@
                 <field
                     name="secondary_uom_id"
                     class="oe_inline"
-                    domain="['|', ('product_id', '=', product_id),
+                    domain="product_id and ['|', ('product_id', '=', product_id),
                                 '&amp;', ('product_tmpl_id.product_variant_ids', 'in', [product_id]),
-                                         ('product_id', '=', False)]"
+                                         ('product_id', '=', False)] or [(0, '=', 1)]"
                     options="{'no_create': True}"
                     attrs="{'readonly': [('state', 'in', ('purchase', 'done', 'cancel'))], 'required': [('secondary_uom_qty', '!=', 0.0)]}"
                 />
@@ -38,9 +38,9 @@
                 />
                 <field
                     name="secondary_uom_id"
-                    domain="['|', ('product_id', '=', product_id),
+                    domain="product_id and ['|', ('product_id', '=', product_id),
                                 '&amp;', ('product_tmpl_id.product_variant_ids', 'in', [product_id]),
-                                         ('product_id', '=', False)]"
+                                         ('product_id', '=', False)] or [(0, '=', 1)]"
                     options="{'no_create': True}"
                     attrs="{'readonly': [('state', 'in', ('purchase','done', 'cancel'))], 'required': [('secondary_uom_qty', '!=', 0.0)]}"
                     optional="show"


### PR DESCRIPTION
cc @Tecnativa TT51683

ping @carlosdauden @CarlosRoca13 