### PR TITLE
[17.0] Fix tests

### DIFF
--- a/purchase_blanket_order/tests/test_purchase_order.py
+++ b/purchase_blanket_order/tests/test_purchase_order.py
@@ -157,7 +157,7 @@ class TestPurchaseOrder(common.TransactionCase):
             }
         )
         po_line = po.order_line[0]
-        po_line.with_context(from_purchase_order=True).name_get()
+        _ = po_line.with_context(from_purchase_order=True).display_name
         po_line.onchange_product_id()
         self.assertEqual(po_line._get_eligible_bo_lines(), bo_lines)
         bo_line_assigned = self.blanket_order_line_obj.search(
@@ -193,7 +193,7 @@ class TestPurchaseOrder(common.TransactionCase):
             }
         )
         po_line = po.order_line[0]
-        po_line.with_context(from_purchase_order=True).name_get()
+        _ = po_line.with_context(from_purchase_order=True).display_name
         po_line.onchange_product_id()
         self.assertEqual(
             po_line._get_eligible_bo_lines(),

--- a/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
+++ b/purchase_order_uninvoiced_amount/tests/test_purchase_order_uninvoiced_amount.py
@@ -79,7 +79,7 @@ class TestPurchaseOrderUninvoiceAmount(TransactionCase):
         invoice_form = Form(
             self.account_move_model.with_context(
                 default_move_type="in_invoice",
-                default_purchase_id=purchase,
+                default_purchase_id=purchase.id,
                 default_partner_id=purchase.partner_id,
             )
         )


### PR DESCRIPTION
- [FIX] purchase_order_uninvoiced_amount: deprecation warning in tests
- [FIX] purchase_order_uninvoiced_amount: test error unsupported operand type(s) for "=="
