### PR TITLE
[17.0][FIX] purchase_advance_payment: do not create starting false param

### DIFF
--- a/purchase_advance_payment/data/ir_config_parameter.xml
+++ b/purchase_advance_payment/data/ir_config_parameter.xml
@@ -4,14 +4,4 @@
         <field name="key">purchase_advance_payment.auto_post_advance_payments</field>
         <field name="value">True</field>
     </record>
-    <record
-        id="auto_reconcile_advance_payments"
-        model="ir.config_parameter"
-        forcecreate="0"
-    >
-        <field
-            name="key"
-        >purchase_advance_payment.auto_reconcile_advance_payments</field>
-        <field name="value">False</field>
-    </record>
 </odoo>


### PR DESCRIPTION
When you uncheck the setting, odoo deletes the param. So when the param exists with value false, Odoo does not handle it propoerly and the setting remains visually active always.

Detected during migration to v18. ref https://github.com/OCA/purchase-workflow/pull/2626#issuecomment-2765431525