### PR TITLE
[13.0][FIX] purchase_requisition_grouped_by_procurement: Correct grouping of purchase requisitions

### DIFF
--- a/purchase_requisition_grouped_by_procurement/models/purchase_requisition.py
+++ b/purchase_requisition_grouped_by_procurement/models/purchase_requisition.py
@@ -41,13 +41,12 @@ class PurchaseRequisition(models.Model):
         the same values to add the line instead of creating a new record.
         """
         if self.env.context.get("grouped_by_procurement") and vals.get("group_id"):
-            domain = []
-            for key in vals:
-                if key == "line_ids":
-                    continue
-                domain.append((key, "=", vals.get(key)))
-            purchase = self.search(domain)
-            if purchase:
-                purchase.write({"line_ids": vals.get("line_ids")})
-                return purchase
+            domain = self._prepare_purchase_requisition_grouped_domain(vals)
+            purchase_requisition = self.search(domain)
+            if purchase_requisition:
+                purchase_requisition.write({"line_ids": vals.get("line_ids")})
+                return purchase_requisition
         return super().create(vals)
+
+    def _prepare_purchase_requisition_grouped_domain(self, vals):
+        return [("group_id", "=", vals.get("group_id")), ("state", "=", "draft")]


### PR DESCRIPTION
Before this commit, if products had different `customer_lead` values, separate purchase.requisition records were incorrectly created instead of being grouped into a single record as intended.

Steps to reproduce:

- Install the Sales module.
- Configure two products with the following settings:
  - Different customer_lead values.
  - Procurement set to Propose a call for tenders.
  - Route set to Make to Order (MTO) and Buy.
- Create a sales order with the two products and confirm it.
- Go to Purchase > Purchase Agreements and search by the sales order name.

Issue: Two purchase requisition records are created instead of the expected single record.
Solution: This fix ensures that purchase requisitions are grouped correctly, even when products have different customer_lead values.

Runboat to test: 
http://oca-purchase-workflow-13-0-3f7f394300f5.runboat.odoo-community.org/web#id=21&action=425&model=sale.order&view_type=form&cids=&menu_id=259

TT51858
@Tecnativa @pedrobaeza @victoralmau could you please review this