### PR TITLE
[18.0][IMP] purchase_tag: Allow to add tags on lines that will be put on orders

### DIFF
--- a/purchase_tag/models/__init__.py
+++ b/purchase_tag/models/__init__.py
@@ -1,2 +1,3 @@
 from . import purchase_tag
 from . import purchase_order
+from . import purchase_order_line

--- a/purchase_tag/models/purchase_order.py
+++ b/purchase_tag/models/purchase_order.py
@@ -2,7 +2,7 @@
 #   (http://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class PurchaseOrder(models.Model):
@@ -10,8 +10,19 @@ class PurchaseOrder(models.Model):
 
     tag_ids = fields.Many2many(
         comodel_name="purchase.tag",
+        compute="_compute_tag_ids",
+        store=True,
+        readonly=False,
         relation="purchase_order_tag_rel",
         column1="purchase_order_id",
         column2="tag_id",
         string="Tags",
     )
+
+    @api.depends("order_line.tag_ids")
+    def _compute_tag_ids(self):
+        # Add the missing tags from order lines ones
+        for purchase in self:
+            for tag in purchase.order_line.tag_ids:
+                if tag not in purchase.tag_ids:
+                    purchase.tag_ids |= tag

--- a/purchase_tag/models/purchase_order_line.py
+++ b/purchase_tag/models/purchase_order_line.py
@@ -1,0 +1,15 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    tag_ids = fields.Many2many(
+        comodel_name="purchase.tag",
+        relation="purchase_order_line_tag_rel",
+        column1="purchase_order_line_id",
+        column2="tag_id",
+        string="Tags",
+    )

--- a/purchase_tag/views/purchase_view.xml
+++ b/purchase_tag/views/purchase_view.xml
@@ -15,6 +15,17 @@
                     options="{'color_field': 'color', 'no_create_edit': True}"
                 />
             </field>
+            <xpath
+                expr="//field[@name='order_line']/list/field[@name='date_planned']"
+                position="after"
+            >
+                <field
+                    name="tag_ids"
+                    widget="many2many_tags"
+                    options="{'color_field': 'color', 'no_create_edit': True}"
+                    optional="hide"
+                />
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION

In some flows, users want to put tags on lines. Those tags should be reflected on purcahse order.