### PR TITLE
[18.0][FIX] purchase_request: not force 0 price

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -177,7 +177,6 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             "order_id": po.id,
             "product_id": product.id,
             "product_uom": product.uom_po_id.id or product.uom_id.id,
-            "price_unit": 0.0,
             "product_qty": qty,
             "analytic_distribution": item.line_id.analytic_distribution,
             "purchase_request_lines": [(4, item.line_id.id)],


### PR DESCRIPTION
When purchase order line values are generated via wizard, if 0 price is forced, it sometimes can be not recomputed, even if quantity is updated after creation. This causes forced 0 price, when actual price should not be 0.