### PR TITLE
[18.0][FIX] purchase_delivery_split_date: fix dropship pick partner

### DIFF
--- a/purchase_delivery_split_date/models/stock_move.py
+++ b/purchase_delivery_split_date/models/stock_move.py
@@ -67,8 +67,18 @@ class StockMove(models.Model):
 
     def _get_new_picking_values(self):
         vals = super()._get_new_picking_values()
-        if self.env.context.get("purchase_delivery_split_date") and not vals.get(
-            "partner_id"
-        ):
-            vals["partner_id"] = fields.first(self.purchase_line_id.partner_id).id
+        if self.env.context.get("purchase_delivery_split_date"):
+            is_dropship = all([move._is_dropshipped() for move in self])
+            if not vals.get("partner_id") or is_dropship:
+                vals["partner_id"] = fields.first(self.purchase_line_id.partner_id).id
+        return vals
+
+    def _assign_picking_values(self, picking):
+        vals = super()._assign_picking_values(picking)
+        # The core function will remove the partner from the picking if it is
+        # different than the one on the moves (Destination Address).
+        # For dropshipping the partner on the pick is the contact !
+        if self.env.context.get("purchase_delivery_split_date"):
+            if "partner_id" in vals.keys():
+                vals.pop("partner_id")
         return vals

--- a/purchase_delivery_split_date/tests/test_purchase_delivery.py
+++ b/purchase_delivery_split_date/tests/test_purchase_delivery.py
@@ -380,3 +380,27 @@ class TestDeliverySingle(BaseCommon):
                 self.po.dest_address_id,
                 f"Picking {picking.name} partner_id must match the PO dest_address_id",
             )
+
+    def test_picking_partner_dropship(self):
+        """Ensure pickings for dropship PO have the correct partner_id."""
+        location_customer = self.env.ref("stock.stock_location_customers")
+        dropship_customer = self.env["res.partner"].create(
+            {"name": "Dropship Customer"}
+        )
+        dropship_partner = self.env["res.partner"].create({"name": "Dropship Partner"})
+        self.po.dest_address_id = dropship_customer
+        self.po.partner_id = dropship_partner
+        self.po.button_confirm()
+        # Because the module `stock_dropshipping is not a dependency
+        # We need to fake a dropshipping PO by changing the destination location
+        # On the operation type and the picking and moves.
+        self.po.picking_ids.picking_type_id.default_location_dest_id = location_customer
+        self.po.picking_ids.location_dest_id = location_customer
+        # Change the date to trigger a new picking
+        self.po.order_line[0].date_planned = self.date_later
+        for picking in self.po.picking_ids:
+            self.assertEqual(
+                picking.partner_id,
+                dropship_partner,
+                f"Picking {picking.name} partner_id must match the dropship address",
+            )


### PR DESCRIPTION
Before this change, for dropship purchase orders when new pickings are created the contact on the new picking is not correct. And actually different than the one set on the original picking.