### PR TITLE
[18.0][FIX] purchase_advance_payment

### DIFF
--- a/purchase_advance_payment/models/account_move.py
+++ b/purchase_advance_payment/models/account_move.py
@@ -10,6 +10,14 @@ class AccountMove(models.Model):
     def action_post(self):
         # Automatic reconciliation of payment when bill confirmed.
         res = super().action_post()
+        for move in self:
+            # Link advance payments without move_id to the new bill.
+            purchase_order = move.line_ids.purchase_order_id
+            move.matched_payment_ids = purchase_order.account_payment_ids.filtered(
+                lambda p: not p.outstanding_account_id
+                and not p.move_id
+                and not p.invoice_ids
+            )
         if bool(
             self.env["ir.config_parameter"]
             .sudo()

--- a/purchase_advance_payment/models/purchase_order.py
+++ b/purchase_advance_payment/models/purchase_order.py
@@ -79,6 +79,26 @@ class PurchaseOrder(models.Model):
                     )
                 else:
                     advance_amount += line_amount
+            # Compute amount by payments without an account.move related.
+            # Also exclude reconciled pre-payments amount because once reconciled
+            # the pre-payment will reduce bill residual amount like any
+            # other payment.
+            adv_pays = order.account_payment_ids.filtered(
+                lambda x: x.state in ["in_process", "paid"]
+                and not x.is_reconciled
+                and not x.move_id
+            )
+            for line in adv_pays:
+                line_currency = line.currency_id or line.company_currency_id
+                if line_currency != order.currency_id:
+                    advance_amount += line.currency_id._convert(
+                        line.amount,
+                        order.currency_id,
+                        order.company_id,
+                        line.date or fields.Date.today(),
+                    )
+                else:
+                    advance_amount += line.amount
             # Consider payments in related invoices.
             invoice_paid_amount = 0.0
             for inv in order.invoice_ids:

--- a/purchase_advance_payment/models/purchase_order.py
+++ b/purchase_advance_payment/models/purchase_order.py
@@ -80,25 +80,30 @@ class PurchaseOrder(models.Model):
                 else:
                     advance_amount += line_amount
             # Compute amount by payments without an account.move related.
-            # Also exclude reconciled pre-payments amount because once reconciled
-            # the pre-payment will reduce bill residual amount like any
-            # other payment.
             adv_pays = order.account_payment_ids.filtered(
                 lambda x: x.state in ["in_process", "paid"]
-                and not x.is_reconciled
+                and not x.outstanding_account_id
                 and not x.move_id
             )
-            for line in adv_pays:
-                line_currency = line.currency_id or line.company_currency_id
-                if line_currency != order.currency_id:
-                    advance_amount += line.currency_id._convert(
-                        line.amount,
+            for ap in adv_pays:
+                if ap.invoice_ids:
+                    # This is not perfect but it is the best we can do.
+                    # Once the payment is linked to the invoice, it is better
+                    # to not consider it anymore because is not going to be
+                    # reconciled (it has no move_id), otherwise the risk to
+                    # double-count payments is high.
+                    continue
+
+                ap_currency = ap.currency_id or ap.company_currency_id
+                if ap_currency != order.currency_id:
+                    advance_amount += ap_currency._convert(
+                        ap.amount,
                         order.currency_id,
                         order.company_id,
-                        line.date or fields.Date.today(),
+                        ap.date or fields.Date.today(),
                     )
                 else:
-                    advance_amount += line.amount
+                    advance_amount += ap.amount
             # Consider payments in related invoices.
             invoice_paid_amount = 0.0
             for inv in order.invoice_ids:

--- a/purchase_advance_payment/tests/test_purchase_advance_payment.py
+++ b/purchase_advance_payment/tests/test_purchase_advance_payment.py
@@ -770,6 +770,8 @@ class TestPurchaseAdvancePayment(common.TransactionCase):
         self.assertEqual(self.purchase_order_1.advance_payment_status, "paid")
 
     def test_11_advance_payments_without_account_moves(self):
+        """Test full flow with advance payments without outstanding
+        account."""
         self.env["ir.config_parameter"].sudo().set_param(
             "purchase_advance_payment.auto_post_advance_payments", False
         )
@@ -783,7 +785,6 @@ class TestPurchaseAdvancePayment(common.TransactionCase):
             "active_ids": [self.purchase_order_2.id],
             "active_id": self.purchase_order_2.id,
         }
-
         advance_payment_1 = (
             self.env["account.voucher.wizard.purchase"]
             .with_context(**context_payment)
@@ -795,6 +796,19 @@ class TestPurchaseAdvancePayment(common.TransactionCase):
             )
         )
         advance_payment_1.make_advance_payment()
+
+        payment_1 = self.purchase_order_2.account_payment_ids
+        self.assertFalse(payment_1.move_id)
+        self.assertEqual(payment_1.state, "draft")
+        if payment_1.outstanding_account_id:
+            # This is forced by Odoo in EE. See
+            # https://github.com/odoo/odoo/commit/0c2810df991b5ac48483f03d4cd0f5d281ece4b8
+            # for more details. We remove it to simulate,
+            # the case of a payment without journal entry.
+            payment_1.outstanding_account_id = False
+        payment_1.action_post()
+        self.assertFalse(payment_1.move_id)
+        self.assertEqual(payment_1.state, "in_process")
 
         self.assertEqual(self.purchase_order_2.amount_residual, 900)
 
@@ -810,30 +824,35 @@ class TestPurchaseAdvancePayment(common.TransactionCase):
         )
         advance_payment_2.make_advance_payment()
 
