### PR TITLE
[17.0][FIX] purchase_manual_delivery: always call the full confirmation stack

### DIFF
--- a/purchase_manual_delivery/models/purchase_order.py
+++ b/purchase_manual_delivery/models/purchase_order.py
@@ -32,9 +32,7 @@ class PurchaseOrder(models.Model):
                 order.pending_to_receive = False
 
     def button_confirm_manual(self):
-        return super(
-            PurchaseOrder, self.with_context(manual_delivery=True)
-        ).button_confirm()
+        return self.with_context(manual_delivery=True).button_confirm()
 
     def button_approve(self, force=False):
         if self.manual_delivery:


### PR DESCRIPTION
Suppose you have module `purchase_x` that depends on purchase, and that it does an override of `button_confirm` to call `fx`.
Because `purchase_x` and `purchase_manual_delivery` have no relation to each other, we could either have `purchase_manual_delivery => purchase_x => purchase`, or `purchase_x => purchase_manual_delivery => purchase`.

If you call button confirm, in all cases you will call `fx` once. If you call button_confirm_manual, in one case you will call `fx` but not the other, depending on how the ORM loaded modules. If you decide that you want an easy solution and add an override of button_confirm_manual to also call `fx`, then you have the possibility to call `fx` twice, so you'd better be sure to make it idempotent.