### PR TITLE
[16.0][FIX] purchase_discount: alignment in report

### DIFF
--- a/purchase_discount/views/report_purchaseorder.xml
+++ b/purchase_discount/views/report_purchaseorder.xml
@@ -5,12 +5,12 @@
         inherit_id="purchase.report_purchaseorder_document"
     >
         <xpath expr="//table[1]/thead/tr//th[last()]" position="before">
-            <th name="th_discount" class="text-right">
+            <th name="th_discount" class="text-end">
                 <strong>Disc. (%)</strong>
             </th>
         </xpath>
         <xpath expr="//td[span[@t-field='line.price_subtotal']]" position="before">
-            <td class="text-right">
+            <td class="text-end">
                 <span t-field="line.discount" />
             </td>
         </xpath>


### PR DESCRIPTION
Quite a trival fix. The bootstrap styles were not migrated correctly

Before:
<img width="760" height="257" alt="2025-11-18_09-38" src="https://github.com/user-attachments/assets/e4e20f5b-48ec-41a5-b1cd-055ee3f31593" />

After:
<img width="763" height="246" alt="2025-11-18_09-40" src="https://github.com/user-attachments/assets/39839ecf-30f0-4ac3-83b8-a992c8067231" />


cc @moduon MT-12675

please take a look @EmilioPascual @pedrobaeza @ramiadavid