### PR TITLE
[16.0][IMP] purchase_tier_validation + purchase_request_tier_validation + purchase_requisition_tier_validation: Change the use of the validated field to validation_status

### DIFF
--- a/purchase_request_tier_validation/views/purchase_request_view.xml
+++ b/purchase_request_tier_validation/views/purchase_request_view.xml
@@ -45,7 +45,7 @@
                     <filter
                         name="tier_validated"
                         string="Validated"
-                        domain="[('validated', '=', True)]"
+                        domain="[('validation_status', '=', 'validated')]"
                         help="Purchase Requests validated and ready to be confirmed"
                     />
                 </group>

--- a/purchase_requisition_tier_validation/views/purchase_requisition_view.xml
+++ b/purchase_requisition_tier_validation/views/purchase_requisition_view.xml
@@ -19,7 +19,7 @@
                 <filter
                     name="tier_validated"
                     string="Validated"
-                    domain="[('validated', '=', True)]"
+                    domain="[('validation_status', '=', 'validated')]"
                     help="Purchase Agreements validated and ready to be confirmed"
                 />
             </filter>

--- a/purchase_tier_validation/views/purchase_order_view.xml
+++ b/purchase_tier_validation/views/purchase_order_view.xml
@@ -18,7 +18,7 @@
                 <filter
                     name="tier_validated"
                     string="Validated"
-                    domain="[('validated', '=', True)]"
+                    domain="[('validation_status', '=', 'validated')]"
                     help="POs validated and ready to be confirmed"
                 />
             </filter>


### PR DESCRIPTION
Change the use of the validated field to validation_status

Related to https://github.com/OCA/server-ux/pull/1084

Locked by:
- [x] `base_tier_validation`: https://github.com/OCA/server-ux/pull/1084

Please @pedrobaeza can you review it?

@Tecnativa