### PR TITLE
[16.0][IMP] purchase_request: Allow a user with read permissions to create messages

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -18,6 +18,7 @@ class PurchaseRequest(models.Model):
 
     _name = "purchase.request"
     _description = "Purchase Request"
+    _mail_post_access = "read"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "id desc"
 


### PR DESCRIPTION
Allow a user with read permissions to create messages

Example use case:
- Create a user with the Purchase Request User permission (or use Marc Demo).
- Create a purchase request requested by Mitchell Admin
- Add the previously created user as a follower.
- The user will be able to create messages and notes.

**Before**
![antes](https://github.com/user-attachments/assets/570cc76e-07d1-4322-9285-e579527e40b3)

**After**
![despues](https://github.com/user-attachments/assets/25f4e505-e650-49d3-a5d4-9e599db55c28)

Please @pedrobaeza can you review it?

@Tecnativa TT56229