### PR TITLE
[16.0][IMP] purchase_discount: Discount < 100% constraint on product supplierinfo

### DIFF
--- a/purchase_discount/models/product_supplierinfo.py
+++ b/purchase_discount/models/product_supplierinfo.py
@@ -22,6 +22,14 @@ class ProductSupplierInfo(models.Model):
         for record in self:
             record.discount = record.partner_id.default_supplierinfo_discount
 
+    _sql_constraints = [
+        (
+            "discount_limit",
+            "CHECK (discount <= 100.0)",
+            "Supplier discount must be lower than 100%.",
+        )
+    ]
+
     @api.model
     def _get_po_to_supplierinfo_synced_fields(self):
         """Overwrite this method for adding other fields to be synchronized


### PR DESCRIPTION
Should be blocking the user from setting an invalid discount before it is propagated to (MTO in the worst case) POs and the message from the PO is not as descriptive:

"Discount must be lower than 100%" <--- how do you know where this comes from a SO with all discounts set to 0? It does not make sense. Therefore, the proposed solution is even better blocking the user when the deed is wrongly done at first.