### PR TITLE
[IMP] purchase_request: allow editing the request reference without developer mode

### DIFF
--- a/purchase_request/__manifest__.py
+++ b/purchase_request/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Purchase Request",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
-    "version": "18.0.2.5.1",
+    "version": "18.0.2.6.0",
     "summary": "Use this module to have notification of requirements of "
     "materials and/or external services and keep track of such "
     "requirements.",

--- a/purchase_request/tests/test_purchase_request.py
+++ b/purchase_request/tests/test_purchase_request.py
@@ -1,6 +1,8 @@
 # Copyright 2018-2019 ForgeFlow, S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 
+from lxml import etree
+
 from odoo import SUPERUSER_ID, exceptions
 from odoo.exceptions import UserError
 from odoo.tests import Form, TransactionCase
@@ -28,6 +30,16 @@ class TestPurchaseRequest(TransactionCase):
             "product_qty": 5.0,
         }
         self.purchase_request_line_obj.create(vals)
+
+    def test_name_editable_without_developer_mode(self):
+        """The request reference is editable without developer mode."""
+        arch = etree.fromstring(
+            self.purchase_request_obj.get_view(
+                self.env.ref("purchase_request.view_purchase_request_form").id
+            )["arch"]
+        )
+        name_field = arch.xpath("//h1/field[@name='name']")[0]
+        self.assertNotIn("readonly", name_field.attrib)
 
     def test_purchase_request_line_action(self):
         action = self.purchase_request.line_ids.action_show_details()

--- a/purchase_request/views/purchase_request_view.xml
+++ b/purchase_request/views/purchase_request_view.xml
@@ -112,11 +112,7 @@
                     <h1>
                         <field name="is_editable" invisible="1" />
                         <field name="is_name_editable" invisible="1" />
-                        <field
-                            name="name"
-                            class="oe_inline"
-                            readonly="is_name_editable == False"
-                        />
+                        <field name="name" class="oe_inline" />
                     </h1>
                     <group>
                         <group>


### PR DESCRIPTION
`is_name_editable` defaults to `base.group_no_one`, so the request reference is
only editable while developer mode is on. A user who manages purchase requests
cannot rename one, not even in draft, and the reference is the only field that
identifies a request in the list view, the search and the report — users
routinely want a descriptive title there rather than the sequence.

This drops the `readonly` modifier so the reference follows the write access to
the record. The sequence still fills it in on create when the default is left
untouched: `create()` only replaces the name while it still equals `New`.

Test: `test_name_editable_without_developer_mode` asserts the form view does not
gate the reference behind a modifier. It fails on `18.0` and passes with this
change; the rest of the module suite stays green (31 tests).

Note: the original description of this PR blamed the readonly for a validation
error on save. That was wrong — see the comment below.
