### PR TITLE
[16.0][IMP] purchase_request: Add specific subtypes for using subscribed partners in some messages

### DIFF
--- a/purchase_request/data/purchase_request_data.xml
+++ b/purchase_request/data/purchase_request_data.xml
@@ -27,4 +27,18 @@
         <field name="default" eval="True" />
         <field name="description">Purchase Request is done</field>
     </record>
+    <record id="mt_request_po_confirmed" model="mail.message.subtype">
+        <field name="name">Purchase Order confirmation</field>
+        <field name="res_model">purchase.request</field>
+        <field name="default" eval="True" />
+        <field name="internal" eval="True" />
+        <field name="description">Purchase Order is confirmed</field>
+    </record>
+    <record id="mt_request_picking_done" model="mail.message.subtype">
+        <field name="name">Purchase receipt confirmation</field>
+        <field name="res_model">purchase.request</field>
+        <field name="default" eval="True" />
+        <field name="internal" eval="True" />
+        <field name="description">Receipt is done</field>
+    </record>
 </odoo>

--- a/purchase_request/i18n/es.po
+++ b/purchase_request/i18n/es.po
@@ -847,6 +847,11 @@ msgid "Purchase Order"
 msgstr "Pedido de compra"
 
 #. module: purchase_request
+#: model:mail.message.subtype,name:purchase_request.mt_request_po_confirmed
+msgid "Purchase Order confirmation"
+msgstr "Pedido de compra confirmado"
+
+#. module: purchase_request
 #: model:ir.model,name:purchase_request.model_purchase_order_line
 msgid "Purchase Order Line"
 msgstr "Línea de pedido de compra"
@@ -858,6 +863,11 @@ msgstr "Línea de pedido de compra"
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_line_details
 msgid "Purchase Order Lines"
 msgstr "Líneas de pedido de compra"
+
+#. module: purchase_request
+#: model:mail.message.subtype,description:purchase_request.mt_request_po_confirmed
+msgid "Purchase Order is confirmed"
+msgstr "El pedido de compra está confirmado"
 
 #. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_form
@@ -1078,6 +1088,11 @@ msgid "RFQ/PO Qty"
 msgstr "Cantidad compra"
 
 #. module: purchase_request
+#: model:mail.message.subtype,name:purchase_request.mt_request_picking_done
+msgid "Purchase receipt confirmation"
+msgstr "Recepción de compra confirmada"
+
+#. module: purchase_request
 #. odoo-python
 #: code:addons/purchase_request/models/stock_move_line.py:0
 #, python-format
@@ -1091,6 +1106,11 @@ msgstr ""
 #, python-format
 msgid "Receipt confirmation for Request %s"
 msgstr "Confirmación de recepción de la solicitud %s"
+
+#. module: purchase_request
+#: model:mail.message.subtype,description:purchase_request.mt_request_picking_done
+msgid "Receipt is done"
+msgstr "Recepción hecha"
 
 #. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_form
@@ -1541,43 +1561,3 @@ msgstr "Debe seleccionar líneas del mismo tipo de recogida."
 #, python-format
 msgid "You have to select lines from the same company."
 msgstr "Debe seleccionar líneas de la misma compañía."
-
-#~ msgid "SMS Delivery error"
-#~ msgstr "Error en la entrega de SMS"
-
-#~ msgid "Number of messages which requires an action"
-#~ msgstr "Número de mensajes que requieren una acción"
-
-#~ msgid "<strong>Analytic Account</strong>"
-#~ msgstr "<strong>Cuenta analítica</strong>"
-
-#~ msgid "Analytic Account"
-#~ msgstr "Cuenta analítica"
-
-#, fuzzy
-#~ msgid "Number of unread messages"
-#~ msgstr "Mensajes no leídos"
-
-#, fuzzy
-#~ msgid "Product Template"
-#~ msgstr "Producto"
-
-#, fuzzy
-#~ msgid "Unread Messages Counter"
-#~ msgstr "Mensajes no leídos"
-
-#~ msgid "<li><b>%s</b>: Ordered quantity %s %s, Planned date %s</li>"
-#~ msgstr "<li><b>%s</b>: Cantidad pedida %s %s, Fecha planificada %s</li>"
-
-#~ msgid "<li><b>%s</b>: Received quantity %s %s</li>"
-#~ msgstr "<li><b>%s</b>: Cantidad recibida %s %s</li>"
-
-#~ msgid "<li><b>%s</b>: Transferred quantity %s %s</li>"
-#~ msgstr "<li><b>%s</b>: Cantidad transferida %s %s</li>"
-
-#~ msgid "Product Unit of Measure"
-#~ msgstr "Unidad de medida"
-
-#, fuzzy
-#~ msgid "Procurement Rule"
-#~ msgstr "Abastecimiento"

--- a/purchase_request/i18n/purchase_request.pot
+++ b/purchase_request/i18n/purchase_request.pot
@@ -703,6 +703,11 @@ msgid "Order Reference"
 msgstr ""
 
 #. module: purchase_request
+#: model:mail.message.subtype,name:purchase_request.mt_request_po_confirmed
+msgid "Order confirmation"
+msgstr ""
+
+#. module: purchase_request
 #. odoo-python
 #: code:addons/purchase_request/models/purchase_order.py:0
 #, python-format
@@ -816,6 +821,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_form
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_line_details
 msgid "Purchase Order Lines"
+msgstr ""
+
+#. module: purchase_request
+#: model:mail.message.subtype,description:purchase_request.mt_request_po_confirmed
+msgid "Purchase Order is confirmed"
 msgstr ""
 
 #. module: purchase_request
@@ -1033,6 +1043,11 @@ msgid "RFQ/PO Qty"
 msgstr ""
 
 #. module: purchase_request
+#: model:mail.message.subtype,name:purchase_request.mt_request_picking_done
+msgid "Receipt confirmation"
+msgstr ""
+
+#. module: purchase_request
 #. odoo-python
 #: code:addons/purchase_request/models/stock_move_line.py:0
 #, python-format
@@ -1045,6 +1060,11 @@ msgstr ""
 #: code:addons/purchase_request/models/stock_move_line.py:0
 #, python-format
 msgid "Receipt confirmation for Request %s"
+msgstr ""
+
+#. module: purchase_request
+#: model:mail.message.subtype,description:purchase_request.mt_request_picking_done
+msgid "Receipt is done"
 msgstr ""
 
 #. module: purchase_request

--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -60,7 +60,10 @@ class PurchaseOrder(models.Model):
                     request, requests_dict[request_id]
                 )
                 request.message_post(
-                    body=message, subtype_id=self.env.ref("mail.mt_note").id
+                    body=message,
+                    subtype_id=self.env.ref(
+                        "purchase_request.mt_request_po_confirmed"
+                    ).id,
                 )
         return True
 

--- a/purchase_request/models/stock_move_line.py
+++ b/purchase_request/models/stock_move_line.py
@@ -108,7 +108,10 @@ class StockMoveLine(models.Model):
                     )
                     if message:
                         request.message_post(
-                            body=message, subtype_id=self.env.ref("mail.mt_note").id
+                            body=message,
+                            subtype_id=self.env.ref(
+                                "purchase_request.mt_request_picking_done"
+                            ).id,
                         )
 
                     picking_message = self._picking_confirm_done_message_content(


### PR DESCRIPTION
Add specific subtypes for using subscribed partners in some messages

The following subtypes have been created:
- Purchase Order confirmation: The email will be sent only to the followers of this subtype.
- Purchase receipt confirmation: The email will be sent only to followers of this subtype.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT56541