### PR TITLE
[18.0][IMP] purchase_request: Allow a user with read permissions to create messages

### DIFF
--- a/purchase_request/models/purchase_request.py
+++ b/purchase_request/models/purchase_request.py
@@ -17,6 +17,7 @@ _STATES = [
 class PurchaseRequest(models.Model):
     _name = "purchase.request"
     _description = "Purchase Request"
+    _mail_post_access = "read"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "id desc"
 


### PR DESCRIPTION
FWP 17.0: https://github.com/OCA/purchase-workflow/pull/2674

Allow a user with read permissions to create messages

Example use case:
- Create a user with the Purchase Request User permission (or use Marc Demo).
- Create a purchase request requested by Mitchell Admin
- Add the previously created user as a follower.
- The user will be able to create messages.

**Before**
![antes](https://github.com/user-attachments/assets/e4840213-2574-4ec7-84be-71091b4dc8e5)

**After**
![despues](https://github.com/user-attachments/assets/3dd6c042-1106-48c8-91f4-74bcc42c8951)

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT56229