### PR TITLE
[18.0][IMP] purchase_partner_incoterm: set default incoterm when PO are created automatically

### DIFF
--- a/purchase_partner_incoterm/models/purchase_order.py
+++ b/purchase_partner_incoterm/models/purchase_order.py
@@ -20,3 +20,23 @@ class PurchaseOrder(models.Model):
             self.partner_id.commercial_partner_id.purchase_incoterm_address_id
         )
         return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("partner_id"):
+                partner = (
+                    self.env["res.partner"]
+                    .browse(vals["partner_id"])
+                    .commercial_partner_id
+                )
+                if "incoterm_id" not in vals and partner.purchase_incoterm_id:
+                    vals["incoterm_id"] = partner.purchase_incoterm_id.id
+                if (
+                    "incoterm_address_id" not in vals
+                    and partner.purchase_incoterm_address_id
+                ):
+                    vals["incoterm_address_id"] = (
+                        partner.purchase_incoterm_address_id.id
+                    )
+        return super().create(vals_list)

--- a/purchase_partner_incoterm/tests/test_purchase_partner_incoterm.py
+++ b/purchase_partner_incoterm/tests/test_purchase_partner_incoterm.py
@@ -37,3 +37,20 @@ class TestPurchasePartnerIncoterm(TransactionCase):
             self.purchase_order.incoterm_address_id,
             self.partner.purchase_incoterm_address_id,
         )
+
+    def test_automated_po_creation(self):
+        auto_po = self.po_model.create({"partner_id": self.partner.id})
+        self.assertEqual(auto_po.incoterm_id, self.partner.purchase_incoterm_id)
+        self.assertEqual(
+            auto_po.incoterm_address_id, self.partner.purchase_incoterm_address_id
+        )
+
+    def test_user_override_preserved(self):
+        custom_incoterm = self.env.ref("account.incoterm_FCA")
+        po_with_custom = self.po_model.create(
+            {
+                "partner_id": self.partner.id,
+                "incoterm_id": custom_incoterm.id,
+            }
+        )
+        self.assertEqual(po_with_custom.incoterm_id, custom_incoterm)


### PR DESCRIPTION
For example, reordering rule POs does not include the default incoterms