### PR TITLE
[16.0][FIX] purchase_security: Compute field correctly and prevent conflicts with other modules

### DIFF
--- a/purchase_security/models/purchase_order.py
+++ b/purchase_security/models/purchase_order.py
@@ -27,7 +27,7 @@ class PurchaseOrder(models.Model):
         is_user_id_editable = self.env.user.has_group(
             "purchase.group_purchase_manager"
         ) or not self.env.user.has_group("purchase_security.group_purchase_own_orders")
-        self.write({"is_user_id_editable": is_user_id_editable})
+        self.is_user_id_editable = is_user_id_editable
 
     @api.depends("user_id")
     def _compute_team_id(self):


### PR DESCRIPTION
Before this commit, in a computed field, the assignment was done using the `write` method. However, this caused incompatibilities with other modules, for example, `purchase_tier_validation`. For cache consistency, it is better to assign the field directly within the compute method instead of calling write.

Steps to reproduce with purchase_tier_validation:

Create a tier definition for purchase.order with any condition.
Create a new purchase.order that satisfies the conditions for the previous rule and request validation.
The message is displayed, and the user cannot open the record. This makes it unusable, as no records can be opened anymore.

This change was introduced during the migration process in PR https://github.com/OCA/purchase-workflow/pull/1902

Runboat instance
http://oca-purchase-workflow-16-0-db4563538698.runboat.odoo-community.org/web?debug=1#cids=1&menu_id=243&action=399&model=purchase.order&view_type=form&id=50

![image](https://github.com/user-attachments/assets/0442773f-2e82-479a-bc44-c1a3fe20d40d)

@HviorForgeFlow  @pedrobaeza could you please review this? Thanks in advance!
