### PR TITLE
[16.0][REF] purchase_triple_discount: Consolidate discount in std field

### DIFF
--- a/purchase_discount/tests/test_purchase_discount.py
+++ b/purchase_discount/tests/test_purchase_discount.py
@@ -199,12 +199,12 @@ class TestPurchaseOrder(TransactionCase):
         line = invoice.invoice_line_ids.filtered(
             lambda x: x.purchase_line_id == self.po_line_1
         )
-        self.assertEqual(line.discount, 50)
+        self.assertAlmostEqual(line.discount, 50)
         line = invoice.invoice_line_ids.filtered(
             lambda x: x.purchase_line_id == self.po_line_2
         )
-        self.assertEqual(line.discount, 30)
+        self.assertAlmostEqual(line.discount, 30)
         line = invoice.invoice_line_ids.filtered(
             lambda x: x.purchase_line_id == self.po_line_3
         )
-        self.assertEqual(line.discount, 0)
+        self.assertAlmostEqual(line.discount, 0)

--- a/purchase_triple_discount/__init__.py
+++ b/purchase_triple_discount/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import report
+from .hooks import post_init_hook

--- a/purchase_triple_discount/__manifest__.py
+++ b/purchase_triple_discount/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Purchase Order Triple Discount",
-    "version": "16.0.2.0.0",
+    "version": "16.0.3.0.0",
     "category": "Purchase Management",
     "author": "Tecnativa," "GRAP," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
@@ -19,4 +19,5 @@
         "views/res_partner_view.xml",
     ],
     "installable": True,
+    "post_init_hook": "post_init_hook",
 }

--- a/purchase_triple_discount/hooks.py
+++ b/purchase_triple_discount/hooks.py
@@ -1,0 +1,25 @@
+# Copyright 2024-Today - Sylvain Le GAL (GRAP)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(cr, registry):
+    _logger.info("Initializing column discount1 on table purchase_order_line")
+    cr.execute(
+        """
+            UPDATE purchase_order_line
+            SET discount1 = discount
+            WHERE discount != 0
+        """
+    )
+    _logger.info("Initializing column discount1 on table product_supplierinfo")
+    cr.execute(
+        """
+            UPDATE product_supplierinfo
+            SET discount1 = discount
+            WHERE discount != 0
+        """
+    )

--- a/purchase_triple_discount/migrations/16.0.3.0.0/post-migrate.py
+++ b/purchase_triple_discount/migrations/16.0.3.0.0/post-migrate.py
@@ -1,0 +1,74 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.logging()
+def compute_purchase_line_discount(env):
+    purchase_lines_to_compute = env["purchase.order.line"].search(
+        [
+            "|",
+            "|",
+            ("discount1", "!=", 0),
+            ("discount2", "!=", 0),
+            ("discount3", "!=", 0),
+        ]
+    )
+    for line in purchase_lines_to_compute:
+        discount = line._get_aggregated_multiple_discounts(
+            [line[x] for x in ["discount1", "discount2", "discount3"]]
+        )
+        rounded_discount = line._fields["discount"].convert_to_column(discount, line)
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE prochase_order_line
+            SET discount = %s
+            WHERE id = %s;
+        """,
+            tuple(
+                [
+                    rounded_discount,
+                    line.id,
+                ]
+            ),
+        )
+
+
+@openupgrade.logging()
+def compute_supplierinfo_line_discount(env):
+    supplierinfo_lines_to_compute = env["product.supplierinfo"].search(
+        [
+            "|",
+            "|",
+            ("discount1", "!=", 0),
+            ("discount2", "!=", 0),
+            ("discount3", "!=", 0),
+        ]
+    )
+    for line in supplierinfo_lines_to_compute:
+        discount = line._get_aggregated_multiple_discounts(
+            [line[x] for x in ["discount1", "discount2", "discount3"]]
+        )
+        rounded_discount = line._fields["discount"].convert_to_column(discount, line)
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE product_supplierinfo
+            SET discount = %s
+            WHERE id = %s;
+        """,
+            tuple(
+                [
+                    rounded_discount,
+                    line.id,
+                ]
+            ),
+        )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    compute_purchase_line_discount(env)
+    compute_supplierinfo_line_discount(env)

