### PR TITLE
[18.0][FWP][FIX] purchase_request: create new product for test

### DIFF
--- a/purchase_request/tests/test_purchase_request_procurement.py
+++ b/purchase_request/tests/test_purchase_request_procurement.py
@@ -17,7 +17,7 @@ class TestPurchaseRequestProcurement(common.TransactionCase):
         self.customer_location = self.env.ref("stock.stock_location_customers")
 
         # Get required Model data
-        self.product_1 = self.env.ref("product.product_product_16")
+        self.product_1 = self.env.ref("product.product_product_16").copy()
         self.product_1.purchase_request = True
         self.route_buy = self.env.ref("purchase_stock.route_warehouse0_buy")
         self.rule_buy = self.route_buy.rule_ids.filtered(


### PR DESCRIPTION
To prevent interference from other modules. In this case, there is a purchase order from Odoo's demo data in a confirmed state but without a picking for the product. The missing picking causes  purchase_manual_delivery to include the PO line's quantity in the forecasted quantity of the product. This prevents the procurement to go through in TestPurchaseRequestProcurement.test_orderpoint.

```
 2024-09-26 14:16:17,327 269 ERROR odoo odoo.addons.purchase_request.tests.test_purchase_request_procurement: FAIL: TestPurchaseRequestProcurement.test_orderpoint
Traceback (most recent call last):
  File "/__w/purchase-workflow/purchase-workflow/purchase_request/tests/test_purchase_request_procurement.py", line 81, in test_orderpoint
    self.assertEqual(
AssertionError: 0.0 != 5
```

Port from commit included in https://github.com/OCA/purchase-workflow/pull/2417