### PR TITLE
[18.0][IMP] purchase_request: Misc changes (hide company_id field + set groups to group_id field)

### DIFF
--- a/purchase_request/data/purchase_request_sequence.xml
+++ b/purchase_request/data/purchase_request_sequence.xml
@@ -7,5 +7,6 @@
         <field name="code">purchase.request</field>
         <field name="prefix">PR</field>
         <field name="padding">5</field>
+        <field name="company_id" />
     </record>
 </odoo>

--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -44,6 +44,7 @@ class PurchaseRequestLine(models.Model):
         related="request_id.company_id",
         string="Company",
         store=True,
+        index=True,
     )
     requested_by = fields.Many2one(
         comodel_name="res.users",

--- a/purchase_request/views/purchase_request_line_view.xml
+++ b/purchase_request/views/purchase_request_line_view.xml
@@ -577,7 +577,6 @@
                                 <field name="qty_in_progress" />
                                 <field name="qty_done" />
                             </group>
-                            <newline />
                             <field name="purchase_lines" nolabel="1" />
                         </page>
                     </notebook>

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -145,6 +145,7 @@
                                 name="picking_type_id"
                                 readonly="is_editable == False"
                             />
+                            <field name="company_id" invisible="1" />
                             <field
                                 name="company_id"
                                 groups="base.group_multi_company"

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -133,7 +133,11 @@
                                 readonly="is_editable == False"
                             />
                             <field name="description" readonly="is_editable == False" />
-                            <field name="group_id" readonly="is_editable == False" />
+                            <field
+                                name="group_id"
+                                readonly="is_editable == False"
+                                groups="base.group_no_one"
+                            />
                         </group>
                         <group>
                             <field name="date_start" readonly="is_editable == False" />

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -186,11 +186,6 @@
                                     <field name="date_required" />
                                     <field name="estimated_cost" widget="monetary" />
                                     <field name="currency_id" column_invisible="1" />
-                                    <field
-                                        name="company_id"
-                                        groups="base.group_multi_company"
-                                        widget="selection"
-                                    />
                                     <field name="cancelled" column_invisible="1" />
                                     <field name="is_editable" column_invisible="1" />
                                     <field name="purchased_qty" />

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -371,11 +371,58 @@
             </search>
         </field>
     </record>
+    <record id="view_purchase_request_kanban" model="ir.ui.view">
+        <field name="name">purchase.request.kanban</field>
+        <field name="model">purchase.request</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile" quick_create="false">
+                <field name="name" />
+                <field name="requested_by" readonly="1" />
+                <field name="estimated_cost" />
+                <field name="state" />
+                <field name="date_start" />
+                <field name="currency_id" readonly="1" />
+                <field name="activity_state" />
+                <progressbar
+                    field="activity_state"
+                    colors="{&quot;planned&quot;: &quot;success&quot;, &quot;today&quot;: &quot;warning&quot;, &quot;overdue&quot;: &quot;danger&quot;}"
+                />
+                <templates>
+                    <t t-name="card">
+                        <div class="d-flex align-items-baseline">
+                            <field name="requested_by" class="fw-bolder fs-5 me-2" />
+                            <field
+                                name="estimated_cost"
+                                widget="monetary"
+                                class="fw-bolder ms-auto flex-shrink-0"
+                            />
+                        </div>
+                        <footer class="align-items-end">
+                            <div class="d-flex flex-wrap gap-1 text-nowrap">
+                                <field name="name" />
+                                <field
+                                    name="date_start"
+                                    options="{'show_time': false}"
+                                />
+                                <field name="activity_ids" widget="kanban_activity" />
+                            </div>
+                            <field
+                                name="state"
+                                widget="label_selection"
+                                options="{'classes': {'draft': 'default', 'cancel': 'default', 'done': 'success', 'approved': 'warning'}}"
+                                class="ms-auto"
+                            />
+                        </footer>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
     <record model="ir.actions.act_window" id="purchase_request_form_action">
         <field name="name">Purchase Requests</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">purchase.request</field>
-        <field name="view_mode">list,form</field>
+        <field name="view_mode">list,kanban,form</field>
         <field name="context">{"search_default_requested_by":uid}</field>
         <field name="search_view_id" ref="view_purchase_request_search" />
         <field name="help" type="html">

--- a/purchase_request_tier_validation/README.rst
+++ b/purchase_request_tier_validation/README.rst
@@ -66,11 +66,11 @@ To use this module, you need to:
 
 Additional features:
 
-- You can filter the Purchase Request requesting your review through the
-  filter *Needs my Review*.
-- User with rights to confirm the Purchase Request (validate all tiers
-  that would be generated) can directly do the operation, this is, there
-  is no need for her/him to request a validation.
+-  You can filter the Purchase Request requesting your review through
+   the filter *Needs my Review*.
+-  User with rights to confirm the Purchase Request (validate all tiers
+   that would be generated) can directly do the operation, this is,
+   there is no need for her/him to request a validation.
 
 Bug Tracker
 ===========
@@ -93,10 +93,10 @@ Authors
 Contributors
 ------------
 
-- Adria Gil <adria.gil@forgeflow.com>
-- `Komit <https://komit-consulting.com>`__:
+-  Adria Gil <adria.gil@forgeflow.com>
+-  `Komit <https://komit-consulting.com>`__:
 
-  - Quan.nhm <quan.nhm@komit-consulting.com>
+   -  Quan.nhm <quan.nhm@komit-consulting.com>
 
 Other credits
 -------------
@@ -104,7 +104,7 @@ Other credits
 Images
 ~~~~~~
 
-- Enric Tobella (logo)
+-  Enric Tobella (logo)
 
 Maintainers
 -----------

--- a/purchase_request_tier_validation/__manifest__.py
+++ b/purchase_request_tier_validation/__manifest__.py
@@ -13,7 +13,9 @@
     "installable": True,
     "depends": ["purchase_request", "base_tier_validation"],
     "data": [
-        "data/purchase_request_tier_definition.xml",
         "views/purchase_request_view.xml",
+    ],
+    "demo": [
+        "demo/tier_definition.xml",
     ],
 }

