### PR TITLE
[18.0][FIX] Duplicate stock.move damages inventory valuation

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -291,7 +291,7 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             new_qty = pr_line_obj._calc_new_qty(
                 line, po_line=po_line, new_pr_line=new_pr_line
             )
-            po_line.product_qty = new_qty
+            po_line.write({"product_qty": new_qty, 'date_planned': fields.Datetime.now()})
             # The quantity update triggers a compute method that alters the
             # unit price (which is what we want, to honor graduate pricing)
             # but also the scheduled date which is what we don't want.


### PR DESCRIPTION
This change prevents the creation of lines when receiving products. This will also prevent inventory valuation from being corrupted, such that if there is more than one line (stock.move), the valuation will be incorrect when the purchase order has been invoiced previously.

Before

https://github.com/user-attachments/assets/07d42f2c-db36-4993-a0d3-0ff26302ce5a

After


https://github.com/user-attachments/assets/a61ed923-05b8-4aaf-a532-49239080880e

