### PR TITLE
[14.0][IMP] purchase_advance_payment: use is_zero method instead of raw comparison

### DIFF
--- a/purchase_advance_payment/models/purchase_order.py
+++ b/purchase_advance_payment/models/purchase_order.py
@@ -90,7 +90,7 @@ class PurchaseOrder(models.Model):
                         invoice_paid_amount += payment[1]
             amount_residual = order.amount_total - advance_amount - invoice_paid_amount
             payment_state = "not_paid"
-            if mls or invoice_paid_amount != 0.0:
+            if mls or not order.currency_id.is_zero(invoice_paid_amount):
                 has_due_amount = float_compare(
                     amount_residual, 0.0, precision_rounding=order.currency_id.rounding
                 )


### PR DESCRIPTION
Same change suggested in #2637 

cc: @marcelsavegnago @kaynnan @LoisRForgeFlow @dreispt