### PR TITLE
[17.0][FIX] sale_purchase_force_vendor: Change the done status of sales orders (does not exist) to sale

### DIFF
--- a/sale_purchase_force_vendor/views/sale_order_view.xml
+++ b/sale_purchase_force_vendor/views/sale_order_view.xml
@@ -26,7 +26,7 @@
                     <field
                         name="vendor_id"
                         domain="vendor_id_domain"
-                        readonly="'state' in ('done', 'cancel')"
+                        readonly="'state' in ('sale', 'cancel')"
                         options='{"no_create": True}'
                     />
                 </group>


### PR DESCRIPTION
Change the `done` status of sales orders (does not exist) to `sale`

Related to https://github.com/OCA/purchase-workflow/pull/2523#discussion_r2099637436

Please @pedrobaeza can you review it?

@Tecnativa