--- a/purchase_triple_discount/migrations/16.0.3.0.0/pre-migrate.py
+++ b/purchase_triple_discount/migrations/16.0.3.0.0/pre-migrate.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from openupgradelib import openupgrade
+
+
+def migrate_order_discount_to_discount1(env):
+    openupgrade.add_fields(
+        env,
+        [
+            (
+                "discount1",
+                "purchase.order.line",
+                "purchase_order_line",
+                "float",
+                "numeric",
+                "purchase_triple_discount",
+                0.0,
+            )
+        ],
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE purchase_order_line
+        SET discount1 = discount;
+        """,
+    )
+
+
+def migrate_supplierinfo_discount_to_discount1(env):
+    openupgrade.add_fields(
+        env,
+        [
+            (
+                "discount1",
+                "product.supplierinfo",
+                "product_supplierinfo",
+                "float",
+                "numeric",
+                "purchase_triple_discount",
+                0.0,
+            )
+        ],
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE product_supplierinfo
+        SET discount1 = discount;
+        """,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    migrate_order_discount_to_discount1(env)
+    migrate_supplierinfo_discount_to_discount1(env)

--- a/purchase_triple_discount/models/__init__.py
+++ b/purchase_triple_discount/models/__init__.py
@@ -1,3 +1,4 @@
+from . import triple_discount_mixin
 from . import product_supplierinfo
 from . import purchase_order
 from . import res_partner

--- a/purchase_triple_discount/models/purchase_order.py
+++ b/purchase_triple_discount/models/purchase_order.py
@@ -1,83 +1,29 @@
 # Copyright 2017-19 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import functools
 
-from odoo import api, fields, models
+from odoo import api, models
 
 
 class PurchaseOrderLine(models.Model):
-    _inherit = "purchase.order.line"
-
-    # adding discount2 and discount3 to depends
-    @api.depends("discount2", "discount3")
-    def _compute_amount(self):
-        return super()._compute_amount()
-
-    discount2 = fields.Float(
-        "Disc. 2 (%)",
-        digits="Discount",
-    )
-
-    discount3 = fields.Float(
-        "Disc. 3 (%)",
-        digits="Discount",
-    )
-
-    _sql_constraints = [
-        (
-            "discount2_limit",
-            "CHECK (discount2 <= 100.0)",
-            "Discount 2 must be lower than 100%.",
-        ),
-        (
-            "discount3_limit",
-            "CHECK (discount3 <= 100.0)",
-            "Discount 3 must be lower than 100%.",
-        ),
-    ]
-
-    def _get_discounted_price_unit(self):
-        # Include possible discounts 2 and 3
-        price_unit = super()._get_discounted_price_unit()
-        aggregated_discount = self._compute_aggregated_discount(self.discount)
-        if aggregated_discount != self.discount:
-            price_unit = self.price_unit * (1 - aggregated_discount / 100)
-        return price_unit
-
-    def _compute_aggregated_discount(self, base_discount):
-        self.ensure_one()
-        discounts = [base_discount]
-        for discount_fname in self._get_multiple_discount_field_names():
-            discounts.append(getattr(self, discount_fname, 0.0))
-        return self._get_aggregated_multiple_discounts(discounts)
+    _name = "purchase.order.line"
+    _inherit = ["purchase.order.line", "triple.discount.mixin"]
 
     @api.model
     def _apply_value_from_seller(self, seller):
         super()._apply_value_from_seller(seller)
         if not seller:
             return
-        self.discount2 = seller.discount2
-        self.discount3 = seller.discount3
+        self.update(
+            {
+                field: seller[field]
+                for field in self._get_multiple_discount_field_names()
+            }
+        )
 
     def _prepare_account_move_line(self, move=False):
         self.ensure_one()
         res = super()._prepare_account_move_line(move)
         res.update(
-            {
-                "discount2": self.discount2,
-                "discount3": self.discount3,
-            }
+            {field: self[field] for field in self._get_multiple_discount_field_names()}
         )
         return res
-
-    def _get_aggregated_multiple_discounts(self, discounts):
-        discount_values = []
-        for discount in discounts:
-            discount_values.append(1 - (discount or 0.0) / 100.0)
-        aggregated_discount = (
-            1 - functools.reduce((lambda x, y: x * y), discount_values)
-        ) * 100
-        return aggregated_discount
-
-    def _get_multiple_discount_field_names(self):
-        return ["discount2", "discount3"]

--- a/purchase_triple_discount/models/res_partner.py
+++ b/purchase_triple_discount/models/res_partner.py
@@ -6,6 +6,13 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
+    default_supplierinfo_discount1 = fields.Float(
+        string="Default Supplier Discount 1 (%)",
+        digits="Discount",
+        help="This value will be used as the default one, for each new "
+        "supplierinfo line depending on that supplier.",
+    )
+
     default_supplierinfo_discount2 = fields.Float(
         string="Default Supplier Discount 2 (%)",
         digits="Discount",

--- a/purchase_triple_discount/models/triple_discount_mixin.py
+++ b/purchase_triple_discount/models/triple_discount_mixin.py
@@ -1,0 +1,90 @@
+# Copyright 2019 Tecnativa - David Vidal
+# Copyright 2019 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import functools
+
+from odoo import api, fields, models
+
+
+class TripleDiscount(models.AbstractModel):
+    # TODO: To be moved to account_invoice_triple_discount
+    _name = "triple.discount.mixin"
+    _description = "Triple discount mixin"
+
+    discount = fields.Float(
+        string="Total discount",
+        compute="_compute_discount",
+        store=True,
+        readonly=True,
+    )
+    discount1 = fields.Float(
+        string="Discount 1 (%)",
+        digits="Discount",
+    )
+    discount2 = fields.Float(
+        string="Discount 2 (%)",
+        digits="Discount",
+    )
+    discount3 = fields.Float(
+        string="Discount 3 (%)",
+        digits="Discount",
+    )
+
+    _sql_constraints = [
+        (
+            "discount1_limit",
+            "CHECK (discount1 <= 100.0)",
+            "Discount 1 must be lower than 100%.",
+        ),
+        (
+            "discount2_limit",
+            "CHECK (discount2 <= 100.0)",
+            "Discount 2 must be lower than 100%.",
+        ),
+        (
+            "discount3_limit",
+            "CHECK (discount3 <= 100.0)",
+            "Discount 3 must be lower than 100%.",
+        ),
+    ]
+
+    @api.depends(lambda self: self._get_multiple_discount_field_names())
+    def _compute_discount(self):
+        for line in self:
+            line.discount = line._get_aggregated_multiple_discounts(
+                [line[x] for x in line._get_multiple_discount_field_names()]
+            )
+
+    def _get_aggregated_multiple_discounts(self, discounts):
+        """
+        Returns the aggregate discount corresponding to any number of discounts.
+        For exemple, if discounts is [11.0, 22.0, 33.0]
+        It will return 46.5114
+        """
+        discount_values = []
+        for discount in discounts:
+            discount_values.append(1 - (discount or 0.0) / 100.0)
+        aggregated_discount = (
+            1 - functools.reduce((lambda x, y: x * y), discount_values)
+        ) * 100
+        return aggregated_discount
+
+    @api.model
+    def _get_multiple_discount_field_names(self):
+        return ["discount1", "discount2", "discount3"]
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("discount") and not any(
+                vals.get(field) for field in self._get_multiple_discount_field_names()
+            ):
+                vals["discount1"] = vals.pop("discount")
+        return super().create(vals_list)
+
+    def write(self, vals):
+        discount_fields = self._get_multiple_discount_field_names()
+        if "discount" in vals:
+            vals["discount1"] = vals.pop("discount")
+            vals.update({field: 0 for field in discount_fields[1:]})
+        return super().write(vals)

--- a/purchase_triple_discount/report/purchase_report.py
+++ b/purchase_triple_discount/report/purchase_report.py
@@ -9,6 +9,16 @@ from odoo import fields, models
 class PurchaseReport(models.Model):
     _inherit = "purchase.report"
 
+    discount = fields.Float(
+        string="Total discount",
+    )
+
+    discount1 = fields.Float(
+        string="Discount 1 (%)",
+        digits="Discount",
+        group_operator="avg",
+    )
+
     discount2 = fields.Float(
         string="Discount 2 (%)",
         digits="Discount",
@@ -22,12 +32,12 @@ class PurchaseReport(models.Model):
 
     def _select(self):
         res = super()._select()
-        res += ", l.discount2 AS discount2, l.discount3 AS discount3"
+        res += ", l.discount1 AS discount1, l.discount2 AS discount2, l.discount3 AS discount3"
         return res
 
     def _group_by(self):
         res = super()._group_by()
-        res += ", l.discount2, l.discount3"
+        res += ", l.discount1, l.discount2, l.discount3"
         return res
 
     def _get_discounted_price_unit_exp(self):
@@ -38,6 +48,6 @@ class PurchaseReport(models.Model):
         :return: SQL expression for discounted unit price.
         """
         return """
-            ((100 - COALESCE(l.discount, 0.0)) *
+            ((100 - COALESCE(l.discount1, 0.0)) *
              (100 - COALESCE(l.discount2, 0.0)) *
              (100 - COALESCE(l.discount3, 0.0))) / 1000000 * l.price_unit"""

--- a/purchase_triple_discount/tests/test_purchase_discount.py
+++ b/purchase_triple_discount/tests/test_purchase_discount.py
@@ -39,7 +39,7 @@ class TestPurchaseOrder(common.TransactionCase):
                 "min_qty": 0.0,
                 "partner_id": cls.partner2.id,
                 "product_tmpl_id": cls.product1.product_tmpl_id.id,
-                "discount": 10,
+                "discount1": 10,
                 "discount2": 20,
                 "discount3": 30,
             }
@@ -109,9 +109,9 @@ class TestPurchaseOrder(common.TransactionCase):
         )
 
     def test_01_purchase_order_classic_discount(self):
-        """Tests with single discount"""
-        self.po_line1.discount = 50.0
-        self.po_line2.discount = 75.0
+        """Tests with single discount1"""
+        self.po_line1.discount1 = 50.0
+        self.po_line2.discount1 = 75.0
         self.assertEqual(self.po_line1.price_subtotal, 300.0)
         self.assertEqual(self.po_line2.price_subtotal, 150.0)
         self.assertEqual(self.order.amount_untaxed, 450.0)
@@ -123,15 +123,15 @@ class TestPurchaseOrder(common.TransactionCase):
     def test_02_purchase_order_simple_triple_discount(self):
         """Tests on a single line"""
         self.po_line2.unlink()
-        # Divide by two on every discount:
-        self.po_line1.discount = 50.0
+        # Divide by two on every discount1:
+        self.po_line1.discount1 = 50.0
         self.po_line1.discount2 = 50.0
         self.po_line1.discount3 = 50.0
         self.assertEqual(self.po_line1.price_subtotal, 75.0)
         self.assertEqual(self.order.amount_untaxed, 75.0)
         self.assertEqual(self.order.amount_tax, 11.25)
-        # Unset first discount:
-        self.po_line1.discount = 0.0
+        # Unset first discount1:
+        self.po_line1.discount1 = 0.0
         self.assertEqual(self.po_line1.price_subtotal, 150.0)
         self.assertEqual(self.order.amount_untaxed, 150.0)
         self.assertEqual(self.order.amount_tax, 22.5)
@@ -143,7 +143,7 @@ class TestPurchaseOrder(common.TransactionCase):
 
     def test_03_purchase_order_complex_triple_discount(self):
         """Tests on multiple lines"""
-        self.po_line1.discount = 50.0
+        self.po_line1.discount1 = 50.0
         self.po_line1.discount2 = 50.0
         self.po_line1.discount3 = 50.0
         self.assertEqual(self.po_line1.price_subtotal, 75.0)
@@ -157,7 +157,7 @@ class TestPurchaseOrder(common.TransactionCase):
     def test_04_purchase_order_triple_discount_invoicing(self):
         """When a confirmed order is invoiced, the resultant invoice
         should inherit the discounts"""
-        self.po_line1.discount = 50.0
+        self.po_line1.discount1 = 50.0
         self.po_line1.discount2 = 50.0
         self.po_line1.discount3 = 50.0
         self.po_line2.discount3 = 50.0
@@ -172,7 +172,7 @@ class TestPurchaseOrder(common.TransactionCase):
         self.invoice._onchange_purchase_auto_complete()
 
         self.assertEqual(
-            self.po_line1.discount, self.invoice.invoice_line_ids[0].discount
+            self.po_line1.discount1, self.invoice.invoice_line_ids[0].discount1
         )
         self.assertEqual(
             self.po_line1.discount2, self.invoice.invoice_line_ids[0].discount2
@@ -188,16 +188,16 @@ class TestPurchaseOrder(common.TransactionCase):
     def test_05_purchase_order_default_discounts(self):
         with Form(self.order2).order_line.edit(0) as line:
             line.product_qty = 1.0
-            self.assertEqual(line.discount, 10)
+            self.assertEqual(line.discount1, 10)
             self.assertEqual(line.discount2, 20)
             self.assertEqual(line.discount3, 30)
             line.product_qty = 10
-            self.assertFalse(line.discount)
+            self.assertFalse(line.discount1)
             self.assertFalse(line.discount2)
             self.assertEqual(line.discount3, 50)
 
     def test_06_default_supplier_discounts(self):
-        self.partner2.default_supplierinfo_discount = 11
+        self.partner2.default_supplierinfo_discount1 = 11
         self.partner2.default_supplierinfo_discount2 = 22
         self.partner2.default_supplierinfo_discount3 = 33
         supplierinfo = self.supplierinfo_obj.new(
@@ -205,10 +205,10 @@ class TestPurchaseOrder(common.TransactionCase):
                 "min_qty": 0.0,
                 "partner_id": self.partner2.id,
                 "product_tmpl_id": self.product1.product_tmpl_id.id,
-                "discount": 10,
+                "discount1": 10,
             }
         )
-        self.assertEqual(supplierinfo.discount, 10)
+        self.assertEqual(supplierinfo.discount1, 10)
         self.assertEqual(supplierinfo.discount2, 22)
         self.assertEqual(supplierinfo.discount3, 33)
 
@@ -223,7 +223,7 @@ class TestPurchaseOrder(common.TransactionCase):
                 "product_uom": self.product2.uom_id.id,
                 "taxes_id": [(6, 0, [self.tax.id])],
                 "price_unit": 999.0,
-                "discount": 11.11,
+                "discount1": 11.11,
                 "discount2": 22.22,
                 "discount3": 33.33,
             }
@@ -236,7 +236,7 @@ class TestPurchaseOrder(common.TransactionCase):
             ]
         )
         self.assertTrue(seller)
-        self.assertEqual(seller.discount, 11.11)
+        self.assertEqual(seller.discount1, 11.11)
         self.assertEqual(seller.discount2, 22.22)
         self.assertEqual(seller.discount3, 33.33)
 

--- a/purchase_triple_discount/views/product_supplierinfo_view.xml
+++ b/purchase_triple_discount/views/product_supplierinfo_view.xml
@@ -7,10 +7,14 @@
             ref="purchase_discount.product_supplierinfo_form_view"
         />
          <field name="arch" type="xml">
-              <field name="discount" position="after">
-                  <field name="discount2" />
-                  <field name="discount3" />
-              </field>
+              <xpath expr="//field[@name='discount']" position="attributes">
+                <attribute name="string">Total discount</attribute>
+            </xpath>
+            <xpath expr="//field[@name='discount']" position="after">
+                <field name="discount1" />
+                <field name="discount2" />
+                <field name="discount3" />
+            </xpath>
          </field>
      </record>
 
@@ -21,10 +25,15 @@
             ref="purchase_discount.product_supplierinfo_tree_view"
         />
          <field name="arch" type="xml">
-              <field name="discount" position="after">
-                  <field name="discount2" />
-                  <field name="discount3" />
-              </field>
+             <xpath expr="//field[@name='discount']" position="attributes">
+                <attribute name="optional">hide</attribute>
+                <attribute name="string">Total discount</attribute>
+            </xpath>
+            <xpath expr="//field[@name='discount']" position="after">
+                <field name="discount1" optional="show" />
+                <field name="discount2" optional="show" />
+                <field name="discount3" optional="show" />
+            </xpath>
          </field>
      </record>
 

--- a/purchase_triple_discount/views/purchase_order_report.xml
+++ b/purchase_triple_discount/views/purchase_order_report.xml
@@ -4,7 +4,13 @@
         id="report_purchaseorder_document_triple_discount"
         inherit_id="purchase_discount.report_purchaseorder_document"
     >
-        <xpath expr="//table[1]/thead/tr//th[last()]" position="after">
+        <xpath expr="//table[1]/thead/tr//th[last()-1]" position="attributes">
+            <attribute name="style">display: none;</attribute>
+        </xpath>
+        <xpath expr="//table[1]/thead/tr//th[last()]" position="before">
+            <th name="th_discount1" class="text-right">
+                <strong>Disc. 1 (%)</strong>
+            </th>
             <th name="th_discount2" class="text-right">
                 <strong>Disc. 2 (%)</strong>
             </th>
@@ -12,7 +18,13 @@
                 <strong>Disc. 3 (%)</strong>
             </th>
         </xpath>
-        <xpath expr="//td[span[@t-field='line.price_subtotal']]" position="after">
+        <xpath expr="//td[span[@t-field='line.discount']]" position="attributes">
+            <attribute name="style">display: none;</attribute>
+        </xpath>
+        <xpath expr="//td[span[@t-field='line.discount']]" position="after">
+            <td name="td_discount1" class="text-right">
+                <span t-field="line.discount1" />
+            </td>
             <td name="td_discount2" class="text-right">
                 <span t-field="line.discount2" />
             </td>

--- a/purchase_triple_discount/views/purchase_view.xml
+++ b/purchase_triple_discount/views/purchase_view.xml
@@ -8,15 +8,30 @@
         <field name="arch" type="xml">
             <xpath
                 expr="//field[@name='order_line']//tree//field[@name='discount']"
+                position="attributes"
+            >
+                <attribute name="optional">hide</attribute>
+                <attribute name="string">Total discount</attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']//tree//field[@name='discount']"
                 position="after"
             >
+                <field name="discount1" optional="show" />
                 <field name="discount2" optional="show" />
                 <field name="discount3" optional="show" />
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']//tree//field[@name='discount']"
+                position="attributes"
+            >
+                <attribute name="string">Total discount</attribute>
             </xpath>
             <xpath
                 expr="//field[@name='order_line']//form//field[@name='discount']"
                 position="after"
             >
+                <field name="discount1" />
                 <field name="discount2" />
                 <field name="discount3" />
             </xpath>

--- a/purchase_triple_discount/views/res_partner_view.xml
+++ b/purchase_triple_discount/views/res_partner_view.xml
@@ -4,7 +4,14 @@
          <field name="model">res.partner</field>
          <field name="inherit_id" ref="purchase_discount.res_partner_form_view" />
          <field name="arch" type="xml">
+             <field name="default_supplierinfo_discount" position="attributes">
+                 <attribute name="string">Total discount</attribute>
+             </field>
             <field name="default_supplierinfo_discount" position="after">
+                <field
+                    name="default_supplierinfo_discount1"
+                    attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}"
+                />
                 <field
                     name="default_supplierinfo_discount2"
                     attrs="{'invisible': [('is_company', '=', False), ('parent_id', '!=', False)]}"


### PR DESCRIPTION
Continuation of #2317 and following https://github.com/OCA/account-invoicing/pull/1840

Try to fix the current red CI state.

-----

Until now, the triple discount feature did use the standard Odoo field as the first discount field, adding only extra fields for the second and the third discount. This implied we had to override any function using discount to consider the other discounts properly.

By adding an extra field discount1 to store the first discount, it allows to redefine the standard discount field to a computed field that will consolidate the triple discount from the other fields, and avoid the need to redefine anything relying on the discount field as it will already consider the triple discounts.

@Tecnativa 