### PR TITLE
[17.0][FIX] purchase_advance_payment: use commercial partner

### DIFF
--- a/purchase_advance_payment/wizard/purchase_advance_payment_wizard.py
+++ b/purchase_advance_payment/wizard/purchase_advance_payment_wizard.py
@@ -150,7 +150,7 @@ class AccountVoucherWizardPurchase(models.TransientModel):
         self.currency_amount = amount_advance
 
     def _prepare_payment_vals(self, purchase):
-        partner_id = purchase.partner_id.id
+        partner_id = purchase.partner_id.commercial_partner_id.id
         return {
             "purchase_id": purchase.id,
             "date": self.date,


### PR DESCRIPTION
The commercial partner is used as the partner of the payable journal items, therefore the payments from the bill will be created for the parent partner. The same should happen with advance payments, otherwise the advanced payments won't appear as options to reconcile when the bill is finally created.

Fwport of #2228 