### PR TITLE
[18.0] MIG product_supplier_code_purchase

### DIFF
--- a/product_supplier_code_purchase/README.rst
+++ b/product_supplier_code_purchase/README.rst
@@ -71,6 +71,7 @@ Contributors
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Aaron Henriquez <ahenriquez@forgeflow.com>
 * Carlos Reyes <carlos@studio73.es>
+* Giuliano Lotta <giuliano.lotta@gmail.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_supplier_code_purchase/__manifest__.py
+++ b/product_supplier_code_purchase/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Product Supplier Code in Purchase",
     "summary": """This module adds to the purchase order line the supplier
                 code defined in the product.""",
-    "version": "16.0.1.0.0",
+    "version": "18.0.1.0.0",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/purchase-workflow",
     "category": "Purchase Management",

--- a/product_supplier_code_purchase/views/purchase_order_view.xml
+++ b/product_supplier_code_purchase/views/purchase_order_view.xml
@@ -1,4 +1,4 @@
-?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
     <record id="purchase_order_form" model="ir.ui.view">

--- a/product_supplier_code_purchase/views/purchase_order_view.xml
+++ b/product_supplier_code_purchase/views/purchase_order_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
     <record id="purchase_order_form" model="ir.ui.view">
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
             <xpath
-                expr="//field[@name='order_line']//tree//field[@name='product_id']"
+                expr="//field[@name='order_line']//list//field[@name='product_id']"
                 position="after"
             >
                 <field name="product_supplier_code" />


### PR DESCRIPTION
Update purchase_order_view.xml to v18
xpath selector, modified to match new v18 purchase_order_view structure (xml /tree element has been deprecated; now using xml  /list element)