### PR TITLE
[16.0][IMP] purchase_only_by_packaging round up product qty

### DIFF
--- a/purchase_only_by_packaging/models/purchase_order_line.py
+++ b/purchase_only_by_packaging/models/purchase_order_line.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
+from math import ceil
+
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
 from odoo.tools import float_compare
@@ -46,6 +48,16 @@ class PurchaseOrderLine(models.Model):
         )
         self.product_qty = qty
         return True
+
+    @api.onchange("product_packaging_id")
+    def _onchange_product_packaging_id(self):
+        # Round up to the next integer and avoid the Warning raised by
+        # _onchange_product_packaging_id defined in the purchase addon
+        # The issue exists for sale order => odoo issue to fix proposed
+        # here: https://github.com/odoo/odoo/issues/197598
+        ceiled_product_packaging_qty = ceil(self.product_packaging_qty)
+        self.product_packaging_qty = ceiled_product_packaging_qty or 1
+        return super()._onchange_product_packaging_id()
 
     @api.onchange("product_qty")
     def _onchange_product_qty(self):


### PR DESCRIPTION
### IMPROVEMENT
When product with packaging is added on po line round up to the next integer and avoid the Warning raised by `_onchange_product_packaging_id` defined in the [purchase addon](https://github.com/odoo/odoo/blob/628b4c01f33583af62f3243666ada07b6ee081c5/addons/purchase/models/purchase.py#L1316)

This is a similar dev already done here: https://github.com/OCA/sale-workflow/pull/2808

It would be preferable to have a fixing solution in the standard odoo code. Pr proposal here:
https://github.com/odoo/odoo/pull/160636
