### PR TITLE
[16.0][FIX] purchase_manual_delivery: Do not use demo data in tests

### DIFF
--- a/purchase_manual_delivery/tests/test_purchase_manual_delivery.py
+++ b/purchase_manual_delivery/tests/test_purchase_manual_delivery.py
@@ -1,84 +1,82 @@
 # Copyright 2019 ForgeFlow S.L.
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tests.common import TransactionCase
+from odoo.tests import Form, new_test_user
+from odoo.tools import mute_logger
 
-from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestPurchaseManualDelivery(TransactionCase):
-    def setUp(self):
-        super(TestPurchaseManualDelivery, self).setUp()
-        self.purchase_order_obj = self.env["purchase.order"]
-        self.purchase_order_line_obj = self.env["purchase.order.line"]
-        self.stock_picking_obj = self.env["stock.picking"]
-        self.env.company.purchase_manual_delivery = True
+class TestPurchaseManualDelivery(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.purchase_order_obj = cls.env["purchase.order"]
+        cls.purchase_order_line_obj = cls.env["purchase.order.line"]
+        cls.stock_picking_obj = cls.env["stock.picking"]
+        cls.env.company.purchase_manual_delivery = True
         # Products
-        self.product1 = self.env.ref("product.product_product_13")
-        self.product2 = self.env.ref("product.product_product_25")
-
-        # Sublocation
-        self.shelf2 = self.env.ref("stock.stock_location_14")
-
-        # Purchase Orders
-        self.po1 = self.purchase_order_obj.create(
-            {
-                "partner_id": self.ref("base.res_partner_3"),
-            }
+        cls.product1 = cls.env["product.product"].create(
+            {"name": "Test product 1", "detailed_type": "product"}
         )
-        self.po1_line1 = self.purchase_order_line_obj.create(
+        cls.product2 = cls.env["product.product"].create(
+            {"name": "Test product 2", "detailed_type": "product"}
+        )
+        # Sublocation
+        cls.shelf2 = cls.env.ref("stock.stock_location_14")
+        # Purchase Orders
+        cls.vendor = cls.env["res.partner"].create({"name": "Test vendor"})
+        cls.po1 = cls.purchase_order_obj.create({"partner_id": cls.vendor.id})
+        cls.po1_line1 = cls.purchase_order_line_obj.create(
             {
-                "order_id": self.po1.id,
-                "product_id": self.product1.id,
-                "product_uom": self.product1.uom_id.id,
-                "name": self.product1.name,
-                "price_unit": self.product1.standard_price,
+                "order_id": cls.po1.id,
+                "product_id": cls.product1.id,
+                "product_uom": cls.product1.uom_id.id,
+                "name": cls.product1.name,
+                "price_unit": cls.product1.standard_price,
                 "date_planned": fields.datetime.now(),
                 "product_qty": 42.0,
             }
         )
-        self.po1_line2 = self.purchase_order_line_obj.create(
+        cls.po1_line2 = cls.purchase_order_line_obj.create(
             {
-                "order_id": self.po1.id,
-                "product_id": self.product2.id,
-                "product_uom": self.product2.uom_id.id,
-                "name": self.product2.name,
-                "price_unit": self.product2.standard_price,
+                "order_id": cls.po1.id,
+                "product_id": cls.product2.id,
+                "product_uom": cls.product2.uom_id.id,
+                "name": cls.product2.name,
+                "price_unit": cls.product2.standard_price,
                 "date_planned": fields.datetime.now(),
                 "product_qty": 12.0,
             }
         )
-
-        self.po2 = self.purchase_order_obj.create(
+        cls.po2 = cls.purchase_order_obj.create({"partner_id": cls.vendor.id})
+        cls.po2_line1 = cls.purchase_order_line_obj.create(
             {
-                "partner_id": self.ref("base.res_partner_3"),
-            }
-        )
-        self.po2_line1 = self.purchase_order_line_obj.create(
-            {
-                "order_id": self.po2.id,
-                "product_id": self.product1.id,
-                "product_uom": self.product1.uom_id.id,
-                "name": self.product1.name,
-                "price_unit": self.product1.standard_price,
+                "order_id": cls.po2.id,
+                "product_id": cls.product1.id,
+                "product_uom": cls.product1.uom_id.id,
+                "name": cls.product1.name,
+                "price_unit": cls.product1.standard_price,
                 "date_planned": fields.datetime.now(),
                 "product_qty": 10.0,
             }
         )
-        self.po2_line2 = self.purchase_order_line_obj.create(
+        cls.po2_line2 = cls.purchase_order_line_obj.create(
             {
-                "order_id": self.po2.id,
-                "product_id": self.product2.id,
-                "product_uom": self.product2.uom_id.id,
-                "name": self.product2.name,
-                "price_unit": self.product2.standard_price,
+                "order_id": cls.po2.id,
+                "product_id": cls.product2.id,
+                "product_uom": cls.product2.uom_id.id,
+                "name": cls.product2.name,
+                "price_unit": cls.product2.standard_price,
                 "date_planned": fields.datetime.now(),
                 "product_qty": 22.0,
             }
         )
 
+    @mute_logger("odoo.models.unlink")
     def test_01_purchase_order_manual_delivery(self):
         """
         Confirm Purchase Order 1, check no incoming shipments have been
@@ -217,6 +215,7 @@ class TestPurchaseManualDelivery(TransactionCase):
         self.assertEqual(self.po2_line1.existing_qty, self.po2_line1.product_qty)
         self.assertEqual(self.po2_line2.existing_qty, self.po2_line2.product_qty)
 
+    @mute_logger("odoo.models.unlink")
     def test_03_purchase_order_line_location(self):
         """
         Confirm Purchase Order 1, create one reception changing the
@@ -256,6 +255,7 @@ class TestPurchaseManualDelivery(TransactionCase):
         self.assertEqual(self.po1_line1.existing_qty, self.po1_line1.product_qty)
         self.assertEqual(self.po1_line2.existing_qty, 0)
 
+    @mute_logger("odoo.models.unlink")
     def test_04_pending_to_receive(self):
         """
         Checks if a purchase order line with existing quantity higher than
@@ -366,12 +366,10 @@ class TestPurchaseManualDelivery(TransactionCase):
         pre-created. Approve Purchase Order 1, check no incoming shipments
         have been pre-created.
         """
-        self.user_purchase_user = mail_new_test_user(
+        self.user_purchase_user = new_test_user(
             self.env,
-            name="Pauline Poivraisselle",
-            login="pauline",
+            login="test-user_purchase_user",
             email="pur@example.com",
-            notification_type="inbox",
             groups="purchase.group_purchase_user",
         )
 
@@ -381,28 +379,13 @@ class TestPurchaseManualDelivery(TransactionCase):
         )
 
         # Create draft RFQ
-        po_vals = {
-            "partner_id": self.ref("base.res_partner_3"),
-            "order_line": [
-                (
-                    0,
-                    0,
-                    {
-                        "name": self.product1.name,
-                        "product_id": self.product1.id,
-                        "product_qty": 5.0,
-                        "product_uom": self.product1.uom_po_id.id,
-                        "price_unit": 5000000.0,
-                    },
-                )
-            ],
-        }
-        self.po = (
-            self.env["purchase.order"]
-            .with_user(self.user_purchase_user)
-            .create(po_vals)
-        )
-
+        order_form = Form(self.env["purchase.order"].with_user(self.user_purchase_user))
+        order_form.partner_id = self.vendor
+        with order_form.order_line.new() as line_form:
+            line_form.product_id = self.product1
+            line_form.product_qty = 5
+            line_form.price_unit = 5000000
+        self.po = order_form.save()
         # confirm RFQ
         self.po.button_confirm_manual()
         self.assertTrue(self.po.order_line.pending_to_receive)


### PR DESCRIPTION
Do not use demo data in tests

Using demo data from core modules can have side effects, e.g. the product used is linked to company A, and the record you are trying to create (purchase order) is from another company causing confusing permission errors.

Please @pedrobaeza can you review it?

@Tecnativa