### PR TITLE
[16.0][FIX] purchase_request_type: use sequence following company document

### DIFF
--- a/purchase_request_type/models/purchase_request.py
+++ b/purchase_request_type/models/purchase_request.py
@@ -42,6 +42,12 @@ class PurchaseRequest(models.Model):
             if request.request_type.picking_type_id:
                 request.picking_type_id = request.request_type.picking_type_id.id
 
+    @api.model
+    def _get_default_name(self):
+        if self and self.request_type.sequence_id:
+            return self.request_type.sequence_id.next_by_id()
+        return super()._get_default_name()
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:

--- a/purchase_request_type/models/purchase_request_type.py
+++ b/purchase_request_type/models/purchase_request_type.py
@@ -8,6 +8,7 @@ class PurchaseRequestType(models.Model):
     _name = "purchase.request.type"
     _description = "Type of purchase request"
     _order = "sequence"
+    _check_company_auto = True
 
     @api.model
     def _get_domain_sequence_id(self):
@@ -34,7 +35,8 @@ class PurchaseRequestType(models.Model):
         required=True,
     )
     picking_type_id = fields.Many2one(
-        comodel_name="stock.picking.type", string="Picking Type"
+        comodel_name="stock.picking.type",
+        check_company=True,
     )
     sequence = fields.Integer(default=10)
     company_id = fields.Many2one(

--- a/purchase_request_type/tests/test_purchase_request_type.py
+++ b/purchase_request_type/tests/test_purchase_request_type.py
@@ -26,6 +26,9 @@ class TestPurchaseRequestType(common.TransactionCase):
         # Picking Type
         cls.picking_type = cls.env.ref("stock.picking_type_in")
         cls.picking_type2 = cls.env.ref("stock.picking_type_internal")
+
+        # Add company in purchase type
+        cls.type2.company_id = cls.picking_type.company_id
         cls.type2.picking_type_id = cls.picking_type
         cls.company2 = cls.company_obj.create({"name": "company2"})
 

--- a/purchase_request_type/views/purchase_request_type_view.xml
+++ b/purchase_request_type/views/purchase_request_type_view.xml
@@ -41,6 +41,7 @@
                         </group>
                         <group>
                             <field name="picking_type_id" />
+                            <field name="company_id" invisible="1" />
                             <field
                                 name="company_id"
                                 groups="base.group_multi_company"


### PR DESCRIPTION
Step to test:
1. Create purchase request type with 2 company
![Selection_004](https://github.com/user-attachments/assets/154a1d50-f1c0-4464-8da2-920824d194b3)

2. Create PR with type company SanFran. sequence is correct.
![Selection_005](https://github.com/user-attachments/assets/c2d8fc40-bc45-47e8-9e66-a9586bf367b3)

3. Switch to Chicago Company, and duplicate with SanFran document. it will use sequence from user company (Chicagi)
![Selection_006](https://github.com/user-attachments/assets/c0436cd1-a62e-4fba-970b-7d1779f45421)


This PR fixed by use sequence from company document.