+        # In the second payment, we confirm without removing the
+        # outstanding account. In CE, this will create the
+        # journal entry anyway, thefore we test the combination of
+        # payments with and without entry.
+        self.assertEqual(self.purchase_order_2.amount_residual, 900)
+        payment_2 = self.purchase_order_2.account_payment_ids - payment_1
+        self.assertEqual(len(payment_2), 1)
+        payment_2.action_post()
+        self.assertEqual(payment_2.state, "in_process")
+        self.assertTrue(payment_2.move_id)
+
         self.assertEqual(self.purchase_order_2.amount_residual, 700)
 
-        advance_payment_3 = (
-            self.env["account.voucher.wizard.purchase"]
-            .with_context(**context_payment)
-            .create(
-                {
-                    "amount_advance": 250,
-                    "order_id": self.purchase_order_2.id,
-                }
-            )
+        self.purchase_order_2.action_create_invoice()
+        self.assertEqual(self.purchase_order_2.invoice_status, "invoiced")
+        aml = self.env["account.move.line"].search(
+            [("purchase_line_id", "=", self.purchase_order_2.order_line.id)]
         )
-        advance_payment_3.make_advance_payment()
-        self.assertEqual(self.purchase_order_2.amount_residual, 450)
-
-        advance_payment_4 = (
-            self.env["account.voucher.wizard.purchase"]
-            .with_context(**context_payment)
-            .create(
-                {
-                    "amount_advance": 450,
-                    "order_id": self.purchase_order_2.id,
-                }
-            )
+        invoice = aml.mapped("move_id")
+        self.assertEqual(len(invoice), 1)
+        self.assertFalse(invoice.matched_payment_ids)
+        invoice.invoice_date = fields.Date.today()
+        invoice.action_post()
+        # We expect payment_1 linked to the invoice because
+        # it has no move_id.
+        self.assertEqual(invoice.matched_payment_ids, payment_1)
+        self.assertEqual(invoice.amount_residual, 1200)
+        self.assertEqual(
+            self.purchase_order_2.amount_residual,
+            1000,
+            "Only payment 2 should be considered at this point.",
         )
-        advance_payment_4.make_advance_payment()
-        self.assertEqual(self.purchase_order_2.amount_residual, 0)

--- a/purchase_advance_payment/tests/test_purchase_advance_payment.py
+++ b/purchase_advance_payment/tests/test_purchase_advance_payment.py
@@ -768,3 +768,72 @@ class TestPurchaseAdvancePayment(common.TransactionCase):
         )._create_payments()
         self.assertEqual(self.purchase_order_1.amount_residual, 0)
         self.assertEqual(self.purchase_order_1.advance_payment_status, "paid")
+
+    def test_11_advance_payments_without_account_moves(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "purchase_advance_payment.auto_post_advance_payments", False
+        )
+        self.purchase_order_2.button_confirm()
+        self.assertEqual(
+            self.purchase_order_2.amount_residual,
+            1200,
+        )
+
+        context_payment = {
+            "active_ids": [self.purchase_order_2.id],
+            "active_id": self.purchase_order_2.id,
+        }
+
+        advance_payment_1 = (
+            self.env["account.voucher.wizard.purchase"]
+            .with_context(**context_payment)
+            .create(
+                {
+                    "amount_advance": 300,
+                    "order_id": self.purchase_order_2.id,
+                }
+            )
+        )
+        advance_payment_1.make_advance_payment()
+
+        self.assertEqual(self.purchase_order_2.amount_residual, 900)
+
+        advance_payment_2 = (
+            self.env["account.voucher.wizard.purchase"]
+            .with_context(**context_payment)
+            .create(
+                {
+                    "amount_advance": 200,
+                    "order_id": self.purchase_order_2.id,
+                }
+            )
+        )
+        advance_payment_2.make_advance_payment()
+
+        self.assertEqual(self.purchase_order_2.amount_residual, 700)
+
+        advance_payment_3 = (
+            self.env["account.voucher.wizard.purchase"]
+            .with_context(**context_payment)
+            .create(
+                {
+                    "amount_advance": 250,
+                    "order_id": self.purchase_order_2.id,
+                }
+            )
+        )
+        advance_payment_3.make_advance_payment()
+        self.assertEqual(self.purchase_order_2.amount_residual, 450)
+
+        advance_payment_4 = (
+            self.env["account.voucher.wizard.purchase"]
+            .with_context(**context_payment)
+            .create(
+                {
+                    "amount_advance": 450,
+                    "order_id": self.purchase_order_2.id,
+                }
+            )
+        )
+        advance_payment_4.make_advance_payment()
+        self.assertEqual(self.purchase_order_2.amount_residual, 0)

--- a/purchase_advance_payment/views/account_payment_views.xml
+++ b/purchase_advance_payment/views/account_payment_views.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
+    <record id="view_account_payment_form" model="ir.ui.view">
+        <field name="name">account.payment.form - purchase_advance_payment</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form" />
+        <field name="arch" type="xml">
+            <field name="memo" position="after">
+                <field
+                    name="purchase_id"
+                    string="Purchase Order"
+                    invisible="not purchase_id"
+                    readonly="1"
+                />
+            </field>
+        </field>
+    </record>
+
     <record id="view_account_payment_search" model="ir.ui.view">
         <field name="name">account.payment.search</field>
         <field name="model">account.payment</field>
@@ -35,6 +51,11 @@
                     string="Payment Sent?"
                     widget="boolean_toggle"
                     column_invisible="not context.get('show_payment_sent')"
+                />
+                <field
+                    name="purchase_id"
+                    column_invisible="not context.get('show_payment_sent')"
+                    optional="show"
                 />
             </field>
         </field>


### PR DESCRIPTION
The residual amount was not being computed correctly in the scenario where the payment generated does not have an account.move related (when the auto_post_advance_payments was disabled).

Also added test cases to ensure this not happens again.

@LoisRForgeFlow 