### PR TITLE
[17.0][FIX] purchase_request: Display the status of the purchase in the corresponding language

### DIFF
--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -107,7 +107,9 @@ class PurchaseRequestLine(models.Model):
     purchase_state = fields.Selection(
         compute="_compute_purchase_state",
         string="Purchase Status",
-        selection=lambda self: self.env["purchase.order"]._fields["state"].selection,
+        selection=lambda self: self.env["purchase.order"]
+        ._fields["state"]
+        ._description_selection(self.env),
         store=True,
     )
     move_dest_ids = fields.One2many(


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/purchase-workflow/pull/2614

Display the status of the purchase in the corresponding language.

**Before**
![antes](https://github.com/user-attachments/assets/8149fc0b-a00c-4dad-8148-b3b821be9643)

**After**
![despues](https://github.com/user-attachments/assets/e12f2eb0-bac6-4b43-bc0f-eae445770424)

Please @pedrobaeza can you review it?

@Tecnativa TT55567