### PR TITLE
[18.0][FIX] purchase_manual_currency: assign amount_total_cc using total_company_currency

### DIFF
--- a/purchase_manual_currency/models/purchase.py
+++ b/purchase_manual_currency/models/purchase.py
@@ -5,6 +5,7 @@ from lxml import etree
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import formatLang
 
 
 class PurchaseOrder(models.Model):
@@ -37,6 +38,27 @@ class PurchaseOrder(models.Model):
         compute="_compute_currency_diff",
         store=True,
     )
+
+    @api.depends_context("lang")
+    @api.depends(
+        "order_line.price_subtotal",
+        "currency_id",
+        "company_id",
+        "total_company_currency",
+    )
+    def _compute_tax_totals(self):
+        super()._compute_tax_totals()
+        # Add amount_total_cc to tax_totals to show total in company currency
+        for order in self:
+            if order.currency_id != order.company_currency_id:
+                amount_cc = formatLang(
+                    self.env,
+                    order.total_company_currency,
+                    currency_obj=self.company_currency_id,
+                )
+                order.tax_totals["amount_total_cc"] = f"({amount_cc})"
+                order.amount_total_cc = order.total_company_currency
+        return
 
     @api.depends("currency_id")
     def _compute_currency_diff(self):


### PR DESCRIPTION
1. Company currency is USD and CNY rate = 8.755600 CNY per USD
<img width="1667" height="118" alt="image" src="https://github.com/user-attachments/assets/9b2ed080-0028-40e0-a9bc-5733b5c72730" />

2. Create RFQ with Manual Currency as you can see, tax summarization displays total amount in company currency using rate in Currency not the manual currency rate
<img width="1708" height="777" alt="image" src="https://github.com/user-attachments/assets/6e948e1b-5fd1-4038-9863-4fc79cbecfaf" />

Fixed:
Reassign `tax_totals["amount_total_cc"]` with `total_company_currency`
