### PR TITLE
[17.0][FIX] purchase_force_invoiced: restore force invoiced flag editable status

### DIFF
--- a/purchase_force_invoiced/view/purchase_order.xml
+++ b/purchase_force_invoiced/view/purchase_order.xml
@@ -13,7 +13,7 @@
                     name="force_invoiced"
                     groups="purchase.group_purchase_manager"
                     invisible="state not in ('purchase', 'done')"
-                    readonly="state == 'done'"
+                    readonly="state != 'done'"
                     widget="boolean_toggle"
                 />
             </field>


### PR DESCRIPTION
Before v17 migration, if you wanted to force invoice status purchase order must be locked. After that migration, condition was changed to the opposite one (purchase order must be unlocked), probably due to a migration error.

This restores original behavior, that shouldn't be changed. Also, restoring old behavior makes the addon coherent with current usage documentation, that's been never changed.

See https://github.com/OCA/purchase-workflow/commit/0d691b0f7d41aac4272e3d6fe56137c64da4bb38 for more details

If merged, I'll port it to v18.

@JordiBForgeFlow @BertVGroenendael could you review? Thanks!