### PR TITLE
[14.0][FIX] purchase_quick: price_unit when qty_to_process is less than seller’s qty_min

### DIFF
--- a/purchase_quick/models/purchase_order.py
+++ b/purchase_quick/models/purchase_order.py
@@ -4,6 +4,8 @@
 # @author Pierrick Brun <pierrick.brun@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from collections import OrderedDict
+
 from odoo import _, models
 from odoo.exceptions import ValidationError
 
@@ -62,10 +64,13 @@ class PurchaseOrder(models.Model):
         return result
 
     def _get_quick_line_qty_vals(self, product):
-        return {
-            "product_qty": product.qty_to_process,
-            "product_uom": product.quick_uom_id.id,
-        }
+        return OrderedDict(
+            {
+                "product_id": None,
+                "product_uom": product.quick_uom_id.id,
+                "product_qty": product.qty_to_process,
+            }
+        )
 
     def _complete_quick_line_vals(self, vals, lines_key=""):
         # This params are need for playing correctly the onchange

--- a/purchase_quick/tests/test_quick_purchase.py
+++ b/purchase_quick/tests/test_quick_purchase.py
@@ -208,3 +208,23 @@ class TestQuickPurchase(SavepointCase):
         product_in_quick_edit.write(
             {"qty_to_process": 5.0, "quick_uom_id": self.uom_unit.id}
         )
+
+    def test_no_pricelist_for_the_min_qty(self):
+        """
+        Checks that if you enter a qty_to_process lower than the seller's min_qty,
+        the price_unit in de pusrchase.order.line is the standard_price.
+        """
+        po = self.env["purchase.order"].create({"partner_id": self.partner.id})
+        ctx = {
+            "parent_id": po.id,
+            "parent_model": "purchase.order",
+            "quick_access_rights_purchase": 1,
+        }
+        product_3 = self.env.ref("product.product_product_5")
+        self._add_seller(product_3, [(5, 5), (10, 1)])
+        product_3 = product_3.with_context(**ctx)
+        product_3.write({"qty_to_process": 1.0, "quick_uom_id": self.uom_unit.id})
+        line_1 = po.order_line
+        self.assertEqual(line_1.product_qty, 1.0)
+        self.assertEqual(line_1.product_uom, self.uom_unit)
+        self.assertEqual(line_1.price_unit, product_3.standard_price)


### PR DESCRIPTION
BWP #2069