### PR TITLE
[16.0][FIX] Avoid repetition of lines at reception

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -303,7 +303,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         new_qty = self.env["purchase.request.line"]._calc_new_qty(
             line, po_line=po_line, new_pr_line=new_pr_line
         )
-        po_line.product_qty = new_qty
+        po_line.write({"product_qty": new_qty, 'date_planned': fields.Datetime.now()})
         if item.keep_estimated_cost:
             po_line.price_unit = price_unit
             po_line._compute_amount()


### PR DESCRIPTION
This change prevents the creation of lines when receiving products. This will also prevent inventory valuation from being corrupted, such that if there is more than one line (stock.move), the valuation will be incorrect when the purchase order has been invoiced previously.

Before
https://github.com/user-attachments/assets/64041144-a51f-47d4-a401-bc69f9844341

After
https://github.com/user-attachments/assets/be2eb62a-dff3-4794-8bf9-ef5c509cfd73

