### PR TITLE
[16.0][FIX] purchase_discount: Relax float comparison

### DIFF
--- a/purchase_discount/tests/test_purchase_discount.py
+++ b/purchase_discount/tests/test_purchase_discount.py
@@ -199,12 +199,12 @@ class TestPurchaseOrder(TransactionCase):
         line = invoice.invoice_line_ids.filtered(
             lambda x: x.purchase_line_id == self.po_line_1
         )
-        self.assertEqual(line.discount, 50)
+        self.assertAlmostEqual(line.discount, 50)
         line = invoice.invoice_line_ids.filtered(
             lambda x: x.purchase_line_id == self.po_line_2
         )
-        self.assertEqual(line.discount, 30)
+        self.assertAlmostEqual(line.discount, 30)
         line = invoice.invoice_line_ids.filtered(
             lambda x: x.purchase_line_id == self.po_line_3
         )
-        self.assertEqual(line.discount, 0)
+        self.assertAlmostEqual(line.discount, 0)


### PR DESCRIPTION
Having conversions with currency rate, leads to a situation where what we want to test is correct, but with a rounding error, so let's use `assertAlmostEqual` to compensate it.

@Tecnativa