### PR TITLE
[16.0][FIX] purchase_discount. Correct stock move price update on PO qty reduction (Multi-currency)

### DIFF
--- a/purchase_discount/models/purchase_order.py
+++ b/purchase_discount/models/purchase_order.py
@@ -132,5 +132,5 @@ class PurchaseOrderLine(models.Model):
                     lambda s: s.state not in ("cancel", "done")
                     and s.product_id == line.product_id
                 )
-                moves.write({"price_unit": line._get_discounted_price_unit()})
+                moves.write({"price_unit": line._get_stock_move_price_unit()})
         return res


### PR DESCRIPTION
Problem: When reducing the quantity of a line in a confirmed Purchase Order (e.g., from 20 to 12 units), inconsistent behavior is observed depending on the currency of the provider:

    - Same Currency (e.g., EUR = EUR): The system correctly updates the existing incoming stock move (20 becomes 12).

    - Foreign Currency (e.g., USD != EUR): The system fails to update the existing move. Instead, it keeps the original incoming move (20) and generates a separate return/outgoing picking for the difference (8).

Root Cause: The issue is located in the write() method override within purchase_discount. When a PO line is modified, the module updates the price_unit of the related stock moves using _get_discounted_price_unit().

    - _get_discounted_price_unit() returns the price in the Order Currency (e.g., USD).

    - Stock moves store the price_unit in the Company Currency (e.g., EUR).

    - Consequently, when Odoo's stock.move._merge_moves() attempts to reconcile the change, the prices do not match (Converted EUR vs Raw USD), preventing the merge and forcing the creation of a return picking.

Solution: This PR changes the method used to update the stock moves from _get_discounted_price_unit() to _get_stock_move_price_unit().

_get_stock_move_price_unit() is the standard method (inherited from purchase_stock) which:

    - Applies discounts and taxes.

    - Crucially: Converts the price from Order Currency to Company Currency.

    - Applies correct precision rounding.