### PR TITLE
[16.0][FIX] purchase_request: Display the status of the purchase in the corresponding language

### DIFF
--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -108,7 +108,9 @@ class PurchaseRequestLine(models.Model):
     purchase_state = fields.Selection(
         compute="_compute_purchase_state",
         string="Purchase Status",
-        selection=lambda self: self.env["purchase.order"]._fields["state"].selection,
+        selection=lambda self: self.env["purchase.order"]
+        ._fields["state"]
+        ._description_selection(self.env),
         store=True,
     )
     move_dest_ids = fields.One2many(


### PR DESCRIPTION
Display the status of the purchase in the corresponding language.

**Before**
![antes](https://github.com/user-attachments/assets/dc15db0e-8a9d-4aa2-8749-d6c38ec02af6)

**After**
![despues](https://github.com/user-attachments/assets/55556886-34d1-44b5-818e-a5967558fcbc)

Please @pedrobaeza can you review it?

@Tecnativa TT55567