### PR TITLE
[17.0][FWP][ADD] purchase_invoice_status_line: reintroduce post_init_hook

### DIFF
--- a/purchase_invoice_status_line/__init__.py
+++ b/purchase_invoice_status_line/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/purchase_invoice_status_line/__manifest__.py
+++ b/purchase_invoice_status_line/__manifest__.py
@@ -14,6 +14,7 @@
         "purchase_force_invoiced",
         "purchase_order_line_menu",
     ],
+    "post_init_hook": "post_init_hook",
     "data": [
         "views/purchase_order_line_views.xml",
     ],

--- a/purchase_invoice_status_line/hooks.py
+++ b/purchase_invoice_status_line/hooks.py
@@ -1,0 +1,12 @@
+def post_init_hook(env):
+    lines_to_update = env["purchase.order.line"].search(
+        [
+            ("force_invoiced", "=", False),
+            ("order_id.force_invoiced", "=", True),
+        ]
+    )
+    if lines_to_update:
+        lines_to_update.write({"force_invoiced": True})
+    all_lines = env["purchase.order.line"].search([])
+    for line in all_lines:
+        line._compute_invoice_status()


### PR DESCRIPTION
Reintroduces post_init_hook according this conversation: https://github.com/OCA/purchase-workflow/pull/2792#discussion_r2352015852