### PR TITLE
[18.0][IMP] purchase_request: Add specific subtypes for using subscribed partners in some messages

### DIFF
--- a/purchase_request/data/purchase_request_data.xml
+++ b/purchase_request/data/purchase_request_data.xml
@@ -27,4 +27,18 @@
         <field name="default" eval="True" />
         <field name="description">Purchase Request is done</field>
     </record>
+    <record id="mt_request_po_confirmed" model="mail.message.subtype">
+        <field name="name">Purchase Order confirmation</field>
+        <field name="res_model">purchase.request</field>
+        <field name="default" eval="True" />
+        <field name="internal" eval="True" />
+        <field name="description">Purchase Order is confirmed</field>
+    </record>
+    <record id="mt_request_picking_done" model="mail.message.subtype">
+        <field name="name">Purchase receipt confirmation</field>
+        <field name="res_model">purchase.request</field>
+        <field name="default" eval="True" />
+        <field name="internal" eval="True" />
+        <field name="description">Receipt is done</field>
+    </record>
 </odoo>

--- a/purchase_request/i18n/es.po
+++ b/purchase_request/i18n/es.po
@@ -799,6 +799,11 @@ msgid "Purchase Order"
 msgstr "orden de compra"
 
 #. module: purchase_request
+#: model:mail.message.subtype,name:purchase_request.mt_request_po_confirmed
+msgid "Purchase Order confirmation"
+msgstr "Pedido de compra confirmado"
+
+#. module: purchase_request
 #: model:ir.model,name:purchase_request.model_purchase_order_line
 msgid "Purchase Order Line"
 msgstr "Línea de Orden de Compra"
@@ -810,6 +815,11 @@ msgstr "Línea de Orden de Compra"
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_line_details
 msgid "Purchase Order Lines"
 msgstr "Líneas de Orden de compra"
+
+#. module: purchase_request
+#: model:mail.message.subtype,description:purchase_request.mt_request_po_confirmed
+msgid "Purchase Order is confirmed"
+msgstr "El pedido de compra está confirmado"
 
 #. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_form
@@ -1025,6 +1035,11 @@ msgid "RFQ/PO Qty"
 msgstr "SOLICITUD DE OFERTA/CANTIDAD ORDEN DE COMPRA"
 
 #. module: purchase_request
+#: model:mail.message.subtype,name:purchase_request.mt_request_picking_done
+msgid "Purchase receipt confirmation"
+msgstr "Recepción de compra confirmada"
+
+#. module: purchase_request
 #. odoo-python
 #: code:addons/purchase_request/models/stock_move_line.py:0
 msgid "Receipt confirmation for Request {name}"
@@ -1041,6 +1056,11 @@ msgstr ""
 #: code:addons/purchase_request/models/purchase_order.py:0
 msgid "Received quantity"
 msgstr ""
+
+#. module: purchase_request
+#: model:mail.message.subtype,description:purchase_request.mt_request_picking_done
+msgid "Receipt is done"
+msgstr "Recepción hecha"
 
 #. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_form
@@ -1467,98 +1487,3 @@ msgstr "Debe seleccionar líneas del mismo tipo de recogida."
 #: code:addons/purchase_request/wizard/purchase_request_line_make_purchase_order.py:0
 msgid "You have to select lines from the same company."
 msgstr "Debe seleccionar líneas de la misma compañía."
