### PR TITLE
[15.0][IMP] sale_purchase_secondary_unit: Move method to sale_stock_secondary_unit

### DIFF
--- a/sale_purchase_secondary_unit/models/stock_rule.py
+++ b/sale_purchase_secondary_unit/models/stock_rule.py
@@ -18,11 +18,6 @@ class StockRule(models.Model):
             super(StockRule, self)._get_procurements_to_merge_groupby(procurement),
         )
 
-    def _get_custom_move_fields(self):
-        fields = super(StockRule, self)._get_custom_move_fields()
-        fields.extend(["secondary_uom_id", "secondary_uom_qty"])
-        return fields
-
     @api.model
     def _run_buy(self, procurements):
         return super(


### PR DESCRIPTION
Depends on:
- [x] https://github.com/OCA/sale-workflow/pull/3798

@Tecnativa TT57030

ping @sergio-teruel @CarlosRoca13 