### PR TITLE
[18.0][FIX] purchase_request: Make currency_id field invisible

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -209,7 +209,7 @@
                                 </list>
                             </field>
                             <group class="oe_subtotal_footer oe_right">
-                                <field name="currency_id" column_invisible="1" />
+                                <field name="currency_id" invisible="1" />
                                 <div class="oe_subtotal_footer_separator oe_inline">
                                     <label for="estimated_cost" />
                                 </div>


### PR DESCRIPTION
Make `currency_id` field invisible.

**Before**
![antes](https://github.com/user-attachments/assets/e821e5de-7486-4a12-b27c-e33a0e6f2f70)

**After**
![despues](https://github.com/user-attachments/assets/8154b107-57df-4e01-9514-d37852ae6826)

Related to https://github.com/OCA/purchase-workflow/pull/2609#pullrequestreview-2685740378

Please @carlos-lopez-tecnativa can you review it?

@Tecnativa