### PR TITLE
[14.0][IMP][purchase_quick] add action to separate personal filters

### DIFF
--- a/purchase_quick/models/product_product.py
+++ b/purchase_quick/models/product_product.py
@@ -5,6 +5,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
+from lxml import etree
+
 from odoo import api, fields, models
 
 
@@ -69,19 +71,34 @@ class ProductProduct(models.Model):
                 [("order_id", "=", purchase.id)]
             )
             args.append(("id", "in", po_lines.mapped("product_id").ids))
-        if self.env.context.get("for_current_supplier") and purchase:
-            seller = purchase.partner_id
-            seller = seller.commercial_partner_id or seller
-            args += [
-                "|",
-                ("variant_specific_seller_ids.name", "=", seller.id),
-                "&",
-                ("seller_ids.name", "=", seller.id),
-                ("product_variant_ids", "!=", False),
-            ]
         return super(ProductProduct, self).search(
             args, offset=offset, limit=limit, order=order, count=count
         )
+
+    def _get_supplier_domain(self, partner_id):
+        return [
+            "|",
+            ("variant_specific_seller_ids.name", "=", partner_id),
+            "&",
+            ("seller_ids.name", "=", partner_id),
+            ("product_variant_ids", "!=", False),
+        ]
+
+    @api.model
+    def fields_view_get(
+        self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        res = super().fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=False
+        )
+        po_partner_id = self.env.context.get("po_partner_id")
+        if view_type == "search" and po_partner_id:
+            doc = etree.XML(res["arch"])
+            node = doc.xpath("//filter[@name='filter_for_current_supplier']")
+            if node:
+                node[0].attrib["domain"] = str(self._get_supplier_domain(po_partner_id))
+                res["arch"] = etree.tostring(doc, pretty_print=True)
+        return res
 
     @api.model
     def check_access_rights(self, operation, raise_exception=True):

--- a/purchase_quick/models/purchase_order.py
+++ b/purchase_quick/models/purchase_order.py
@@ -35,18 +35,20 @@ class PurchaseOrder(models.Model):
 
     def add_product(self):
         self.ensure_one()
+        xmlid = "purchase_quick.purchase_quick_add_product_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(xmlid)
         res = self._common_action_keys()
         res["context"].update(self._get_context_add_products())
         domain = self._get_domain_add_products()
         if domain:
             res["domain"] = domain
         commercial = self.partner_id.commercial_partner_id.name
-        res["name"] = "🔙 {} ({})".format(_("Product Variants"), commercial)
+        res["display_name"] = "🔙 {} ({})".format(_("Product Variants"), commercial.name)
         res["view_id"] = (self.env.ref("purchase_quick.product_tree_view4purchase").id,)
         res["search_view_id"] = (
             self.env.ref("purchase_quick.product_search_form_view").id,
         )
-        return res
+        return action.update(res)
 
     def _get_quick_line(self, product):
         result = self.env["purchase.order.line"].search(

--- a/purchase_quick/models/purchase_order.py
+++ b/purchase_quick/models/purchase_order.py
@@ -38,17 +38,22 @@ class PurchaseOrder(models.Model):
         xmlid = "purchase_quick.purchase_quick_add_product_action"
         action = self.env["ir.actions.act_window"]._for_xml_id(xmlid)
         res = self._common_action_keys()
-        res["context"].update(self._get_context_add_products())
-        domain = self._get_domain_add_products()
-        if domain:
-            res["domain"] = domain
-        commercial = self.partner_id.commercial_partner_id.name
+        commercial = self.partner_id.commercial_partner_id
+        res["domain"] = "[('purchase_ok', '=', True)]"
+        res["context"].update(
+            {
+                "search_default_filter_for_current_supplier": 1,
+                "quick_access_rights_purchase": 1,
+                "po_partner_id": commercial.id,
+            }
+        )
         res["display_name"] = "🔙 {} ({})".format(_("Product Variants"), commercial.name)
         res["view_id"] = (self.env.ref("purchase_quick.product_tree_view4purchase").id,)
         res["search_view_id"] = (
             self.env.ref("purchase_quick.product_search_form_view").id,
         )
-        return action.update(res)
+        action.update(res)
+        return action
 
     def _get_quick_line(self, product):
         result = self.env["purchase.order.line"].search(

--- a/purchase_quick/views/product_view.xml
+++ b/purchase_quick/views/product_view.xml
@@ -37,7 +37,6 @@
                     name="filter_for_current_supplier"
                     string="For current supplier"
                     domain="[]"
-                    context="{'for_current_supplier': True}"
                     help="Filter products supplied by the supplier of the current parent object"
                 />
             </xpath>

--- a/purchase_quick/views/purchase_view.xml
+++ b/purchase_quick/views/purchase_view.xml
@@ -17,4 +17,8 @@
         </field>
     </record>
 
+    <record model="ir.actions.act_window" id="purchase_quick_add_product_action">
+        <field name="res_model">product.product</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
The Add Product button does not have a dedicated ir.actions.act_window. As a result, any personal (default or shared) filter is automatically applied to every product.product view.
We need the ability to distinguish the default filter used for Quick Purchase from those used in other contexts.

This PR add an action. 


also replace : https://github.com/OCA/purchase-workflow/pull/1847 with : 
- improve supplier search
- replace purchase_ok filter in context by a domain to be constistant with the purchase order regular view.