### PR TITLE
[17.0][FIX] purchase_request: Add Markup to messages

### DIFF
--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -1,7 +1,10 @@
 # Copyright 2018-2019 ForgeFlow, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 
+from markupsafe import Markup
+
 from odoo import _, api, exceptions, fields, models
+from odoo.tools import html_escape
 
 
 class PurchaseOrder(models.Model):
@@ -29,13 +32,13 @@ class PurchaseOrder(models.Model):
                 "<li><b>%(prl_name)s</b>: Ordered quantity %(prl_qty)s %(prl_uom)s, "
                 "Planned date %(prl_date_planned)s</li>"
             ) % {
-                "prl_name": line["name"],
+                "prl_name": html_escape(line["name"]),
                 "prl_qty": line["product_qty"],
                 "prl_uom": line["product_uom"],
                 "prl_date_planned": line["date_planned"],
             }
         message += "</ul>"
-        return message
+        return Markup(message)
 
     def _purchase_request_confirm_message(self):
         request_obj = self.env["purchase.request"]
@@ -62,7 +65,6 @@ class PurchaseOrder(models.Model):
                 request.message_post(
                     body=message,
                     subtype_id=self.env.ref("mail.mt_comment").id,
-                    body_is_html=True,
                 )
         return True
 
@@ -184,7 +186,6 @@ class PurchaseOrderLine(models.Model):
                 alloc.purchase_request_line_id.request_id.message_post(
                     body=message,
                     subtype_id=self.env.ref("mail.mt_comment").id,
-                    body_is_html=True,
                 )
 
                 alloc.purchase_request_line_id._compute_qty()
@@ -209,12 +210,12 @@ class PurchaseOrderLine(models.Model):
             "<li><b>%(product_name)s</b>: "
             "Received quantity %(product_qty)s %(product_uom)s</li>"
         ) % {
-            "product_name": message_data["product_name"],
+            "product_name": html_escape(message_data["product_name"]),
             "product_qty": message_data["product_qty"],
             "product_uom": message_data["product_uom"],
         }
         message += "</ul>"
-        return message
+        return Markup(message)
 
     def _prepare_request_message_data(self, alloc, request_line, allocated_qty):
         return {

--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -1,7 +1,10 @@
 # Copyright 2019 ForgeFlow, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 
+from markupsafe import Markup
+
 from odoo import _, api, fields, models
+from odoo.tools import html_escape
 
 
 class PurchaseRequestAllocation(models.Model):
@@ -103,12 +106,12 @@ class PurchaseRequestAllocation(models.Model):
             "<li><b>%(product_name)s</b>: "
             "Received quantity %(product_qty)s %(product_uom)s</li>"
         ) % {
-            "product_name": message_data["product_name"],
+            "product_name": html_escape(message_data["product_name"]),
             "product_qty": message_data["product_qty"],
             "product_uom": message_data["product_uom"],
         }
         message += "</ul>"
-        return message
+        return Markup(message)
 
     def _prepare_message_data(self, po_line, request, allocated_qty):
         return {
@@ -130,5 +133,4 @@ class PurchaseRequestAllocation(models.Model):
             request.message_post(
                 body=message,
                 subtype_id=self.env.ref("mail.mt_comment").id,
-                body_is_html=True,
             )

--- a/purchase_request/models/stock_move_line.py
+++ b/purchase_request/models/stock_move_line.py
@@ -1,7 +1,10 @@
 # Copyright 2017 ForgeFlow, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 
+from markupsafe import Markup
+
 from odoo import _, api, models
+from odoo.tools import html_escape
 
 
 class StockMoveLine(models.Model):
@@ -30,12 +33,12 @@ class StockMoveLine(models.Model):
             "<li><b>%(product_name)s</b>: "
             "Transferred quantity %(product_qty)s %(product_uom)s</li>"
         ) % {
-            "product_name": message_data["product_name"],
+            "product_name": html_escape(message_data["product_name"]),
             "product_qty": message_data["product_qty"],
             "product_uom": message_data["product_uom"],
         }
         message += "</ul>"
-        return message
+        return Markup(message)
 
     @api.model
     def _picking_confirm_done_message_content(self, message_data):
@@ -57,12 +60,12 @@ class StockMoveLine(models.Model):
             "<li><b>%(product_name)s</b>: "
             "Transferred quantity %(product_qty)s %(product_uom)s</li>"
         ) % {
-            "product_name": message_data["product_name"],
+            "product_name": html_escape(message_data["product_name"]),
             "product_qty": message_data["product_qty"],
             "product_uom": message_data["product_uom"],
         }
         message += "</ul>"
-        return message
+        return Markup(message)
 
     def _prepare_message_data(self, ml, request, allocated_qty):
         return {
@@ -109,7 +112,6 @@ class StockMoveLine(models.Model):
                     request.message_post(
                         body=message,
                         subtype_id=self.env.ref("mail.mt_comment").id,
-                        body_is_html=True,
                     )
 
                     picking_message = self._picking_confirm_done_message_content(
@@ -118,7 +120,6 @@ class StockMoveLine(models.Model):
                     ml.move_id.picking_id.message_post(
                         body=picking_message,
                         subtype_id=self.env.ref("mail.mt_comment").id,
-                        body_is_html=True,
                     )
 
                 allocation._compute_open_product_qty()


### PR DESCRIPTION
Add Markup to messages

Remove warning log
`WARNING odoo odoo.addons.mail.models.mail_thread: Posting HTML message using body_is_html=True, use a Markup object instead (user: 1)`

@Tecnativa