### PR TITLE
[15.0][FIX] purchase_order_secondary_unit: Purchase secondary uom by default non store in variant

### DIFF
--- a/purchase_order_secondary_unit/__manifest__.py
+++ b/purchase_order_secondary_unit/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Purchase Order Secondary Unit",
     "summary": "Purchase product in a secondary unit",
-    "version": "15.0.1.4.1",
+    "version": "15.0.2.0.0",
     "development_status": "Beta",
     "category": "Purchase",
     "website": "https://github.com/OCA/purchase-workflow",

--- a/purchase_order_secondary_unit/migrations/15.0.2.0.0/post-migration.py
+++ b/purchase_order_secondary_unit/migrations/15.0.2.0.0/post-migration.py
@@ -1,0 +1,33 @@
+# Copyright 2025 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Set default purchase secondary uom from template to variants.
+    # purchase_secondary_uom_id is no longer stored on product.template, so
+    # the legacy values must be read straight from the column, which is
+    # still physically present at this point (Odoo never drops it).
+    env.cr.execute(
+        "SELECT id, purchase_secondary_uom_id FROM product_template"
+        " WHERE purchase_secondary_uom_id IS NOT NULL"
+    )
+    legacy_values = dict(env.cr.fetchall())
+    templates = (
+        env["product.template"].with_context(acive_test=False).browse(legacy_values)
+    )
+    unique_variants = templates.filtered(lambda tmpl: tmpl.product_variant_count == 1)
+    for template in unique_variants:
+        legacy_secondary_uom_id = legacy_values[template.id]
+        if template.product_variant_ids.purchase_secondary_uom_id.id != (
+            legacy_secondary_uom_id
+        ):
+            # Force store purchase_secondary_uom_id for unique variants
+            template.product_variant_ids.purchase_secondary_uom_id = (
+                legacy_secondary_uom_id
+            )
+    # purchase secondary uom computattion in product template for products
+    # with more than one variant
+    (templates - unique_variants)._compute_purchase_secondary_uom_id()

--- a/purchase_order_secondary_unit/models/product_template.py
+++ b/purchase_order_secondary_unit/models/product_template.py
@@ -1,6 +1,6 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import _, api, fields, models
 
 
 class ProductTemplate(models.Model):
@@ -9,5 +9,65 @@ class ProductTemplate(models.Model):
     purchase_secondary_uom_id = fields.Many2one(
         comodel_name="product.secondary.unit",
         string="Default secondary unit for purchases",
+        compute="_compute_purchase_secondary_uom_id",
+        inverse="_inverse_purchase_secondary_uom_id",
+        help="In order to set a value, please first add at least one record"
+        " in 'Secondary Unit of Measure'",
         domain="[('product_tmpl_id', '=', id), ('product_id', '=', False)]",
     )
+
+    @api.depends("product_variant_ids", "product_variant_ids.purchase_secondary_uom_id")
+    def _compute_purchase_secondary_uom_id(self):
+        unique_variants = self.filtered(lambda tmpl: tmpl.product_variant_count == 1)
+        for template in unique_variants:
+            template.purchase_secondary_uom_id = (
+                template.product_variant_ids.purchase_secondary_uom_id
+            )
+        for template in self - unique_variants:
+            if len(template.product_variant_ids.purchase_secondary_uom_id) == 1:
+                template.purchase_secondary_uom_id = (
+                    template.product_variant_ids.purchase_secondary_uom_id
+                )
+            else:
+                template.purchase_secondary_uom_id = False
+
+    def _inverse_purchase_secondary_uom_id(self):
+        for template in self:
+            # if template.product_variant_count == 1:
+            template.product_variant_ids.purchase_secondary_uom_id = (
+                template.purchase_secondary_uom_id
+            )
+
+    @api.onchange("purchase_secondary_uom_id")
+    def onchange_purchase_secondary_uom_id(self):
+        if len(self.product_variant_ids.purchase_secondary_uom_id) > 1:
+            return {
+                "warning": {
+                    "title": _("Warning"),
+                    "message": _(
+                        "Product variants have distinct purchase secondary uom:"
+                        "\n{secondary_uom}\n"
+                        "All variants will be written with new secondary uom"
+                    ).format(
+                        secondary_uom="\n".join(
+                            self.product_variant_ids.mapped(
+                                "purchase_secondary_uom_id.name"
+                            )
+                        )
+                    ),
+                }
+            }
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        templates = super(ProductTemplate, self).create(vals_list)
+        # This is needed to set given values to first variant after creation
+        for template, vals in zip(templates, vals_list):
+            related_vals = {}
+            if vals.get("purchase_secondary_uom_id"):
+                related_vals["purchase_secondary_uom_id"] = vals[
+                    "purchase_secondary_uom_id"
+                ]
+            if related_vals:
+                template.write(related_vals)
+        return templates


### PR DESCRIPTION
@Tecnativa TT59046

ping @carlosdauden @carlos-lopez-tecnativa 

Depends on:
- [x] https://github.com/OCA/purchase-workflow/pull/3163