--- a/purchase_request_tier_validation/data/purchase_request_tier_definition.xml
+++ b/purchase_request_tier_validation/data/purchase_request_tier_definition.xml
@@ -11,5 +11,6 @@
             name="reviewer_group_id"
             ref='purchase_request.group_purchase_request_manager'
         />
+        <field name="company_id" /> <!-- no company set by default -->
     </record>
 </odoo>

--- a/purchase_request_tier_validation/demo/tier_definition.xml
+++ b/purchase_request_tier_validation/demo/tier_definition.xml
@@ -11,6 +11,7 @@
             name="reviewer_group_id"
             ref='purchase_request.group_purchase_request_manager'
         />
-        <field name="company_id" /> <!-- no company set by default -->
+        <field name="company_id" />
+        <!-- no company set by default -->
     </record>
 </odoo>

--- a/purchase_request_tier_validation/static/description/index.html
+++ b/purchase_request_tier_validation/static/description/index.html
@@ -418,11 +418,11 @@ statuses.</li>
 </ol>
 <p>Additional features:</p>
 <ul class="simple">
-<li>You can filter the Purchase Request requesting your review through the
-filter <em>Needs my Review</em>.</li>
+<li>You can filter the Purchase Request requesting your review through
+the filter <em>Needs my Review</em>.</li>
 <li>User with rights to confirm the Purchase Request (validate all tiers
-that would be generated) can directly do the operation, this is, there
-is no need for her/him to request a validation.</li>
+that would be generated) can directly do the operation, this is,
+there is no need for her/him to request a validation.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/purchase-workflow/pull/2608

Changes done:
- [x] `purchase_request`: Hide the `company_id` field from the lines + add index.
- [x] `purchase_request`: Set groups to `group_id` field
- [x] `purchase_request`: Add company_id field (invisible) to form view.
- [x] `purchase_request`: Leave the company_id field empty in the sequence.
- [x] `purchase_request_tier_validation`: Leave the company_id field empty in the definition.
- [x] `purchase_request_tier_validation`: Change tier.definition data to demo data.
- [x] `purchase_request`: Add kanban view.
![ejemplo](https://github.com/user-attachments/assets/08f4a2af-81d6-4efa-89e6-f8ca439a364f)

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT51248 TT55213