### PR TITLE
[18.0][FIX] purchase_request: Display the status of the purchase in the corresponding language

### DIFF
--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -107,7 +107,9 @@ class PurchaseRequestLine(models.Model):
     purchase_state = fields.Selection(
         compute="_compute_purchase_state",
         string="Purchase Status",
-        selection=lambda self: self.env["purchase.order"]._fields["state"].selection,
+        selection=lambda self: self.env["purchase.order"]
+        ._fields["state"]
+        ._description_selection(self.env),
         store=True,
     )
     move_dest_ids = fields.One2many(


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/purchase-workflow/pull/2617

Display the status of the purchase in the corresponding language.

**Before**
![antes](https://github.com/user-attachments/assets/ff47f46f-43a3-4c75-913d-84e25582cd9f)

**After**
![despues](https://github.com/user-attachments/assets/e0df13c9-9f5d-4eea-8428-016c8d462723)

Please @pedrobaeza can you review it?

@Tecnativa TT55567