### PR TITLE
[17.0][FIX] purchase_request: Change the types of messages that are created to notes.

### DIFF
--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -64,7 +64,7 @@ class PurchaseOrder(models.Model):
                 )
                 request.message_post(
                     body=message,
-                    subtype_id=self.env.ref("mail.mt_comment").id,
+                    subtype_id=self.env.ref("mail.mt_note").id,
                 )
         return True
 
@@ -185,7 +185,7 @@ class PurchaseOrderLine(models.Model):
                 )
                 alloc.purchase_request_line_id.request_id.message_post(
                     body=message,
-                    subtype_id=self.env.ref("mail.mt_comment").id,
+                    subtype_id=self.env.ref("mail.mt_note").id,
                 )
 
                 alloc.purchase_request_line_id._compute_qty()

--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -132,5 +132,5 @@ class PurchaseRequestAllocation(models.Model):
             message = self._purchase_request_confirm_done_message_content(message_data)
             request.message_post(
                 body=message,
-                subtype_id=self.env.ref("mail.mt_comment").id,
+                subtype_id=self.env.ref("mail.mt_note").id,
             )

--- a/purchase_request/models/stock_move_line.py
+++ b/purchase_request/models/stock_move_line.py
@@ -111,7 +111,7 @@ class StockMoveLine(models.Model):
                     )
                     request.message_post(
                         body=message,
-                        subtype_id=self.env.ref("mail.mt_comment").id,
+                        subtype_id=self.env.ref("mail.mt_note").id,
                     )
 
                     picking_message = self._picking_confirm_done_message_content(
@@ -119,7 +119,7 @@ class StockMoveLine(models.Model):
                     )
                     ml.move_id.picking_id.message_post(
                         body=picking_message,
-                        subtype_id=self.env.ref("mail.mt_comment").id,
+                        subtype_id=self.env.ref("mail.mt_note").id,
                     )
 
                 allocation._compute_open_product_qty()


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/purchase-workflow/pull/2666

Change the types of messages that are created to notes.

Change the subtype from `mail.mt_comment` to `mail.mt_note` to prevent an email being sent to the vendor.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT56225