### PR TITLE
[17.0][FIX] purchase_lot: super call

### DIFF
--- a/purchase_lot/models/purchase_order_line.py
+++ b/purchase_lot/models/purchase_order_line.py
@@ -44,8 +44,9 @@ class PurchaseOrderLine(models.Model):
         values,
     ):
         lot_id = values.get("restrict_lot_id", False)
-        self = self.filtered(lambda line: line.lot_id.id == lot_id)
-        return super()._find_candidate(
+        return super(
+            PurchaseOrderLine, self.filtered(lambda line: line.lot_id.id == lot_id)
+        )._find_candidate(
             product_id,
             product_qty,
             product_uom,


### PR DESCRIPTION
The _find_candidate() function seems to be dead code right now because the recordset filter is not propagated to super().

Correct me if i am wrong