### PR TITLE
[17.0][IMP] purchase_request: Allow a user with read permissions to create messages

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -17,6 +17,7 @@ _STATES = [
 class PurchaseRequest(models.Model):
     _name = "purchase.request"
     _description = "Purchase Request"
+    _mail_post_access = "read"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "id desc"
 


### PR DESCRIPTION
FWP 16.0: https://github.com/OCA/purchase-workflow/pull/2669

Allow a user with read permissions to create messages

Example use case:
- Create a user with the Purchase Request User permission (or use Marc Demo).
- Create a purchase request requested by Mitchell Admin
- Add the previously created user as a follower.
- The user will be able to create messages.

**Before**
![antes](https://github.com/user-attachments/assets/82b0c13c-15dc-45a8-bdc5-ec52dd19d798)

**After**
![despues](https://github.com/user-attachments/assets/c73da91f-e4b6-40d9-902e-7f94c4d01eb3)


**Note:** Now it is only necessary to create messages, notes, activities and attachments can be used without this change.

Please @pedrobaeza can you review it?

@Tecnativa TT56229