### PR TITLE
[18.0][FIX] purchase_force_invoiced: restore force invoiced flag editable status

### DIFF
--- a/purchase_force_invoiced/view/purchase_order.xml
+++ b/purchase_force_invoiced/view/purchase_order.xml
@@ -13,7 +13,7 @@
                     name="force_invoiced"
                     groups="purchase_force_invoiced.group_force_invoiced"
                     invisible="state not in ('purchase', 'done')"
-                    readonly="state == 'done'"
+                    readonly="state != 'done'"
                     widget="boolean_toggle"
                 />
             </field>


### PR DESCRIPTION
Fw-port of #2726 

Before v17 migration, if you wanted to force invoice status purchase order must be locked. After that migration, condition was changed to the opposite one (purchase order must be unlocked), probably due to a migration error.

This restores original behavior, that shouldn't be changed. Also, restoring old behavior makes the addon coherent with current usage documentation, that's been never changed.