### PR TITLE
[16.0][IMP] purchase_order_supplierinfo_update : also synchronize `discount` from PO lines to supplierinfo (and other fields)

### DIFF
--- a/purchase_order_supplierinfo_update/models/purchase_order.py
+++ b/purchase_order_supplierinfo_update/models/purchase_order.py
@@ -26,7 +26,8 @@ class PurchaseOrderLine(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if vals.get("price_unit"):
+        to_synch = self._get_synch_fields_line_to_supplierinfo()
+        if vals.get("price_unit") or any(key in to_synch for key in vals.keys()):
             self.update_supplierinfo_price()
         return res
 
@@ -70,3 +71,14 @@ class PurchaseOrderLine(models.Model):
         # Set price
         if new_seller_price != seller.price:
             seller.sudo().price = new_seller_price
+
+        # Set other fields like `discount` (see `purchase_discount`)
+        for field in self._get_synch_fields_line_to_supplierinfo():
+            if field in seller and field in self:
+                seller.sudo()[field] = self[field]
+
+    def _get_synch_fields_line_to_supplierinfo(self):
+        triple_discount = "triple.discount.mixin" in self.env
+        return (
+            ["discount1", "discount2", "discount3"] if triple_discount else ["discount"]
+        )


### PR DESCRIPTION
It can be useful to synchronize other fields from PO lines to supplierinfo prices, like `discount` from the module `purchase_discount` or `discount1/2/3` from `purchase_discount_triple`.
This update allow it without hard dependency with such modules `purchase_discount` or `purchase_discount_triple` by verifying if the field exists in PO lines and supplierinfo models before trying to write it.

Finally the method `_get_synch_fields_line_to_supplierinfo()` can be inherited to add other fields to synchronize from PO lines to supplierinfo.