### PR TITLE
[FIX] purchase_triple_discount: avoid duplicated field on res.partner form view

### DIFF
--- a/purchase_triple_discount/hooks.py
+++ b/purchase_triple_discount/hooks.py
@@ -23,3 +23,13 @@ def post_init_hook(cr, registry):
             WHERE discount != 0
         """
     )
+    _logger.info(
+        "Initializing column default_supplierinfo_discount1 on table res_partner"
+    )
+    cr.execute(
+        """
+            UPDATE res_partner
+            SET default_supplierinfo_discount1 = default_supplierinfo_discount
+            WHERE default_supplierinfo_discount != 0
+        """
+    )

--- a/purchase_triple_discount/views/res_partner_view.xml
+++ b/purchase_triple_discount/views/res_partner_view.xml
@@ -5,7 +5,7 @@
          <field name="inherit_id" ref="purchase_discount.res_partner_form_view" />
          <field name="arch" type="xml">
              <field name="default_supplierinfo_discount" position="attributes">
-                 <attribute name="string">Total discount</attribute>
+                 <attribute name="invisible">1</attribute>
              </field>
             <field name="default_supplierinfo_discount" position="after">
                 <field


### PR DESCRIPTION
- Hide discount field on partner, when triple_discount module is installed. 
- initialize correctly the discount field during triple_discount installation