### PR TITLE
[17.0][IMP] purchase_stock_price_unit_sync: Avoid create adjustment svl when product_cost_price_avco_sync is installed

### DIFF
--- a/purchase_stock_price_unit_sync/__manifest__.py
+++ b/purchase_stock_price_unit_sync/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Purchase stock price unit sync",
     "summary": "Update cost price in stock moves already done",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "category": "Purchase",
     "website": "https://github.com/OCA/purchase-workflow",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/purchase_stock_price_unit_sync/migrations/17.0.1.0.1/pre-migration.py
+++ b/purchase_stock_price_unit_sync/migrations/17.0.1.0.1/pre-migration.py
@@ -1,0 +1,14 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if env["ir.module.module"].search(
+        [("name", "=", "product_cost_price_avco_sync"), ("state", "=", "installed")]
+    ):
+        # Delete adjustment svl's when product_cost_price_avco_sync is installed
+        openupgrade.logged_query(
+            env.cr,
+            "DELETE FROM stock_valuation_layer WHERE account_move_id IS NOT NULL",
+        )

--- a/purchase_stock_price_unit_sync/models/__init__.py
+++ b/purchase_stock_price_unit_sync/models/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import account_move_line
 from . import purchase_order

--- a/purchase_stock_price_unit_sync/models/account_move_line.py
+++ b/purchase_stock_price_unit_sync/models/account_move_line.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Tecnativa - Carlos Roca
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _generate_price_difference_vals(self, layers):
+        # Remove svl_vals_list returned by the original module when
+        # product_cost_price_avco_sync is installed because it will
+        # make the synchronization.
+        if self.env["ir.module.module"].search(
+            [("name", "=", "product_cost_price_avco_sync"), ("state", "=", "installed")]
+        ):
+            return [[], []]
+        return super()._generate_price_difference_vals(layers)


### PR DESCRIPTION
When product_cost_price_avco_sync is installed, the synchronization is done by that module, so it is not necessary to create an adjustment svl to correct the price using the invoices.

cc @Tecnativa TT58144

ping @pedrobaeza @carlosdauden 