### PR TITLE
[18.0][FIX] purchase_all_shipments: Fix the test cases.

### DIFF
--- a/purchase_all_shipments/tests/test_three_step_reception.py
+++ b/purchase_all_shipments/tests/test_three_step_reception.py
@@ -9,7 +9,7 @@ class TestThreeStepReception(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.wh = cls.env.ref("stock.warehouse0")
-        cls.po = cls.env.ref("purchase.purchase_order_1")
+        cls.po = cls.env.ref("purchase.purchase_order_2")
 
     def test_three_steps_generate_three_pickings(self):
         self.wh.reception_steps = "three_steps"


### PR DESCRIPTION
In the recent change in Odoo 18 PR: https://github.com/odoo/odoo/pull/205346
The product with ID: product.product_product_27 has been used in purchase_order_1, which was previously enabled to use lot tracking from the MRP module, but now, because of the above PR, it has been enabled from the stock module, which is causing the failure of all new PR test cases in the repo (18.0 branch).