### PR TITLE
[17.0][IMP] purchase_request_tier_validation: Hide Confirm button if the validation is pending or rejected.

### DIFF
--- a/purchase_request_tier_validation/views/purchase_request_view.xml
+++ b/purchase_request_tier_validation/views/purchase_request_view.xml
@@ -8,9 +8,14 @@
         <field name="inherit_id" ref="purchase_request.view_purchase_request_form" />
         <field name="arch" type="xml">
             <button name="button_approved" position="attributes">
-                <attribute name="invisible">state != 'draft'</attribute>
+                <attribute
+                    name="invisible"
+                >state != 'draft' or validation_status in ('pending', 'rejected')</attribute>
                 <attribute name="string">Confirm</attribute>
             </button>
+            <field name="state" position="after">
+                <field name="validation_status" invisible="1" />
+            </field>
             <button name="button_to_approve" position="attributes">
                 <attribute name="invisible">1</attribute>
             </button>


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/purchase-workflow/pull/2605

Hide Confirm button if the validation is pending or rejected.

**Before**
![antes](https://github.com/user-attachments/assets/69f6b7d9-8016-4b32-8612-dc3a02719eab)

**After**
![despues](https://github.com/user-attachments/assets/a088bddf-480a-4869-9b3b-eead90bea175)

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT55409