### PR TITLE
[18.0][FIX] purchase_request: Prevent errors in migration script

### DIFF
--- a/purchase_request/migrations/18.0.2.2.0/pre-migration.py
+++ b/purchase_request/migrations/18.0.2.2.0/pre-migration.py
@@ -11,7 +11,10 @@ _noupdate_xmlids = [
 
 
 @openupgrade.migrate()
-def migrate(env, version):
+def migrate(cr, version):
+    # Workaround to execute the migration script without errors
+    # see https://github.com/odoo/odoo/blob/2a839ef1ed09c36f27ce7536ca3052d9f65ceed9/odoo/modules/migration.py#L252-L256
+    env = cr
     openupgrade.set_xml_ids_noupdate_value(
         env, "purchase_request", _noupdate_xmlids, True
     )


### PR DESCRIPTION
Odoo in V18 raises an error if the signature of the function is not strictly (cr, version). See: https://github.com/odoo/odoo/blob/2a839ef1ed09c36f27ce7536ca3052d9f65ceed9/odoo/modules/migration.py#L252-L256

This solves the error reported in: https://github.com/OCA/purchase-workflow/pull/2727#pullrequestreview-3073770181

@Tecnativa @pedrobaeza @victoralmau @StefanRijnhart could you please review this?