### PR TITLE
[FIX]purchase_all_shipments:multi-steps route

### DIFF
--- a/purchase_all_shipments/models/__init__.py
+++ b/purchase_all_shipments/models/__init__.py
@@ -1,1 +1,2 @@
 from . import purchase_order
+from . import stock_move

--- a/purchase_all_shipments/models/purchase_order.py
+++ b/purchase_all_shipments/models/purchase_order.py
@@ -19,9 +19,18 @@ class PurchaseOrder(models.Model):
 
     def _compute_all_pickings(self):
         for rec in self:
+            all_picking_ids = self.env["stock.picking"]
             groups = rec.mapped("picking_ids.group_id")
-            all_picking_ids = self.env["stock.picking"].search(
-                [("group_id", "in", groups.ids)]
+            if groups:
+                group_pickings = self.env["stock.picking"].search(
+                    [("group_id", "in", groups.ids)]
+                )
+                all_picking_ids |= group_pickings
+            # add pickings connected by move_orig_ids (multi-steps) - recursively
+            all_picking_ids |= (
+                rec.mapped("order_line.move_ids")
+                ._get_move_dest_ids()
+                .mapped("picking_id")
             )
             rec.all_picking_ids = all_picking_ids
 

--- a/purchase_all_shipments/models/stock_move.py
+++ b/purchase_all_shipments/models/stock_move.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_move_dest_ids(self):
+        """Recursively get all destination moves"""
+        res = self.filtered("move_dest_ids").mapped("move_dest_ids")
+        if res.filtered("move_dest_ids"):
+            res |= res.filtered("move_dest_ids")._get_move_dest_ids()
+        return res


### PR DESCRIPTION
Problem
The _compute_all_pickings method in purchase_all_shipments module fails to include intermediate pickings when a Purchase Order is automatically created by orderpoint rules using multi-step routes.

Root Cause: When a PO is created through orderpoint automation, the intermediate pickings in multi-step routes are not properly linked via move_orig_ids at computation time, causing them to be excluded from the all_picking_ids field.

Impact:

Users cannot view all related pickings for automatically generated POs
Affects visibility and tracking of complete fulfillment process
Only occurs with orderpoint-generated POs; manually created POs work correctly

Reproduction:

Configure multi-step routes (e.g., Buy → Input → Stock)
Set up orderpoint rules
Let orderpoint create PO automatically
Check "All Pickings" - intermediate steps are missing
This issue is reproducible in RUNBOAT v16