### PR TITLE
[18.0][FIX] purchase_request: fix migration script for enterprise migration

### DIFF
--- a/purchase_request/migrations/18.0.1.0.0/post-migration.py
+++ b/purchase_request/migrations/18.0.1.0.0/post-migration.py
@@ -5,6 +5,7 @@ from openupgradelib import openupgrade, openupgrade_180
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade_180.convert_company_dependent(
-        env, "product.template", "purchase_request"
-    )
+    if openupgrade.table_exists(env.cr, "ir_property"):
+        openupgrade_180.convert_company_dependent(
+            env, "product.template", "purchase_request"
+        )


### PR DESCRIPTION
If you are migrating using the enterprise service, the table ir_property is already converted and deleted. Also the conversion to company_dependent is done for all the fields in that service too. So when trying to access the table in the openupgrade process it raises an exception. So I'm adding a condition to ensure this table still exists and being able to do the migration with both services!