### PR TITLE
[IMP] purchase_no_rfq: Complete migration to 17.0

### DIFF
--- a/purchase_no_rfq/README.rst
+++ b/purchase_no_rfq/README.rst
@@ -33,19 +33,19 @@ Quotation' state, simplifying the workflow for the end users.
 
 Once installed :
 
--  The menu item 'Purchase > Purchase > Requests for Quotation' is
-   hidden. A single menu item 'Purchase Order' is available
--  The states names of the purchase order is altered. 'RFQ' is replaced
-   by 'Draft' and 'RFQ sent' by 'Sent'.
--  The colors in the tree view is correctly set to ``decoration-info``
-   for 'draft' and 'sent' orders.
+- The menu item 'Purchase > Purchase > Requests for Quotation' is
+  hidden. A single menu item 'Purchase Order' is available
+- The states names of the purchase order is altered. 'RFQ' is replaced
+  by 'Draft' and 'RFQ sent' by 'Sent'.
+- The colors in the tree view is correctly set to ``decoration-info``
+  for 'draft' and 'sent' orders.
 
 |image1|
 
--  In the form view, all the RFQ names are removed or replaced by
-   'Purchase Order'. The module makes also the 'Print' button allways
-   available and not only on 'draft' and 'sent' status.
--  The option 'Print > Request For quotation' is also disabled.
+- In the form view, all the RFQ names are removed or replaced by
+  'Purchase Order'. The module makes also the 'Print' button allways
+  available and not only on 'draft' and 'sent' status.
+- The option 'Print > Request For quotation' is also disabled.
 
 |image2|
 
@@ -78,10 +78,12 @@ Authors
 Contributors
 ------------
 
--  Sylvain LE GAL <https://twitter.com/legalsylvain>
--  `Binhex <https://binhex.cloud/>`__:
+- Sylvain LE GAL <https://twitter.com/legalsylvain>
+- `Binhex <https://binhex.cloud/>`__:
 
-   -  Deriman Alonso
+  - Deriman Alonso
+
+- Alejandro Parrales <alejandro17parrales@gmail.com>
 
 Maintainers
 -----------

--- a/purchase_no_rfq/hooks.py
+++ b/purchase_no_rfq/hooks.py
@@ -2,17 +2,14 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api
-
 
 def uninstall_hook(env):
-    with api.Environment.manage():
-        # Unhide menu item for request for quotation and restore sequence
-        env.ref("purchase.menu_purchase_rfq").write(
-            {
-                "groups_id": [(5,)],
-                "sequence": 0,
-            }
-        )
-        # ReCreate ir.actions.report
-        env.ref("purchase.report_purchase_quotation").create_action()
+    # Unhide menu item for request for quotation and restore sequence
+    env.ref("purchase.menu_purchase_rfq").write(
+        {
+            "groups_id": [(5,)],
+            "sequence": 0,
+        }
+    )
+    # ReCreate ir.actions.report
+    env.ref("purchase.report_purchase_quotation").create_action()

--- a/purchase_no_rfq/models/purchase_order.py
+++ b/purchase_no_rfq/models/purchase_order.py
@@ -12,6 +12,8 @@ class PurchaseOrder(models.Model):
     state = fields.Selection(selection_add=[("draft", "Draft"), ("sent", "Sent")])
 
     def print_quotation(self):
+        # Allows printing orders in 'draft' state by changing them to 'sent'
+        # before generating the report.
         orders = self.filtered(lambda x: x.state == "draft")
         orders.write({"state": "sent"})
         report = self.env.ref("purchase.action_report_purchase_order")

--- a/purchase_no_rfq/readme/CONTRIBUTORS.md
+++ b/purchase_no_rfq/readme/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 - Sylvain LE GAL \<<https://twitter.com/legalsylvain>\>
 - [Binhex](https://binhex.cloud/):
     -   Deriman Alonso
+- Alejandro Parrales \<<alejandro17parrales@gmail.com>\>

--- a/purchase_no_rfq/static/description/index.html
+++ b/purchase_no_rfq/static/description/index.html
@@ -425,6 +425,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Deriman Alonso</li>
 </ul>
 </li>
+<li>Alejandro Parrales &lt;<a class="reference external" href="mailto:alejandro17parrales&#64;gmail.com">alejandro17parrales&#64;gmail.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/purchase_no_rfq/views/view_purchase_order.xml
+++ b/purchase_no_rfq/views/view_purchase_order.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="view_purchase_order_tree" model="ir.ui.view">
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_view_tree" />
@@ -10,7 +9,7 @@
                 <attribute name="decoration-info">state in ('draft','sent')</attribute>
             </xpath>
             <field name="state" position="attributes">
-                <attribute name="invisible">0</attribute>
+                <attribute name="column_invisible">0</attribute>
                 <attribute name="optional">show</attribute>
                 <attribute name="widget">badge</attribute>
                 <attribute
@@ -21,15 +20,12 @@
                     name="decoration-success"
                 >state == 'purchase' or state == 'done'</attribute>
             </field>
-            <field name="date_order" position="attributes">
+             <field name="date_order" position="attributes">
                 <attribute name="widget">remaining_days</attribute>
-                <attribute
-                    name="invisible"
-                >state in ('purchase', 'done', 'cancel')</attribute>
+                <attribute name="column_invisible">0</attribute>
             </field>
         </field>
     </record>
-
 
     <record id="purchase_order_form" model="ir.ui.view">
         <field name="model">purchase.order</field>
@@ -61,15 +57,12 @@
             >
                 <attribute name="string">Print</attribute>
             </xpath>
-
-            <!-- Add a print button, displayed in non draft and sent states -->
-            <xpath expr="/form/header/button[@name='print_quotation']" position="after">
-                    <button
-                    name="print_quotation"
-                    string="Print"
-                    type="object"
-                    groups="base.group_user"
-                />
+            <xpath
+                expr="/form/header/button[@name='print_quotation'][last()]"
+                position="attributes"
+            >
+                <attribute name="string">Print</attribute>
+                <attribute name="invisible">state=='draft'</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This PR completes the migration of purchase_no_rfq to Odoo 17.0, fixing issues in views and uninstall hooks.
- Fixes decoration and visibility attributes in tree and form views.
- Cleans up uninstall hook logic.
- The Print button now follows a clearer logic: it is hidden in draft state, avoiding the need to show both buttons at once.
![PR Purchase_no_rfq](https://github.com/user-attachments/assets/6bf6caea-c524-4f88-99c6-7f2ba2cadeac)
