### PR TITLE
[FIX issues 2537] purchase_request: Allow copying descriptions to new PO by updating `wiz_id` field properties" 

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -325,7 +325,7 @@ class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):
         string="Wizard",
         required=True,
         ondelete="cascade",
-        readonly=True,
+        readonly=False,
     )
     line_id = fields.Many2one(
         comodel_name="purchase.request.line", string="Purchase Request Line"


### PR DESCRIPTION
This change fixes an issue in the wizard that creates a purchase order from a purchase request, where copying item descriptions (boolean toggle) was blocked due to the wiz_id field in purchase.request.line.make.purchase.order.item  being required and readonly.

I modified the field to be non-required (required=False) and non-readonly (readonly=False), which allows item descriptions to be copied correctly when creating a purchase order