### PR TITLE
[16.0][FIX] purchase_deposit: fixes account.tax access error in a multi company environment

### DIFF
--- a/purchase_deposit/wizard/purchase_make_invoice_advance.py
+++ b/purchase_deposit/wizard/purchase_make_invoice_advance.py
@@ -56,7 +56,9 @@ class PurchaseAdvancePaymentInv(models.TransientModel):
     def _compute_deposit_account_id(self):
         product = self.purchase_deposit_product_id
         self.deposit_account_id = product.property_account_expense_id
-        self.deposit_taxes_id = product.supplier_taxes_id
+        self.deposit_taxes_id = product.supplier_taxes_id.filtered(
+            lambda tx: tx.company_id == self.env.company
+        )
 
     def _prepare_deposit_val(self, order, po_line, amount):
         ir_property_obj = self.env["ir.property"]


### PR DESCRIPTION
Solves access error when creating a Deposit invoice, because it was getting all the product taxes of the existing companies.
<img width="1532" height="402" alt="image" src="https://github.com/user-attachments/assets/624d5959-c417-496f-9d21-0d62ceebdbb4" />
