### PR TITLE
[14.0][FIX] purchase_advance_payment: fix payment_state

### DIFF
--- a/purchase_advance_payment/models/purchase_order.py
+++ b/purchase_advance_payment/models/purchase_order.py
@@ -90,7 +90,7 @@ class PurchaseOrder(models.Model):
                         invoice_paid_amount += payment[1]
             amount_residual = order.amount_total - advance_amount - invoice_paid_amount
             payment_state = "not_paid"
-            if mls or order.invoice_ids:
+            if mls or invoice_paid_amount != 0.0:
                 has_due_amount = float_compare(
                     amount_residual, 0.0, precision_rounding=order.currency_id.rounding
                 )


### PR DESCRIPTION
Having an invoice does not necessarily mean that the payment is partial. Changed to when there is `account_payment_ids` or there is a paid amount on the invoice (`invoice_paid_amount`)

Creating a draft invoice before the changes:
![image](https://github.com/user-attachments/assets/555e98e2-673a-4063-aca5-9a897a29b867)

Creating a draft invoice after the changes in this PR:
![image](https://github.com/user-attachments/assets/599c4cf3-b3e5-494c-a7ee-e490a2478133)

When we confirm and pay the invoice, the status will be updated:
![image](https://github.com/user-attachments/assets/8e34b352-ec50-4230-8a21-c23f5aacefdc)


Ticket: HT00980

cc: @marcelsavegnago @kaynnan 