### PR TITLE
[16.0][IMP] purchase_request: Define analytic_distribution field hidden by default

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -194,6 +194,7 @@
                                         widget="analytic_distribution"
                                         groups="analytic.group_analytic_accounting"
                                         options="{'product_field': 'product_id', 'business_domain': 'purchase_order'}"
+                                        optional="hide"
                                     />
                                     <field name="date_required" />
                                     <field name="estimated_cost" widget="monetary" />


### PR DESCRIPTION
Define `analytic_distribution` field hidden by default similar to line tree view (https://github.com/OCA/purchase-workflow/blob/b4670f4f387c96648a8609111a6758f71d5e595d/purchase_request/views/purchase_request_line_view.xml#L46)

Please @carlos-lopez-tecnativa can you review it?

@Tecnativa TT55563