### PR TITLE
[16.0][UPD] purchase_force_invoiced_quantity : rename force_invoiced to force_invoiced_qty

### DIFF
--- a/purchase_force_invoiced_quantity/__manifest__.py
+++ b/purchase_force_invoiced_quantity/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Purchase Force Invoiced Quantity",
     "summary": "Add manual invoice quantity in purchase order lines",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "author": "Cetmix, Odoo Community Association (OCA)",
     "category": "Purchase Management",
     "license": "AGPL-3",

--- a/purchase_force_invoiced_quantity/demo/demo_purchase_order.xml
+++ b/purchase_force_invoiced_quantity/demo/demo_purchase_order.xml
@@ -9,7 +9,7 @@
         <field name="order_id" ref="so_purchase_force_invoiced_qty_1" />
         <field name="product_id" ref="demo_product_purchase_force_invoiced_qty_1" />
         <field name="product_uom_qty">5</field>
-        <field name="force_invoiced">3</field>
+        <field name="force_invoiced_qty">3</field>
         <field name="price_unit">295.00</field>
     </record>
 
@@ -17,7 +17,7 @@
         <field name="order_id" ref="so_purchase_force_invoiced_qty_1" />
         <field name="product_id" ref="demo_product_purchase_force_invoiced_qty_2" />
         <field name="product_uom_qty">5</field>
-        <field name="force_invoiced">0</field>
+        <field name="force_invoiced_qty">0</field>
         <field name="price_unit">145.00</field>
     </record>
 

--- a/purchase_force_invoiced_quantity/migrations/16.0.1.1.0/pre-migration.py
+++ b/purchase_force_invoiced_quantity/migrations/16.0.1.1.0/pre-migration.py
@@ -1,0 +1,58 @@
+# Copyright 2025 ForgeFlow
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate_force_invoiced_to_force_invoiced_qty(cr):
+    cr.execute(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = 'purchase_order_line'
+        AND column_name = 'force_invoiced'
+        """
+    )
+    old_field_exists = cr.fetchone()
+    cr.execute(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = 'purchase_order_line'
+        AND column_name = 'force_invoiced_qty'
+        """
+    )
+    new_field_exists = cr.fetchone() is not None
+    if old_field_exists and not new_field_exists:
+        _logger.info(
+            "Migrating force_invoiced field to force_invoiced_qty in purchase_order_line"
+        )
+        cr.execute(
+            """
+            ALTER TABLE purchase_order_line
+            ADD COLUMN IF NOT EXISTS force_invoiced_qty numeric DEFAULT 0.0
+            """
+        )
+        cr.execute(
+            """
+            UPDATE purchase_order_line
+            SET force_invoiced_qty = COALESCE(force_invoiced, 0.0)
+            WHERE force_invoiced IS NOT NULL
+            """
+        )
+        cr.execute(
+            "ALTER TABLE purchase_order_line DROP COLUMN IF EXISTS force_invoiced"
+        )
+        _logger.info("Successfully migrated force_invoiced to force_invoiced_qty")
+    elif new_field_exists:
+        _logger.info("Field force_invoiced_qty already exists, skipping migration")
+    else:
+        _logger.info(
+            "No force_invoiced field found in purchase_order_line, skipping migration"
+        )
+
+
+def migrate(cr, version):
+    migrate_force_invoiced_to_force_invoiced_qty(cr)

--- a/purchase_force_invoiced_quantity/migrations/16.0.1.1.0/pre-migration.py
+++ b/purchase_force_invoiced_quantity/migrations/16.0.1.1.0/pre-migration.py
@@ -3,55 +3,26 @@
 
 import logging
 
+from odoo.tools.sql import column_exists
+
 _logger = logging.getLogger(__name__)
 
 
 def migrate_force_invoiced_to_force_invoiced_qty(cr):
-    cr.execute(
-        """
-        SELECT column_name
-        FROM information_schema.columns
-        WHERE table_name = 'purchase_order_line'
-        AND column_name = 'force_invoiced'
-        """
-    )
-    old_field_exists = cr.fetchone()
-    cr.execute(
-        """
-        SELECT column_name
-        FROM information_schema.columns
-        WHERE table_name = 'purchase_order_line'
-        AND column_name = 'force_invoiced_qty'
-        """
-    )
-    new_field_exists = cr.fetchone() is not None
+    old_field_exists = column_exists(cr, "purchase_order_line", "force_invoiced")
+    new_field_exists = column_exists(cr, "purchase_order_line", "force_invoiced_qty")
     if old_field_exists and not new_field_exists:
         _logger.info(
-            "Migrating force_invoiced field to force_invoiced_qty in purchase_order_line"
+            "Renaming force_invoiced field to force_invoiced_qty in purchase_order_line"
         )
         cr.execute(
-            """
-            ALTER TABLE purchase_order_line
-            ADD COLUMN IF NOT EXISTS force_invoiced_qty numeric DEFAULT 0.0
-            """
+            "ALTER TABLE purchase_order_line RENAME COLUMN force_invoiced TO force_invoiced_qty"
         )
