### PR TITLE
[16.0][FIX] Avoid repetition of lines at reception

### DIFF
--- a/purchase_request/tests/test_purchase_request.py
+++ b/purchase_request/tests/test_purchase_request.py
@@ -118,6 +118,7 @@ class TestPurchaseRequest(TransactionCase):
         with self.assertRaises(UserError):
             purchase_request_line.unlink()
         purchase = purchase_request_line.purchase_lines.order_id
+        purchase_request_line.purchase_lines.price_unit = 100.0
         purchase.button_done()
         self.assertEqual(purchase.state, "done")
 

--- a/purchase_request/tests/test_purchase_request_allocation.py
+++ b/purchase_request/tests/test_purchase_request_allocation.py
@@ -70,10 +70,11 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
             active_ids=[purchase_request_line1.id, purchase_request_line2.id],
         ).create(vals)
         wiz_id.make_purchase_order()
+        (
+            purchase_request_line1 + purchase_request_line2
+        ).purchase_lines.price_unit = 100.0
         purchase_request1.action_view_purchase_order()
         po_line = purchase_request_line1.purchase_lines[0]
-        # Add unit price in PO Line
-        po_line.write({"price_unit": 10})
         purchase = po_line.order_id
         purchase.order_line.action_open_request_line_tree_view()
         purchase.button_confirm()
@@ -157,10 +158,9 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
             active_model="purchase.request.line", active_ids=[purchase_request_line1.id]
         ).create(vals)
         wiz_id.make_purchase_order()
+        purchase_request_line1.purchase_lines.price_unit = 100.0
         purchase_request1.action_view_purchase_order()
         po_line = purchase_request_line1.purchase_lines[0]
-        # Add unit price in PO Line
-        po_line.write({"price_unit": 10})
         purchase = po_line.order_id
         purchase.button_confirm()
         self.assertEqual(purchase_request_line1.qty_in_progress, 2.0)
@@ -191,6 +191,7 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
             active_model="purchase.request.line", active_ids=[purchase_request_line2.id]
         ).create(vals)
         wiz_id.make_purchase_order()
+        purchase_request_line2.purchase_lines.price_unit = 100.0
         (purchase_request1 + purchase_request2).action_view_purchase_order()
         po_line = purchase_request_line2.purchase_lines[0]
         purchase2 = po_line.order_id
@@ -229,6 +230,7 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
             active_model="purchase.request.line", active_ids=[purchase_request_line1.id]
         ).create(vals)
         wiz_id.make_purchase_order()
+        purchase_request_line1.purchase_lines.price_unit = 100.0
         self.assertEqual(
             purchase_request_line1.purchase_request_allocation_ids[0].open_product_qty,
             2.0,
@@ -265,6 +267,9 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
         ).create(vals)
         # Create PO
         wiz_id.make_purchase_order()
+        (
+            purchase_request_line1 + purchase_request_line2
+        ).purchase_lines.price_unit = 100.0
         po_line = purchase_request_line1.purchase_lines[0]
         self.assertEqual(po_line.product_qty, 2, "Quantity should be 2")
         self.assertEqual(
@@ -349,6 +354,7 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
         ).create(vals)
         # Create PO
         wiz_id.make_purchase_order()
+        purchase_request_line1.purchase_lines.price_unit = 100.0
         po_line = purchase_request_line1.purchase_lines[0]
         self.assertEqual(
             purchase_request_line1.purchase_request_allocation_ids[

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -303,17 +303,17 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         new_qty = self.env["purchase.request.line"]._calc_new_qty(
             line, po_line=po_line, new_pr_line=new_pr_line
         )
-        po_line.product_qty = new_qty
-        if item.keep_estimated_cost:
-            po_line.price_unit = price_unit
-            po_line._compute_amount()
         # The quantity update triggers a compute method that alters the
         # unit price (which is what we want, to honor graduate pricing)
         # but also the scheduled date which is what we don't want.
         date_required = line.date_required
-        po_line.date_planned = datetime(
+        date_planned = datetime(
             date_required.year, date_required.month, date_required.day
         )
+        po_line.write({"product_qty": new_qty, "date_planned": date_planned})
+        if item.keep_estimated_cost:
+            po_line.price_unit = price_unit
+            po_line._compute_amount()
 
 
 class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):


### PR DESCRIPTION


This change prevents the creation of lines when receiving products. This will also prevent inventory valuation from being corrupted, such that if there is more than one line (stock.move), the valuation will be incorrect when the purchase order has been invoiced previously.

Before
https://github.com/user-attachments/assets/64041144-a51f-47d4-a401-bc69f9844341

After
https://github.com/user-attachments/assets/be2eb62a-dff3-4794-8bf9-ef5c509cfd73
