### PR TITLE
[15.0][FIX] purchase_requisition_grouped_by_procurement: Correct grouping of purchase requisitions

### DIFF
--- a/purchase_requisition_grouped_by_procurement/models/purchase_requisition.py
+++ b/purchase_requisition_grouped_by_procurement/models/purchase_requisition.py
@@ -17,13 +17,15 @@ class PurchaseRequisition(models.Model):
         if self.env.context.get("grouped_by_procurement") and vals.get(
             "procurement_group_id"
         ):
-            domain = []
-            for key in vals:
-                if key == "line_ids":
-                    continue
-                domain.append((key, "=", vals.get(key)))
-            purchase = self.search(domain)
-            if purchase:
-                purchase.write({"line_ids": vals.get("line_ids")})
-                return purchase
+            domain = self._prepare_purchase_requisition_grouped_domain(vals)
+            purchase_requisition = self.search(domain)
+            if purchase_requisition:
+                purchase_requisition.write({"line_ids": vals.get("line_ids")})
+                return purchase_requisition
         return super().create(vals)
+
+    def _prepare_purchase_requisition_grouped_domain(self, vals):
+        return [
+            ("procurement_group_id", "=", vals.get("procurement_group_id")),
+            ("state", "=", "draft"),
+        ]


### PR DESCRIPTION

Before this commit, if products had different customer_lead values, separate purchase.requisition records were incorrectly created instead of being grouped into a single record as intended.

Steps to reproduce:

- Install the Sales module.
- Configure two products with the following settings:
  - Different customer_lead values.
  - Procurement set to Propose a call for tenders.
  - Route set to Make to Order (MTO) and Buy.
- Create a sales order with the two products and confirm it.
- Go to Purchase > Purchase Agreements and search by the sales order name.

Issue: Two purchase requisition records are created instead of the expected single record.
Solution: This fix ensures that purchase requisitions are grouped correctly, even when products have different customer_lead values.

fwd-port of https://github.com/OCA/purchase-workflow/pull/2473

TT51858
@Tecnativa @pedrobaeza @victoralmau  could you please review this