### PR TITLE
[16.0][FIX] purchase_cancel_reason: cancel before writing cancel reason.

### DIFF
--- a/purchase_cancel_reason/wizard/purchase_order_cancel.py
+++ b/purchase_cancel_reason/wizard/purchase_order_cancel.py
@@ -23,6 +23,9 @@ class PurchaseOrderCancel(models.TransientModel):
         if purchase_ids is None or active_model != "purchase.order":
             return act_close
         purchase = self.env["purchase.order"].browse(purchase_ids)
-        purchase.cancel_reason_id = self.reason_id.id
+
+        # NB: cancel **before** updating "cancel related" fields so as not to
+        # break behavior of other modules (e.g. base_tier_validation > TierValidation.write())
         purchase.button_cancel()
+        purchase.cancel_reason_id = self.reason_id.id
         return act_close


### PR DESCRIPTION
Ensures the purchase order is cancelled **before** writting the `cancel_reason_id`:
1. This makes more sense.
2. Certain integration modules, such as `base_tier_validation`, rely on the record being in the 'cancel' state when the `write` method is executed to properly skip validation tiers. Cancelling first guarantees the correct state for these integrations.