### PR TITLE
[16.0][FIX] purchase_landed_cost + purchase_allowed_product + purchase_order_uninvoiced_amount: Post-install test + fallback to load CoA

### DIFF
--- a/purchase_allowed_product/tests/test_purchase_allowed_product.py
+++ b/purchase_allowed_product/tests/test_purchase_allowed_product.py
@@ -3,24 +3,36 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
+from odoo.tests import tagged
 from odoo.tests.common import Form, TransactionCase
 
 
+@tagged("-at_install", "post_install")
 class TestPurchaseAllowedProduct(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.supplierinfo_model = self.env["product.supplierinfo"]
-        self.product_model = self.env["product.product"]
-        self.partner_4 = self.env.ref("base.res_partner_4")
-        self.supplierinfo = self.supplierinfo_model.search(
-            [("partner_id", "=", self.partner_4.id)]
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
+        cls.supplierinfo_model = cls.env["product.supplierinfo"]
+        cls.product_model = cls.env["product.product"]
+        cls.partner_4 = cls.env.ref("base.res_partner_4")
+        cls.supplierinfo = cls.supplierinfo_model.search(
+            [("partner_id", "=", cls.partner_4.id)]
         )
-        self.partner_4_supplied_products = self.product_model.search(
+        cls.partner_4_supplied_products = cls.product_model.search(
             [
                 (
                     "product_tmpl_id",
                     "in",
-                    [x.product_tmpl_id.id for x in self.supplierinfo],
+                    [x.product_tmpl_id.id for x in cls.supplierinfo],
                 )
             ]
         )

--- a/purchase_landed_cost/tests/test_purchase_landed_cost.py
+++ b/purchase_landed_cost/tests/test_purchase_landed_cost.py
@@ -7,13 +7,23 @@ from datetime import datetime
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestPurchaseLandedCost(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestPurchaseLandedCost, cls).setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         expense_type_obj = cls.env["purchase.expense.type"]
         cls.type_amount = expense_type_obj.create(
             {

--- a/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
+++ b/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
@@ -4,16 +4,27 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import fields
+from odoo.tests import tagged
 from odoo.tests.common import Form, TransactionCase
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
+@tagged("-at_install", "post_install")
 class TestPurchaseOrderUninvoiceAmount(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         # Environmet
         cls.purchase_order_model = cls.env["purchase.order"]
         cls.purchase_order_line_model = cls.env["purchase.order.line"]
@@ -79,8 +90,8 @@ class TestPurchaseOrderUninvoiceAmount(TransactionCase):
         invoice_form = Form(
             self.account_move_model.with_context(
                 default_move_type="in_invoice",
-                default_purchase_id=purchase,
-                default_partner_id=purchase.partner_id,
+                default_purchase_id=purchase.id,
+                default_partner_id=purchase.partner_id.id,
             )
         )
         return invoice_form.save()


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa