### PR TITLE
[18.0][IMP] purchase_request: Define analytic_distribution field hidden by default

### DIFF
--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -182,6 +182,7 @@
                                         widget="analytic_distribution"
                                         groups="analytic.group_analytic_accounting"
                                         options="{'product_field': 'product_id', 'business_domain': 'purchase_order'}"
+                                        optional="hide"
                                     />
                                     <field name="date_required" />
                                     <field name="estimated_cost" widget="monetary" />


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/purchase-workflow/pull/2627

Define `analytic_distribution` field hidden by default similar to line tree view (https://github.com/OCA/purchase-workflow/blob/734e483cc793c29f653d75ffc34718e8117a9886/purchase_request/views/purchase_request_line_view.xml#L46)

Please @carlos-lopez-tecnativa can you review it?

@Tecnativa TT55563