### PR TITLE
[18.0][FIX] purchase_advance_payment: Add index to purchase_id field fixes #3726

### DIFF
--- a/purchase_advance_payment/models/payment.py
+++ b/purchase_advance_payment/models/payment.py
@@ -11,4 +11,5 @@ class AccountPayment(models.Model):
         "purchase.order",
         "Purchase",
         readonly=True,
+        index=True,
     )


### PR DESCRIPTION
## Summary
- Add index=True to purchase_id field in AccountPayment model
- Fixes performance issue #3726 where lack of database index caused latencies on large databases

## Test plan
- [x] Python syntax validation passes
- [x] Check that existing functionality is preserved
- [x] Database index will be automatically created by Odoo migration

## Issue reference
Fixes #3726

💘 Generated with Crush