### PR TITLE
[18.0][IMP] purchase_invoice_plan: compute name display in invoice plan

### DIFF
--- a/purchase_invoice_plan/models/purchase_invoice_plan.py
+++ b/purchase_invoice_plan/models/purchase_invoice_plan.py
@@ -203,3 +203,12 @@ class PurchaseInvoicePlan(models.Model):
                 )
                 % ", ".join(installments)
             )
+
+    @api.depends("purchase_id", "installment", "plan_date", "percent")
+    def _compute_display_name(self):
+        for rec in self:
+            display_name = (
+                f"{rec.purchase_id.name}, "
+                f"Invoice Plan #{rec.installment}: {rec.plan_date} ({rec.percent}%)"
+            )
+            rec.display_name = display_name

--- a/purchase_invoice_plan/tests/test_purchase_invoice_plan.py
+++ b/purchase_invoice_plan/tests/test_purchase_invoice_plan.py
@@ -183,6 +183,8 @@ class TestPurchaseInvoicePlan(BaseCommon):
         self.assertEqual(len(self.test_po_product.invoice_plan_ids), 5)
         first_install = self.test_po_product.invoice_plan_ids[0]
         first_install.amount = 1000
+        self.assertIn(self.test_po_product.name, first_install.display_name)
+        self.assertIn("Invoice Plan", first_install.display_name)
         self.test_po_product.invoice_plan_ids[4].amount = 3000
         self.test_po_product.button_confirm()
         self.assertEqual(self.test_po_product.state, "purchase")


### PR DESCRIPTION
This PR implement display name on purchase.invoice.plan if other module link to it

Format: `<name po>, Invoice Plan #<installment>: <plan_date> (<percent>%)`

![Selection_011](https://github.com/user-attachments/assets/8b3a8e04-a352-434c-a5ad-b6445e055508)
