### PR TITLE
[18.0][FIX] purchase_request: Fix Application Error when clicking duplicate a stock picking

### DIFF
--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -108,7 +108,6 @@ class StockMove(models.Model):
         """
         if default is None:
             default = {}
-        
         for rec in self:
             if not default.get("purchase_request_allocation_ids") and (
                 default.get("product_uom_qty") or rec.state in ("done", "cancel")

--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -108,21 +108,10 @@ class StockMove(models.Model):
         """
         if default is None:
             default = {}
-<<<<<<< Updated upstream
+        
         for rec in self:
             if not default.get("purchase_request_allocation_ids") and (
                 default.get("product_uom_qty") or rec.state in ("done", "cancel")
-=======
-        
-        if not default.get("purchase_request_allocation_ids") and (
-            default.get("product_uom_qty") or self.state in ("done", "cancel")
-        ):
-            default["purchase_request_allocation_ids"] = []
-            new_move_qty = default.get("product_uom_qty") or self.product_uom_qty
-            rounding = self.product_id.uom_id.rounding
-            for alloc in self.purchase_request_allocation_ids.filtered(
-                "open_product_qty"
->>>>>>> Stashed changes
             ):
                 default["purchase_request_allocation_ids"] = []
                 new_move_qty = default.get("product_uom_qty") or rec.product_uom_qty

--- a/purchase_request/models/stock_move.py
+++ b/purchase_request/models/stock_move.py
@@ -108,9 +108,21 @@ class StockMove(models.Model):
         """
         if default is None:
             default = {}
+<<<<<<< Updated upstream
         for rec in self:
             if not default.get("purchase_request_allocation_ids") and (
                 default.get("product_uom_qty") or rec.state in ("done", "cancel")
+=======
+        
+        if not default.get("purchase_request_allocation_ids") and (
+            default.get("product_uom_qty") or self.state in ("done", "cancel")
+        ):
+            default["purchase_request_allocation_ids"] = []
+            new_move_qty = default.get("product_uom_qty") or self.product_uom_qty
+            rounding = self.product_id.uom_id.rounding
+            for alloc in self.purchase_request_allocation_ids.filtered(
+                "open_product_qty"
+>>>>>>> Stashed changes
             ):
                 default["purchase_request_allocation_ids"] = []
                 new_move_qty = default.get("product_uom_qty") or rec.product_uom_qty


### PR DESCRIPTION
**Current Behavior**
1. Install module purchase_request
2. create a stock picking with at least 2 picking lines.
3. Error will appear, ref link: http://oca-purchase-workflow-18-0-c2f7f9abc0b0.runboat.odoo-community.org/odoo/receipts/8
![image](https://github.com/user-attachments/assets/391995de-544c-44ef-a72f-4edcaf2a9dcb)

**Expected**
Should be duplicated normally.