### PR TITLE
[16.0][IMP]purchase_order_type: Automatically get partner purchase type on purchase creation.

### DIFF
--- a/purchase_order_type/README.rst
+++ b/purchase_order_type/README.rst
@@ -77,8 +77,9 @@ Authors
 Contributors
 ~~~~~~~~~~~~
 
-* Guewen Baconnier <guewen.baconnier@camptocamp.com>
-* Pimolnat Suntian <pimolnats@ecosoft.co.th>
+-  Guewen Baconnier <guewen.baconnier@camptocamp.com>
+-  Pimolnat Suntian <pimolnats@ecosoft.co.th>
+-  Roger Sans <roger.sans@sygel.es>
 
 Maintainers
 ~~~~~~~~~~~

--- a/purchase_order_type/models/purchase_order.py
+++ b/purchase_order_type/models/purchase_order.py
@@ -17,6 +17,8 @@ class PurchaseOrder(models.Model):
         string="Type",
         ondelete="restrict",
         domain="[('company_id', 'in', [False, company_id])]",
+        compute="_compute_partner_order_type",
+        store=True,
     )
 
     @api.onchange("partner_id")
@@ -73,3 +75,13 @@ class PurchaseOrder(models.Model):
             and self.order_type.company_id not in [self.company_id, False]
         ):
             self.order_type = self._default_order_type()
+
+    @api.depends("partner_id")
+    def _compute_partner_order_type(self):
+        for record in self:
+            if record.partner_id and not record.order_type:
+                record.order_type = record.partner_id.purchase_type
+            elif record.partner_id and record.order_type:
+                record.order_type = record.order_type
+            else:
+                record.order_type = False

--- a/purchase_order_type/readme/CONTRIBUTORS.rst
+++ b/purchase_order_type/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* Roger Sans <roger.sans@sygel.es>

--- a/purchase_order_type/static/description/index.html
+++ b/purchase_order_type/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -428,12 +429,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Guewen Baconnier &lt;<a class="reference external" href="mailto:guewen.baconnier&#64;camptocamp.com">guewen.baconnier&#64;camptocamp.com</a>&gt;</li>
 <li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
+<li>Roger Sans &lt;<a class="reference external" href="mailto:roger.sans&#64;sygel.es">roger.sans&#64;sygel.es</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Backport of https://github.com/OCA/purchase-workflow/pull/2396