### PR TITLE
[18.0][FIX] purchase_request: Ensure correct HTML rendering in chatter mesages

### DIFF
--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -37,7 +37,7 @@ class PurchaseOrder(models.Model):
                 "prl_date_planned": line["date_planned"],
             }
         message += "</ul>"
-        return Markup(message)
+        return message
 
     def _purchase_request_confirm_message(self):
         request_obj = self.env["purchase.request"]
@@ -192,27 +192,27 @@ class PurchaseOrderLine(models.Model):
 
     @api.model
     def _purchase_request_confirm_done_message_content(self, message_data):
-        title = (
-            _("Service confirmation for Request %s") % (message_data["request_name"])
+        title = _("Service confirmation for Request {request_name}").format(
+            request_name=message_data["request_name"]
         )
-        message = f"<h3>{title}</h3>"
-        message += _(
-            "The following requested services from Purchase"
-            " Request %(request_name)s requested by %(requestor)s "
-            "have now been received:",
+
+        message_body = _(
+            "The following requested services from Purchase Request {request_name} "
+            "requested by {requestor} have now been received:"
+        ).format(
             request_name=message_data["request_name"],
             requestor=message_data["requestor"],
         )
-        message += "<ul>"
-        message += _(
-            "<li><b>%(product_name)s</b>: "
-            "Received quantity %(product_qty)s %(product_uom)s</li>",
-            product_name=html_escape(message_data["product_name"]),
-            product_qty=message_data["product_qty"],
-            product_uom=message_data["product_uom"],
+
+        product_line = Markup(
+            "<ul><li><b>{}</b>: " + _("Received quantity") + " {} {}</li></ul>"
+        ).format(
+            html_escape(message_data["product_name"]),
+            message_data["product_qty"],
+            html_escape(message_data["product_uom"]),
         )
-        message += "</ul>"
-        return Markup(message)
+
+        return Markup("<h3>{}</h3>{}{}").format(title, message_body, product_line)
 
     def _prepare_request_message_data(self, alloc, request_line, allocated_qty):
         return {

--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -111,7 +111,7 @@ class PurchaseRequestAllocation(models.Model):
             "product_uom": message_data["product_uom"],
         }
         message += "</ul>"
-        return Markup(message)
+        return message
 
     def _prepare_message_data(self, po_line, request, allocated_qty):
         return {

--- a/purchase_request/models/stock_move_line.py
+++ b/purchase_request/models/stock_move_line.py
@@ -13,55 +13,57 @@ class StockMoveLine(models.Model):
     @api.model
     def _purchase_request_confirm_done_message_content(self, message_data):
         title = _(
-            "Receipt confirmation %(picking_name)s for your Request %(request_name)s",
+            "Receipt confirmation {picking_name} for your Request {request_name}"
+        ).format(
             picking_name=message_data["picking_name"],
             request_name=message_data["request_name"],
         )
-        message = f"<h3>{title}</h3>"
-        message += _(
-            "The following requested items from Purchase Request %(request_name)s "
-            "have now been received in %(location_name)s using Picking "
-            "%(picking_name)s:",
+
+        message_body = _(
+            "The following requested items from Purchase Request {request_name} "
+            "have now been received in {location_name} "
+            "using Picking {picking_name}:"
+        ).format(
             request_name=message_data["request_name"],
             location_name=message_data["location_name"],
             picking_name=message_data["picking_name"],
         )
-        message += "<ul>"
-        message += _(
-            "<li><b>%(product_name)s</b>: "
-            "Transferred quantity %(product_qty)s %(product_uom)s</li>",
-            product_name=html_escape(message_data["product_name"]),
-            product_qty=message_data["product_qty"],
-            product_uom=message_data["product_uom"],
+
+        product_line = Markup(
+            "<ul><li><b>{}</b>: " + _("Transferred quantity") + " {} {}</li></ul>"
+        ).format(
+            html_escape(message_data["product_name"]),
+            message_data["product_qty"],
+            html_escape(message_data["product_uom"]),
         )
-        message += "</ul>"
-        return Markup(message)
+
+        return Markup("<h3>{}</h3>{}{}").format(title, message_body, product_line)
 
     @api.model
     def _picking_confirm_done_message_content(self, message_data):
-        title = _(
-            "Receipt confirmation for Request %(name)s",
-            name=message_data["request_name"],
+        title = _("Receipt confirmation for Request {name}").format(
+            name=message_data["request_name"]
         )
-        message = f"<h3>{title}</h3>"
-        message += _(
-            "The following requested items from Purchase Request %(request_name)s "
-            "requested by %(requestor)s "
-            "have now been received in %(location_name)s:",
+
+        message_body = _(
+            "The following requested items from Purchase Request {request_name} "
+            "requested by {requestor} "
+            "have now been received in {location_name}:"
+        ).format(
             request_name=message_data["request_name"],
             requestor=message_data["requestor"],
             location_name=message_data["location_name"],
         )
-        message += "<ul>"
-        message += _(
-            "<li><b>%(product_name)s</b>: "
-            "Transferred quantity %(product_qty)s %(product_uom)s</li>",
-            product_name=html_escape(message_data["product_name"]),
-            product_qty=message_data["product_qty"],
-            product_uom=message_data["product_uom"],
+
+        product_line = Markup(
+            "<ul><li><b>{}</b>: " + _("Transferred quantity") + " {} {}</li></ul>"
+        ).format(
+            html_escape(message_data["product_name"]),
+            message_data["product_qty"],
+            html_escape(message_data["product_uom"]),
         )
-        message += "</ul>"
-        return Markup(message)
+
+        return Markup("<h3>{}</h3>{}{}").format(title, message_body, product_line)
 
     def _prepare_message_data(self, ml, request, allocated_qty):
         return {


### PR DESCRIPTION
Fixes https://github.com/OCA/purchase-workflow/issues/2591

- Removed duplicate Markup to messages that already were Markup
- Used `html_escape()` for correctly escaping product_uom and  properly handle translations before formatting, preventing double escaping.

This fixes incorrect markup display in chatter messages.

Some examples "after / before" on the different messages:

![image](https://github.com/user-attachments/assets/03cf9c9e-dc6d-48ed-b804-0711f6ec4365)

![image](https://github.com/user-attachments/assets/309dd7aa-4536-4bb9-a46f-9e16b2e6037d)

![image](https://github.com/user-attachments/assets/4cf589d0-fabc-4a19-9e5a-e297b59b3043)

