### PR TITLE
[FIX] purchase_*_breadown: Replace name for partner_id on supplier references

### DIFF
--- a/purchase_supplierinfo_product_breakdown/models/product_supplierinfo.py
+++ b/purchase_supplierinfo_product_breakdown/models/product_supplierinfo.py
@@ -7,7 +7,7 @@ class ProductSupplierInfo(models.Model):
     product_use_components = fields.Boolean(
         related="product_tmpl_id.use_product_components"
     )
-    partner_use_components = fields.Boolean(related="name.use_product_components")
+    partner_use_components = fields.Boolean(related="partner_id.use_product_components")
     component_ids = fields.One2many(
         comodel_name="product.supplierinfo.component", inverse_name="supplierinfo_id"
     )

--- a/purchase_supplierinfo_product_breakdown/models/product_supplierinfo_component.py
+++ b/purchase_supplierinfo_product_breakdown/models/product_supplierinfo_component.py
@@ -9,7 +9,7 @@ class ProductSupplierInfoComponent(models.Model):
         comodel_name="product.supplierinfo", string="Supplier Info"
     )
     parent_product_ids = fields.One2many(related="supplierinfo_id.product_variant_ids")
-    partner_id = fields.Many2one(related="supplierinfo_id.name")
+    partner_id = fields.Many2one(related="supplierinfo_id.partner_id")
     component_id = fields.Many2one(
         comodel_name="product.product",
         string="Component",

--- a/purchase_supplierinfo_product_breakdown/tests/common.py
+++ b/purchase_supplierinfo_product_breakdown/tests/common.py
@@ -32,17 +32,17 @@ class SupplierInfoCommon(TransactionCase):
 
         with Form(self.product_product_component_hammer) as form:
             with form.seller_ids.new() as seller:
-                seller.name = self.res_partner_supplier_max
+                seller.partner_id = self.res_partner_supplier_max
                 seller.price = 5
 
         with Form(self.product_product_component_saw) as form:
             with form.seller_ids.new() as seller:
-                seller.name = self.res_partner_supplier_max
+                seller.partner_id = self.res_partner_supplier_max
                 seller.price = 3.0
 
         with Form(self.product_product_toolbox) as form:
             with form.seller_ids.new() as seller:
-                seller.name = self.res_partner_anna
+                seller.partner_id = self.res_partner_anna
                 seller.price = 100.0
 
         self.product_supplier_info = self.product_product_toolbox.seller_ids

--- a/purchase_vendor_bill_breakdown/models/product_supplierinfo_component.py
+++ b/purchase_vendor_bill_breakdown/models/product_supplierinfo_component.py
@@ -24,7 +24,8 @@ class ProductSupplierInfoComponent(models.Model):
     def get_supplier_by_args(self, product_id, partner_id):
         """Get first supplier by product and vendor name"""
         return self.env["product.supplierinfo"].search(
-            [("product_tmpl_id", "=", product_id), ("name", "=", partner_id)], limit=1
+            [("product_tmpl_id", "=", product_id), ("partner_id", "=", partner_id)],
+            limit=1,
         )
 
     @api.depends("component_id", "component_id.seller_ids")
@@ -33,7 +34,8 @@ class ProductSupplierInfoComponent(models.Model):
         for rec in self:
             price = (
                 self.get_supplier_by_args(
-                    rec.component_id.product_tmpl_id.id, rec.supplierinfo_id.name.id
+                    rec.component_id.product_tmpl_id.id,
+                    rec.supplierinfo_id.partner_id.id,
                 ).price
                 or rec.component_id.standard_price
             )

--- a/purchase_vendor_bill_breakdown/models/purchase_order_line.py
+++ b/purchase_vendor_bill_breakdown/models/purchase_order_line.py
@@ -53,7 +53,7 @@ class PurchaseOrderLine(models.Model):
             rec.supplier_id = self.env["product.supplierinfo"].search(
                 [
                     ("product_tmpl_id", "=", rec.product_id.product_tmpl_id.id),
-                    ("name", "=", rec.order_id.partner_id.id),
+                    ("partner_id", "=", rec.order_id.partner_id.id),
                 ],
                 limit=1,
             )

--- a/purchase_vendor_bill_breakdown/tests/common.py
+++ b/purchase_vendor_bill_breakdown/tests/common.py
@@ -80,20 +80,20 @@ class PurchaseTransactionCase(TransactionCase):
 
         with Form(self.product_product_component_test_1) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_supplier
+                line.partner_id = self.res_partner_supplier
                 line.price = 5.0
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_supplier_2
+                line.partner_id = self.res_partner_supplier_2
                 line.price = 6.0
 
         with Form(self.product_product_component_test_2) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_supplier
+                line.partner_id = self.res_partner_supplier
                 line.price = 3.0
 
         with Form(self.product_product_test_1) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_test_use_product_components
+                line.partner_id = self.res_partner_test_use_product_components
                 line.price = 100
 
         self.product_supplier_info = self.product_product_test_1.seller_ids[0]
@@ -108,22 +108,22 @@ class PurchaseTransactionCase(TransactionCase):
 
         with Form(self.product_product_component_test_3) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_supplier
+                line.partner_id = self.res_partner_supplier
                 line.price = 1.0
 
         with Form(self.product_product_component_test_4) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_supplier
+                line.partner_id = self.res_partner_supplier
                 line.price = 5.0
 
         with Form(self.product_product_component_test_5) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_supplier
+                line.partner_id = self.res_partner_supplier
                 line.price = 6.0
 
         with Form(self.product_product_test_3) as form:
             with form.seller_ids.new() as line:
-                line.name = self.supplier_partner
+                line.partner_id = self.supplier_partner
                 line.price = 100
 
         seller_id = self.product_product_test_3.seller_ids[0]

--- a/purchase_vendor_bill_breakdown/tests/test_components_flow.py
+++ b/purchase_vendor_bill_breakdown/tests/test_components_flow.py
@@ -16,7 +16,7 @@ class TestComponentsFlow(PurchaseTransactionCase):
         PurchaseOrder = self.env["purchase.order"]
         with Form(self.product_product_test_1) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_test_use_product_components
+                line.partner_id = self.res_partner_test_use_product_components
                 line.price = 1.0
 
         with Form(
@@ -34,30 +34,30 @@ class TestComponentsFlow(PurchaseTransactionCase):
 
         with Form(self.product_product_component_test_1) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_test_use_product_components
+                line.partner_id = self.res_partner_test_use_product_components
                 line.price = 100.0
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_test_use_product_components
+                line.partner_id = self.res_partner_test_use_product_components
                 line.price = 200.0
 
         with Form(self.product_product_component_test_2) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_test_use_product_components
+                line.partner_id = self.res_partner_test_use_product_components
                 line.price = 150.0
 
         with Form(self.product_product_component_test_3) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_test_use_product_components
+                line.partner_id = self.res_partner_test_use_product_components
                 line.price = 200.0
 
         with Form(self.product_product_component_test_4) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_test_use_product_components
+                line.partner_id = self.res_partner_test_use_product_components
                 line.price = 180.0
 
         with Form(self.product_product_component_test_5) as form:
             with form.seller_ids.new() as line:
-                line.name = self.res_partner_test_use_product_components
+                line.partner_id = self.res_partner_test_use_product_components
                 line.price = 170.0
 
         form = Form(PurchaseOrder)

--- a/purchase_vendor_bill_breakdown/tests/test_product_supplierinfo_component.py
+++ b/purchase_vendor_bill_breakdown/tests/test_product_supplierinfo_component.py
@@ -107,12 +107,12 @@ class TestProductSupplierInfoComponent(SupplierInfoCommon):
         supplier_empty = SupplierInfoComponent.get_supplier_by_args(
             self.product_product_component_hammer.product_tmpl_id.id,
             self.res_partner_supplier_max.id,
-        ).name
+        ).partner_id
         self.assertFalse(supplier_empty, msg="Recordset must be empty")
         supplier_valid = SupplierInfoComponent.get_supplier_by_args(
             self.product_product_component_hammer.product_tmpl_id.id,
             self.res_partner_anna.id,
-        ).name
+        ).partner_id
         self.assertEqual(
             supplier_valid,
             self.res_partner_anna,
@@ -125,12 +125,12 @@ class TestProductSupplierInfoComponent(SupplierInfoCommon):
         supplier_empty = SupplierInfoComponent.get_supplier_by_args(
             self.product_product_component_hammer.product_tmpl_id.id,
             self.res_partner_anna.id,
-        ).name
+        ).partner_id
         self.assertFalse(supplier_empty, msg="Recordset must be empty")
         supplier_valid = SupplierInfoComponent.get_supplier_by_args(
             self.product_product_component_hammer.product_tmpl_id.id,
             self.res_partner_supplier_max.id,
-        ).name
+        ).partner_id
         self.assertEqual(
             supplier_valid,
             self.res_partner_supplier_max,


### PR DESCRIPTION
Greenify v14 CI