### PR TITLE
[FIX] purchase_manual_delivery: use _product_purchase_domain on _compute_draft_quantity_count

### DIFF
--- a/purchase_manual_delivery/report/stock_forecasted.py
+++ b/purchase_manual_delivery/report/stock_forecasted.py
@@ -23,7 +23,9 @@ class ReplenishmentReport(models.AbstractModel):
             ("state", "in", ["purchase", "done"]),
             ("pending_to_receive", "=", True),
         ]
-        domain += self._product_domain(product_template_ids, product_variant_ids)
+        domain += self._product_purchase_domain(
+            product_template_ids, product_variant_ids
+        )
         warehouse_id = self.env.context.get("warehouse", False)
         if warehouse_id:
             domain += [("order_id.picking_type_id.warehouse_id", "=", warehouse_id)]


### PR DESCRIPTION
Raising error wrong domain
`ValueError: Invalid field purchase.order.line.product_tmpl_id in leaf ('product_tmpl_id', 'in', [30])`

Method _compute_draft_quantity_count was calling wrong domain function _product_domain, instead of _product_purchase_domain