### PR TITLE
[15.0][FIX] purchase_order_revision: Allow non-admins to view revisions

### DIFF
--- a/purchase_order_revision/models/purchase_order.py
+++ b/purchase_order_revision/models/purchase_order.py
@@ -30,12 +30,11 @@ class PurchaseOrder(models.Model):
 
     def action_view_revisions(self):
         self.ensure_one()
-        action = self.env.ref("purchase.purchase_rfq")
-        result = action.read()[0]
-        result["domain"] = ["|", ("active", "=", False), ("active", "=", True)]
-        result["context"] = {
+        action = self.env["ir.actions.actions"]._for_xml_id("purchase.purchase_rfq")
+        action["domain"] = ["|", ("active", "=", False), ("active", "=", True)]
+        action["context"] = {
             "active_test": 0,
             "search_default_current_revision_id": self.id,
             "default_current_revision_id": self.id,
         }
-        return result
+        return action


### PR DESCRIPTION
I've fixed the issue where non-admin users received an error about insufficient authority when clicking the action_view_revisions button.

The relevant comment
https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-14.0#tasks-to-do-in-the-migration.

@qrtl QT5141