### PR TITLE
[16.0][IMP] purchase_request_tier_validation: Hide Confirm button if the validation is pending or rejected.

### DIFF
--- a/purchase_request_tier_validation/views/purchase_request_view.xml
+++ b/purchase_request_tier_validation/views/purchase_request_view.xml
@@ -8,9 +8,14 @@
         <field name="inherit_id" ref="purchase_request.view_purchase_request_form" />
         <field name="arch" type="xml">
             <button name="button_approved" position="attributes">
-                <attribute name="states">draft</attribute>
                 <attribute name="string">Confirm</attribute>
+                <attribute
+                    name="attrs"
+                >{'invisible':['|', ('validation_status', 'in', ('pending', 'rejected')),('state', '!=', 'draft')]}</attribute>
             </button>
+            <field name="state" position="after">
+                <field name="validation_status" invisible="1" />
+            </field>
             <button name="button_to_approve" position="attributes">
                 <attribute name="invisible">1</attribute>
             </button>


### PR DESCRIPTION
Hide Confirm button if the validation is pending or rejected.

**Before**
![antes](https://github.com/user-attachments/assets/eaeba587-f8b3-4d84-9888-e63df6676677)

**After**
![despues](https://github.com/user-attachments/assets/f19a3f72-1107-46e3-8707-85d915377758)

@Tecnativa TT55409