### PR TITLE
[15.0][IMP] purchase_reception_status_line: add over-received status and propagation logic for orders and lines

### DIFF
--- a/purchase_reception_status_line/__manifest__.py
+++ b/purchase_reception_status_line/__manifest__.py
@@ -11,6 +11,9 @@
     "maintainers": ["DavidJForgeFlow"],
     "website": "https://github.com/OCA/purchase-workflow",
     "depends": ["purchase_reception_status"],
-    "data": ["views/purchase_order.xml"],
+    "data": [
+        "views/purchase_order.xml",
+        "views/purchase_order_line_views.xml",
+    ],
     "installable": True,
 }

--- a/purchase_reception_status_line/models/purchase_order.py
+++ b/purchase_reception_status_line/models/purchase_order.py
@@ -1,11 +1,41 @@
 # Copyright 2024 ForgeFlow (http://www.akretion.com/)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
+
+    force_received = fields.Boolean(
+        compute="_compute_force_received",
+        inverse="_inverse_force_received",
+        store=True,
+        tracking=True,
+        help="If true, the order is marked forced only when all lines are fully received"
+        " and at least one line was manually forced.",
+    )
+
+    @api.depends("order_line.reception_status", "order_line.force_received")
+    def _compute_force_received(self):
+        for po in self:
+            all_received = all(
+                line.reception_status == "received" for line in po.order_line
+            )
+            any_forced = any(line.force_received for line in po.order_line)
+            po.force_received = all_received and any_forced
+
+    def _inverse_force_received(self):
+        for po in self:
+            if po.force_received:
+                to_force = po.order_line.filtered(
+                    lambda l: l.reception_status != "received"
+                )
+                to_force.write({"force_received": True})
+            else:
+                forced_lines = po.order_line.filtered(lambda l: l.force_received)
+                forced_lines.write({"force_received": False})
+                forced_lines._compute_reception_status()
 
     @api.depends(
         "state",

--- a/purchase_reception_status_line/models/purchase_order_line.py
+++ b/purchase_reception_status_line/models/purchase_order_line.py
@@ -6,46 +6,39 @@ from odoo.tools import float_compare
 
 
 class PurchaseOrderLine(models.Model):
-    _inherit = "purchase.order.line"
+    _name = "purchase.order.line"
+    _inherit = ["purchase.order.line", "mail.thread", "mail.activity.mixin"]
 
     reception_status = fields.Selection(
         [
             ("no", "Nothing Received"),
             ("partial", "Partially Received"),
             ("received", "Fully Received"),
+            ("over", "Over Received"),
         ],
         compute="_compute_reception_status",
         store=True,
     )
     force_received = fields.Boolean(
+        string="Force closed by Buyer",
         readonly=False,
         states={"draft": [("readonly", True)]},
-        compute="_compute_force_received",
         store=True,
         copy=False,
         help="If true, the reception status will be forced to Fully Received, "
         "even if some quantities are not fully received. ",
+        tracking=True,
     )
 
-    @api.depends("order_id.force_received")
-    def _compute_force_received(self):
-        prec = self.env["decimal.precision"].precision_get("Product Unit of Measure")
+    def action_commute_force_received(self):
         for rec in self:
-            if (
-                rec.order_id.force_received
-                and not float_compare(
-                    rec.qty_received, rec.product_qty, precision_digits=prec
-                )
-                >= 0
-            ):
-                rec.force_received = True
+            rec.force_received = not rec.force_received
 
     @api.depends(
         "state",
         "force_received",
         "qty_received",
         "product_qty",
-        "order_id.force_received",
     )
     def _compute_reception_status(self):
         prec = self.env["decimal.precision"].precision_get("Product Unit of Measure")
@@ -54,15 +47,21 @@ class PurchaseOrderLine(models.Model):
             if line.order_id.state in ("purchase", "done"):
                 if line.force_received:
                     status = "received"
-                elif (
-                    float_compare(
-                        line.qty_received, line.product_qty, precision_digits=prec
-                    )
-                    >= 0
-                ):
-                    status = "received"
-                elif float_compare(line.qty_received, 0, precision_digits=prec) > 0:
-                    status = "partial"
-            line.reception_status = (
-                status if not line.order_id.force_received else "received"
-            )
+                else:
+                    if (
+                        float_compare(
+                            line.qty_received, line.product_qty, precision_digits=prec
+                        )
+                        > 0
+                    ):
+                        status = "over"
+                    elif (
+                        float_compare(
+                            line.qty_received, line.product_qty, precision_digits=prec
+                        )
+                        == 0
+                    ):
+                        status = "received"
+                    elif float_compare(line.qty_received, 0, precision_digits=prec) > 0:
+                        status = "partial"
+            line.reception_status = status

--- a/purchase_reception_status_line/static/description/index.html
+++ b/purchase_reception_status_line/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -424,9 +423,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/purchase_reception_status_line/tests/test_purchase_receipt_status_line.py
+++ b/purchase_reception_status_line/tests/test_purchase_receipt_status_line.py
@@ -74,3 +74,53 @@ class TestPurchaseReceiptionStatusLine(TransactionCase):
         self.assertEqual(self.order.order_line[0].reception_status, "received")
         self.assertEqual(self.order.order_line[1].reception_status, "received")
         self.assertEqual(self.order.order_line[1].force_received, True)
+
+    def test_03_over_received_status(self):
+        over_line = self.env["purchase.order.line"].create(
+            {
+                "order_id": self.order.id,
+                "name": self.product.name,
+                "product_id": self.product.id,
+                "product_qty": 5.0,
+                "qty_received_manual": 7.0,
+            }
+        )
+        self.order.button_confirm()
+        self.assertEqual(over_line.reception_status, "over")
+        over_line.force_received = True
+        self.assertEqual(over_line.reception_status, "received")
+
+    def test_04_order_force_logic_and_propagation(self):
+        l1 = self.env["purchase.order.line"].create(
+            {
+                "order_id": self.order.id,
+                "name": self.product.name,
+                "product_id": self.product.id,
+                "product_qty": 4.0,
+                "qty_received_manual": 0.0,
+            }
+        )
+        l2 = self.env["purchase.order.line"].create(
+            {
+                "order_id": self.order.id,
+                "name": self.product.name,
+                "product_id": self.product.id,
+                "product_qty": 3.0,
+                "qty_received_manual": 0.0,
+            }
+        )
+        self.order.button_confirm()
+        self.assertTrue(l1.reception_status == "no")
+        self.assertTrue(l2.reception_status == "no")
+        self.assertFalse(self.order.force_received)
+        l1.force_received = True
+        self.assertFalse(self.order.force_received)
+        l2.force_received = True
+        self.assertTrue(self.order.force_received)
+        l1.force_received = False
+        self.assertFalse(self.order.force_received)
+        self.assertTrue(l2.force_received)
+        self.order.force_received = True
+        self.assertTrue(all(line.force_received for line in self.order.order_line))
+        self.order.force_received = False
+        self.assertFalse(any(line.force_received for line in self.order.order_line))

--- a/purchase_reception_status_line/views/purchase_order_line_views.xml
+++ b/purchase_reception_status_line/views/purchase_order_line_views.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="purchase_order_line_tree" model="ir.ui.view">
+        <field
+            name="name"
+        >purchase.order.line.tree - purchase_reception_status_line</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_tree" />
+        <field name="arch" type="xml">
+            <field name="product_uom" position="after">
+                <field name="reception_status" optional="hide" />
+                <field
+                    name="force_received"
+                    groups="purchase.group_purchase_manager"
+                    optional="hide"
+                />
+                <field name="state" invisible="1" />
+                <button
+                    name="action_commute_force_received"
+                    type="object"
+                    string="Force Receive"
+                    attrs="{'invisible': ['|','|',('state', 'not in', ['purchase', 'done']),('force_received', '=', True),('reception_status','=','received')]}"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="purchase_order_line_form2" model="ir.ui.view">
+        <field
+            name="name"
+        >purchase.order.line.form - purchase_reception_status_line</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_form2" />
+        <field name="arch" type="xml">
+            <sheet position="after">
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" groups="base.group_user" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
+                </div>
+            </sheet>
+        </field>
+    </record>
+
+    <record id="purchase_order_line_search_filters" model="ir.ui.view">
+        <field name="name">purchase.order.line.search.reception_status.filters</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='hide_cancelled']" position="after">
+                <separator string="Reception Status" />
+                <filter
+                    name="filter_no"
+                    string="Nothing Received"
+                    domain="[('reception_status','=','no'),('state','in',['done','purchase'])]"
+                />
+                <filter
+                    name="filter_partial"
+                    string="Partially Received"
+                    domain="[('reception_status','=','partial'),('state','in',['done','purchase'])]"
+                />
+                <filter
+                    name="filter_received"
+                    string="Fully Received"
+                    domain="[('reception_status','=','received'),('state','in',['done','purchase'])]"
+                />
+                <filter
+                    name="filter_over"
+                    string="Over Received"
+                    domain="[('reception_status','=','over'),('state','in',['done','purchase'])]"
+                />
+                <separator />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
**PR Summary**
- Add `over received` status to purchase order lines  
- Propagation logic for orders and lines