### PR TITLE
[18.0][IMP] purchase_security: allow to open the form view from the editable tree view

### DIFF
--- a/purchase_security/models/purchase_team.py
+++ b/purchase_security/models/purchase_team.py
@@ -19,3 +19,24 @@ class PurchaseTeam(models.Model):
         column2="res_users_id",
         string="Purchase Users",
     )
+
+    def open_form_view(self):
+        """Allow to open the form view from the editable tree view.
+
+        The main reason to use the form view is to manage the team members
+        of larger teams. The many2many_avatar_user widget in the tree view
+        does not allow to remove some of the users if ellipsis ('+3') is
+        triggered in the widget.
+        """
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "purchase_security.action_purchase_team_display"
+        )
+        action.update(
+            {
+                "res_id": self.id,
+                "view_mode": "form",
+                "views": [(False, "form")],
+            }
+        )
+        return action

--- a/purchase_security/views/purchase_team_views.xml
+++ b/purchase_security/views/purchase_team_views.xml
@@ -18,53 +18,7 @@
                     </div>
                     <notebook>
                         <page string="Members">
-                            <field name="user_ids" mode="kanban" class="w-100">
-                                <kanban>
-                                    <field name="id" />
-                                    <field name="name" />
-                                    <field name="email" />
-                                    <field name="avatar_128" />
-                                    <templates>
-                                        <t t-name="kanban-card">
-                                            <div
-                                                class="oe_kanban_card oe_kanban_global_click"
-                                            >
-                                                <div
-                                                    class="o_kanban_card_content d-flex"
-                                                >
-                                                    <div>
-                                                        <img
-                                                            t-att-src="kanban_image('res.users', 'avatar_128', record.id.raw_value)"
-                                                            class="o_kanban_image o_image_64_cover"
-                                                            alt="Avatar"
-                                                        />
-                                                    </div>
-                                                    <div
-                                                        class="oe_kanban_details d-flex flex-column ml-3"
-                                                    >
-                                                        <strong
-                                                            class="o_kanban_record_title oe_partner_heading"
-                                                        >
-                                                            <field name="name" />
-                                                        </strong>
-                                                        <div
-                                                            class="d-flex align-items-baseline text-break"
-                                                        >
-                                                            <i
-                                                                class="fa fa-envelope mr-1"
-                                                                role="img"
-                                                                aria-label="Email"
-                                                                title="Email"
-                                                            />
-                                                            <field name="email" />
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </t>
-                                    </templates>
-                                </kanban>
-                            </field>
+                            <field name="user_ids" mode="kanban" />
                         </page>
                     </notebook>
                 </sheet>

--- a/purchase_security/views/purchase_team_views.xml
+++ b/purchase_security/views/purchase_team_views.xml
@@ -83,6 +83,12 @@
                     widget="many2many_avatar_user"
                     domain="[('share', '=', False)]"
                 />
+                <button
+                    icon="fa-pencil"
+                    name="open_form_view"
+                    type="object"
+                    title="Open Form View"
+                />
             </list>
         </field>
     </record>


### PR DESCRIPTION
The main reason to use the form view is to manage the team members of larger teams. The many2many_avatar_user widget in the tree view does not allow to remove some of the users if ellipsis ('+3') is triggered in the widget.

Port of https://github.com/OCA/purchase-workflow/pull/2422

Additionally, fix invalid res.users Kanban view causing "Error: Missing 'card' template" in the UI when opening the security team form view.