### PR TITLE
[18.0][FIX] purchase_request: Add Markup to messages

### DIFF
--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -4,6 +4,7 @@
 from markupsafe import Markup
 
 from odoo import _, api, exceptions, fields, models
+from odoo.tools import html_escape
 
 
 class PurchaseOrder(models.Model):
@@ -30,13 +31,13 @@ class PurchaseOrder(models.Model):
                 "<li><b>%(prl_name)s</b>: Ordered quantity %(prl_qty)s %(prl_uom)s, "
                 "Planned date %(prl_date_planned)s</li>"
             ) % {
-                "prl_name": line["name"],
+                "prl_name": html_escape(line["name"]),
                 "prl_qty": line["product_qty"],
                 "prl_uom": line["product_uom"],
                 "prl_date_planned": line["date_planned"],
             }
         message += "</ul>"
-        return message
+        return Markup(message)
 
     def _purchase_request_confirm_message(self):
         request_obj = self.env["purchase.request"]
@@ -206,12 +207,12 @@ class PurchaseOrderLine(models.Model):
         message += _(
             "<li><b>%(product_name)s</b>: "
             "Received quantity %(product_qty)s %(product_uom)s</li>",
-            product_name=message_data["product_name"],
+            product_name=html_escape(message_data["product_name"]),
             product_qty=message_data["product_qty"],
             product_uom=message_data["product_uom"],
         )
         message += "</ul>"
-        return message
+        return Markup(message)
 
     def _prepare_request_message_data(self, alloc, request_line, allocated_qty):
         return {

--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -4,6 +4,7 @@
 from markupsafe import Markup
 
 from odoo import _, api, fields, models
+from odoo.tools import html_escape
 
 
 class PurchaseRequestAllocation(models.Model):
@@ -105,12 +106,12 @@ class PurchaseRequestAllocation(models.Model):
             "<li><b>%(product_name)s</b>: "
             "Received quantity %(product_qty)s %(product_uom)s</li>"
         ) % {
-            "product_name": message_data["product_name"],
+            "product_name": html_escape(message_data["product_name"]),
             "product_qty": message_data["product_qty"],
             "product_uom": message_data["product_uom"],
         }
         message += "</ul>"
-        return message
+        return Markup(message)
 
     def _prepare_message_data(self, po_line, request, allocated_qty):
         return {

--- a/purchase_request/models/stock_move_line.py
+++ b/purchase_request/models/stock_move_line.py
@@ -4,6 +4,7 @@
 from markupsafe import Markup
 
 from odoo import _, api, models
+from odoo.tools import html_escape
 
 
 class StockMoveLine(models.Model):
@@ -29,12 +30,12 @@ class StockMoveLine(models.Model):
         message += _(
             "<li><b>%(product_name)s</b>: "
             "Transferred quantity %(product_qty)s %(product_uom)s</li>",
-            product_name=message_data["product_name"],
+            product_name=html_escape(message_data["product_name"]),
             product_qty=message_data["product_qty"],
             product_uom=message_data["product_uom"],
         )
         message += "</ul>"
-        return message
+        return Markup(message)
 
     @api.model
     def _picking_confirm_done_message_content(self, message_data):
@@ -55,12 +56,12 @@ class StockMoveLine(models.Model):
         message += _(
             "<li><b>%(product_name)s</b>: "
             "Transferred quantity %(product_qty)s %(product_uom)s</li>",
-            product_name=message_data["product_name"],
+            product_name=html_escape(message_data["product_name"]),
             product_qty=message_data["product_qty"],
             product_uom=message_data["product_uom"],
         )
         message += "</ul>"
-        return message
+        return Markup(message)
 
     def _prepare_message_data(self, ml, request, allocated_qty):
         return {


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/purchase-workflow/pull/2569

Add Markup to messages

Remove warning log
`WARNING odoo odoo.addons.mail.models.mail_thread: Posting HTML message using body_is_html=True, use a Markup object instead (user: 1)`

@Tecnativa