### PR TITLE
[IMP] purchase_order_split_date: let all receipts inherit the PO's partner_id

### DIFF
--- a/purchase_delivery_split_date/models/stock_move.py
+++ b/purchase_delivery_split_date/models/stock_move.py
@@ -67,3 +67,11 @@ class StockMove(models.Model):
                 if not new_picking.partner_id and picking.partner_id:
                     new_picking.partner_id = picking.partner_id
             reserved_moves._action_assign()
+
+    def _get_new_picking_values(self):
+        vals = super()._get_new_picking_values()
+        if self._context.get("purchase_delivery_split_date") and not vals.get(
+            "partner_id"
+        ):
+            vals["partner_id"] = fields.first(self.purchase_line_id.partner_id).id
+        return vals


### PR DESCRIPTION
Proposal to fix the issue described in https://github.com/OCA/purchase-workflow/issues/2746.