-
-#~ msgid "SMS Delivery error"
-#~ msgstr "Error en la entrega de SMS"
-
-#~ msgid ""
-#~ "<li><b>%(product_name)s</b>: Transferred quantity %(product_qty)s "
-#~ "%(product_uom)s</li>"
-#~ msgstr ""
-#~ "<li><b>%(product_name)s</b>: Cantidad transferida %(product_qty)s "
-#~ "%(product_uom)s</li>"
-
-#~ msgid ""
-#~ "Receipt confirmation %(picking_name)s for your Request %(request_name)s"
-#~ msgstr ""
-#~ "Confirmación de recepción %(picking_name)s para su solicitud "
-#~ "%(request_name)s"
-
-#~ msgid "Service confirmation for Request %s"
-#~ msgstr "Confirmación de servicio para la solicitud %s"
-
-#~ msgid ""
-#~ "The following requested items from Purchase Request %(request_name)s have "
-#~ "now been received in %(location_name)s using Picking %(picking_name)s:"
-#~ msgstr ""
-#~ "Los siguientes artículos solicitados de la Solicitud de Compra "
-#~ "%(request_name)s han sido recibidos en %(location_name)s utilizando el "
-#~ "sistema de recogida %(picking_name)s:"
-
-#~ msgid ""
-#~ "The following requested items from Purchase Request %(request_name)s "
-#~ "requested by %(requestor)s have now been received in %(location_name)s:"
-#~ msgstr ""
-#~ "Los siguientes artículos solicitados de la solicitud de compra "
-#~ "%(request_name)s solicitada por %(requestor)s ya se han recibido en "
-#~ "%(location_name)s:"
-
-#~ msgid ""
-#~ "The following requested services from Purchase Request %(request_name)s "
-#~ "requested by %(requestor)s have now been received:"
-#~ msgstr ""
-#~ "Los siguientes servicios solicitados de la Solicitud de compra "
-#~ "%(request_name)s solicitados por %(requestor)s ahora se han recibido:"
-
-#~ msgid "Analytic Distribution Search"
-#~ msgstr "Búsqueda de distribución analítica"
-
-#, python-format
-#~ msgid "Receipt confirmation for Request %s"
-#~ msgstr "Confirmación de recepción de la solicitud %s"
-
-#~ msgid "Analytic"
-#~ msgstr "Analítica"
-
-#~ msgid "Last Modified on"
-#~ msgstr "Última modificación en"
-
-#~ msgid "Main Attachment"
-#~ msgstr "Archivo adjunto principal"
-
-#~ msgid "Number of messages which requires an action"
-#~ msgstr "Número de mensajes que requieren una acción"
-
-#~ msgid "<strong>Analytic Account</strong>"
-#~ msgstr "<strong>Cuenta analítica</strong>"
-
-#~ msgid "Analytic Account"
-#~ msgstr "Cuenta analítica"
-
-#, fuzzy
-#~ msgid "Number of unread messages"
-#~ msgstr "Mensajes no leídos"
-
-#, fuzzy
-#~ msgid "Product Template"
-#~ msgstr "Producto"
-
-#, fuzzy
-#~ msgid "Unread Messages Counter"
-#~ msgstr "Mensajes no leídos"
-
-#~ msgid "<li><b>%s</b>: Ordered quantity %s %s, Planned date %s</li>"
-#~ msgstr "<li><b>%s</b>: Cantidad pedida %s %s, Fecha planificada %s</li>"
-
-#~ msgid "<li><b>%s</b>: Received quantity %s %s</li>"
-#~ msgstr "<li><b>%s</b>: Cantidad recibida %s %s</li>"
-
-#~ msgid "<li><b>%s</b>: Transferred quantity %s %s</li>"
-#~ msgstr "<li><b>%s</b>: Cantidad transferida %s %s</li>"
-
-#~ msgid "Product Unit of Measure"
-#~ msgstr "Unidad de medida"
-
-#, fuzzy
-#~ msgid "Procurement Rule"
-#~ msgstr "Abastecimiento"

--- a/purchase_request/i18n/purchase_request.pot
+++ b/purchase_request/i18n/purchase_request.pot
@@ -656,6 +656,11 @@ msgid "Order Reference"
 msgstr ""
 
 #. module: purchase_request
+#: model:mail.message.subtype,name:purchase_request.mt_request_po_confirmed
+msgid "Order confirmation"
+msgstr ""
+
+#. module: purchase_request
 #. odoo-python
 #: code:addons/purchase_request/models/purchase_order.py:0
 msgid "Order confirmation %(po_name)s for your Request %(pr_name)s"
@@ -767,6 +772,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_form
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_line_details
 msgid "Purchase Order Lines"
+msgstr ""
+
+#. module: purchase_request
+#: model:mail.message.subtype,description:purchase_request.mt_request_po_confirmed
+msgid "Purchase Order is confirmed"
 msgstr ""
 
 #. module: purchase_request
@@ -979,6 +989,11 @@ msgid "RFQ/PO Qty"
 msgstr ""
 
 #. module: purchase_request
+#: model:mail.message.subtype,name:purchase_request.mt_request_picking_done
+msgid "Receipt confirmation"
+msgstr ""
+
+#. module: purchase_request
 #. odoo-python
 #: code:addons/purchase_request/models/stock_move_line.py:0
 msgid "Receipt confirmation for Request {name}"
@@ -994,6 +1009,11 @@ msgstr ""
 #. odoo-python
 #: code:addons/purchase_request/models/purchase_order.py:0
 msgid "Received quantity"
+msgstr ""
+
+#. module: purchase_request
+#: model:mail.message.subtype,description:purchase_request.mt_request_picking_done
+msgid "Receipt is done"
 msgstr ""
 
 #. module: purchase_request

--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -63,7 +63,9 @@ class PurchaseOrder(models.Model):
                 )
                 request.message_post(
                     body=Markup(message),
-                    subtype_id=self.env.ref("mail.mt_note").id,
+                    subtype_id=self.env.ref(
+                        "purchase_request.mt_request_po_confirmed"
+                    ).id,
                 )
         return True
 

--- a/purchase_request/models/stock_move_line.py
+++ b/purchase_request/models/stock_move_line.py
@@ -107,10 +107,13 @@ class StockMoveLine(models.Model):
                     message = self._purchase_request_confirm_done_message_content(
                         message_data
                     )
-                    request.message_post(
-                        body=Markup(message),
-                        subtype_id=self.env.ref("mail.mt_note").id,
-                    )
+                    if message:
+                        request.message_post(
+                            body=Markup(message),
+                            subtype_id=self.env.ref(
+                                "purchase_request.mt_request_picking_done"
+                            ).id,
+                        )
 
                     picking_message = self._picking_confirm_done_message_content(
                         message_data


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/purchase-workflow/pull/2733

Add specific subtypes for using subscribed partners in some messages

The following subtypes have been created:
- Purchase Order confirmation: The email will be sent only to the followers of this subtype.
- Purchase receipt confirmation: The email will be sent only to followers of this subtype.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT56541