### PR TITLE
[17.0][FIX] purchase_request: Fix allocation of purchase request lines

### DIFF
--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -85,7 +85,7 @@ class PurchaseRequestAllocation(models.Model):
     )
     def _compute_open_product_qty(self):
         for rec in self:
-            if rec.purchase_state in ["cancel", "done"]:
+            if rec.purchase_state == "cancel":
                 rec.open_product_qty = 0.0
             else:
                 rec.open_product_qty = (


### PR DESCRIPTION
This commit allow to post message in purchase requests when the purchase order is in done state. Odoo allow to confirm a purchase order in done state automatically, the message is not posted in the purchase request when the purchase order is in done state.