### PR TITLE
[17.0][FIX] purchase_request: Prevent unlink of protected mail activity data.

### DIFF
--- a/purchase_request/tests/test_purchase_request_procurement.py
+++ b/purchase_request/tests/test_purchase_request_procurement.py
@@ -104,7 +104,6 @@ class TestPurchaseRequestProcurement(common.TransactionCase):
         self.env["mail.activity"].search(
             [("activity_type_id", "=", activity.id)]
         ).unlink()
-        activity.unlink()
         self.assertFalse(move.created_purchase_request_line_id.request_id.activity_ids)
         move._action_cancel()
         self.assertTrue(move.created_purchase_request_line_id.request_id.activity_ids)


### PR DESCRIPTION
Fix test failure due to protected activity type `mail.mail_activity_data_todo`.

In Odoo 17, core changes prevent the deletion of certain master data like `mail.mail_activity_data_todo`. This PR updates the test to avoid unlinking the activity type.

Ref: [Odoo commit 10d1634, line 172](https://github.com/odoo/odoo/commit/10d16344449fafe1646e085c05233ecab7df48aa#diff-37df585509f3129b2a4473822341a8d5af404cd7a50bb7d2876bdf8472b43d87R172)