### PR TITLE
[16.0][FIX] purchase_request: Change the types of messages that are created to notes

### DIFF
--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -60,7 +60,7 @@ class PurchaseOrder(models.Model):
                     request, requests_dict[request_id]
                 )
                 request.message_post(
-                    body=message, subtype_id=self.env.ref("mail.mt_comment").id
+                    body=message, subtype_id=self.env.ref("mail.mt_note").id
                 )
         return True
 
@@ -181,7 +181,7 @@ class PurchaseOrderLine(models.Model):
                 )
                 if message:
                     alloc.purchase_request_line_id.request_id.message_post(
-                        body=message, subtype_id=self.env.ref("mail.mt_comment").id
+                        body=message, subtype_id=self.env.ref("mail.mt_note").id
                     )
 
                 alloc.purchase_request_line_id._compute_qty()

--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -128,5 +128,5 @@ class PurchaseRequestAllocation(models.Model):
             message_data = self._prepare_message_data(po_line, request, allocated_qty)
             message = self._purchase_request_confirm_done_message_content(message_data)
             request.message_post(
-                body=message, subtype_id=self.env.ref("mail.mt_comment").id
+                body=message, subtype_id=self.env.ref("mail.mt_note").id
             )

--- a/purchase_request/models/stock_move_line.py
+++ b/purchase_request/models/stock_move_line.py
@@ -108,7 +108,7 @@ class StockMoveLine(models.Model):
                     )
                     if message:
                         request.message_post(
-                            body=message, subtype_id=self.env.ref("mail.mt_comment").id
+                            body=message, subtype_id=self.env.ref("mail.mt_note").id
                         )
 
                     picking_message = self._picking_confirm_done_message_content(
@@ -117,7 +117,7 @@ class StockMoveLine(models.Model):
                     if picking_message:
                         ml.move_id.picking_id.message_post(
                             body=picking_message,
-                            subtype_id=self.env.ref("mail.mt_comment").id,
+                            subtype_id=self.env.ref("mail.mt_note").id,
                         )
 
                 allocation._compute_open_product_qty()


### PR DESCRIPTION
Change the types of messages that are created to notes.

Change the subtype from `mail.mt_comment` to `mail.mt_note` to prevent an email being sent to the vendor.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT56225