### PR TITLE
[18.0][IMP] purchase_request_tier_validation: Hide Confirm button if the validation is pending or rejected

### DIFF
--- a/purchase_request_tier_validation/views/purchase_request_view.xml
+++ b/purchase_request_tier_validation/views/purchase_request_view.xml
@@ -8,9 +8,14 @@
         <field name="inherit_id" ref="purchase_request.view_purchase_request_form" />
         <field name="arch" type="xml">
             <button name="button_approved" position="attributes">
-                <attribute name="invisible">state != 'draft'</attribute>
+                <attribute
+                    name="invisible"
+                >state != 'draft' or validation_status in ('pending', 'rejected')</attribute>
                 <attribute name="string">Confirm</attribute>
             </button>
+            <field name="state" position="after">
+                <field name="validation_status" invisible="1" />
+            </field>
             <button name="button_to_approve" position="attributes">
                 <attribute name="invisible">1</attribute>
             </button>


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/purchase-workflow/pull/2607

Hide Confirm button if the validation is pending or rejected.

**Before**
![antes](https://github.com/user-attachments/assets/898c18ef-7bc7-4ddb-bc0d-c59bc796a3b9)

**After**
![despues](https://github.com/user-attachments/assets/113bb47b-dc2c-4f22-8cdc-31e8b1a7475c)

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT55409