### PR TITLE
[15.0][FIX] purchase_rfq_number: update po, rfq reference

### DIFF
--- a/purchase_rfq_number/models/purchase_order.py
+++ b/purchase_rfq_number/models/purchase_order.py
@@ -22,6 +22,9 @@ class PurchaseOrder(models.Model):
         default="New",
     )
 
+    def _generate_sequence(self, sequence_code):
+        return self.env["ir.sequence"].next_by_code(sequence_code) or "New"
+
     @api.model
     def create(self, vals):
 
@@ -33,7 +36,7 @@ class PurchaseOrder(models.Model):
             keep_name_po = self.env.company.keep_name_po
 
         if not keep_name_po and vals.get("name", "New") == "New":
-            vals["name"] = self.env["ir.sequence"].next_by_code("purchase.rfq") or "New"
+            vals["name"] = self._generate_sequence("purchase.rfq")
 
         return super().create(vals)
 
@@ -49,7 +52,7 @@ class PurchaseOrder(models.Model):
                     po_number = (
                         order.po_number
                         if order.po_number != "New"
-                        else self.env["ir.sequence"].next_by_code("purchase.order")
+                        else order._generate_sequence("purchase.order")
                     )
                     rfq_vals["name"] = po_number
                     rfq_vals["po_number"] = po_number

--- a/purchase_rfq_number/models/purchase_order.py
+++ b/purchase_rfq_number/models/purchase_order.py
@@ -39,23 +39,23 @@ class PurchaseOrder(models.Model):
 
     def button_confirm(self):
         for order in self:
-            if order.state in ["draft", "sent"] and not order.company_id.keep_name_po:
+            if order.state in ["draft", "sent"]:
+                rfq_vals = {"rfq_number": order.name}
                 if order.company_id.auto_attachment_rfq:
                     # save rfq pdf as attachment
                     order.action_get_rfq_attachment()
 
-                po_number = (
-                    order.po_number
-                    if order.po_number != "New"
-                    else self.env["ir.sequence"].next_by_code("purchase.order")
-                )
-                order.write(
-                    {
-                        "rfq_number": order.name,
-                        "name": po_number,
-                        "po_number": po_number,
-                    }
-                )
+                if not order.company_id.keep_name_po:
+                    po_number = (
+                        order.po_number
+                        if order.po_number != "New"
+                        else self.env["ir.sequence"].next_by_code("purchase.order")
+                    )
+                    rfq_vals["name"] = po_number
+                    rfq_vals["po_number"] = po_number
+                else:
+                    rfq_vals["po_number"] = order.name
+                order.write(rfq_vals)
 
         return super().button_confirm()
 


### PR DESCRIPTION
This PR fixed 2 Topic

1. when config with `Use Same Enumeration`, po and rfq reference will update sequence
2. split function generate sequence for other module can hooks

**Before**:
Create RFQ -> Number is `P00001`, RFQ Reference is `New`, PO Reference is `New`
After confirm RFQ -> Number is `P00001`, RFQ Reference is `New`, PO Reference is `New`

**After**:
Create RFQ -> Number is `P00001`, RFQ Reference is `New`, PO Reference is `New`
After confirm RFQ -> Number is `P00001`, RFQ Reference is `P00001`, PO Reference is `P00001`