-        cr.execute(
-            """
-            UPDATE purchase_order_line
-            SET force_invoiced_qty = COALESCE(force_invoiced, 0.0)
-            WHERE force_invoiced IS NOT NULL
-            """
-        )
-        cr.execute(
-            "ALTER TABLE purchase_order_line DROP COLUMN IF EXISTS force_invoiced"
-        )
-        _logger.info("Successfully migrated force_invoiced to force_invoiced_qty")
-    elif new_field_exists:
+        _logger.info("Successfully renamed force_invoiced to force_invoiced_qty")
+    if new_field_exists:
         _logger.info("Field force_invoiced_qty already exists, skipping migration")
-    else:
-        _logger.info(
-            "No force_invoiced field found in purchase_order_line, skipping migration"
-        )
+    if not old_field_exists:
+        _logger.info("Field force_invoiced does not exist, skipping migration")
 
 
 def migrate(cr, version):

--- a/purchase_force_invoiced_quantity/models/purchase_order_line.py
+++ b/purchase_force_invoiced_quantity/models/purchase_order_line.py
@@ -7,27 +7,27 @@ from odoo import api, fields, models
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
-    force_invoiced = fields.Float(
+    force_invoiced_qty = fields.Float(
         digits="Product Unit of Measure",
         help=(
             "This amount will be deducted from quantity to invoice."
-            "\nquantity to invoice = delivered - invoiced - force invoiced"
+            "\nquantity to invoice = delivered - invoiced - force invoiced qty"
         ),
     )
 
-    @api.depends("force_invoiced")
+    @api.depends("force_invoiced_qty")
     def _compute_qty_invoiced(self):
         """
         Compute the quantity to invoice.
         """
         res = super()._compute_qty_invoiced()
-        for line in self.filtered(lambda l: l.force_invoiced):
+        for line in self.filtered(lambda l: l.force_invoiced_qty):
             # compute qty_to_invoice
             if (
                 line.order_id.state in ["purchase", "done"]
                 and line.product_id.purchase_method != "purchase"
             ):
                 line.qty_to_invoice = (
-                    line.qty_received - line.qty_invoiced - line.force_invoiced
+                    line.qty_received - line.qty_invoiced - line.force_invoiced_qty
                 )
         return res

--- a/purchase_force_invoiced_quantity/static/description/index.html
+++ b/purchase_force_invoiced_quantity/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -437,9 +436,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/purchase_force_invoiced_quantity/tests/test_purchase_force_invoiced_quantity.py
+++ b/purchase_force_invoiced_quantity/tests/test_purchase_force_invoiced_quantity.py
@@ -49,7 +49,7 @@ class TestPurchaseForceInvoicedQTY(TransactionCase):
         pol1.qty_received = 1
         pol2.qty_received = 2
 
-        pol2.force_invoiced = 3
+        pol2.force_invoiced_qty = 3
         self.assertEqual(
             pol2.qty_to_invoice, -1, msg="The quantity to invoice should be -1"
         )

--- a/purchase_force_invoiced_quantity/views/purchase_order.xml
+++ b/purchase_force_invoiced_quantity/views/purchase_order.xml
@@ -11,7 +11,7 @@
                 position="after"
             >
                 <field
-                    name="force_invoiced"
+                    name="force_invoiced_qty"
                     optional="show"
                     attrs="{'column_invisible': [('parent.state', 'not in', ['purchase', 'done'])], 'readonly': [('parent.state', 'not in', ['purchase', 'done'])]}"
                 />


### PR DESCRIPTION
This PR adds a pre-migration script to rename the field `force_invoiced` to `force_invoiced_qty` in `purchase_order_line` in this module.
The reason is to avoid having two fields with the same name across different modules.   https://github.com/OCA/purchase-workflow/pull/2792
Since the field stores a float value, it is more appropriate to use the `_qty` suffix in this one.

As this field was originally introduced by @dessanhemrayev , tagging you here in case you’d like to review and confirm that this change makes sense from your perspective.
