### PR TITLE
[FIX]purchase_order_type: try to assign the correct sequence on create

### DIFF
--- a/purchase_order_type/models/purchase_order.py
+++ b/purchase_order_type/models/purchase_order.py
@@ -40,6 +40,12 @@ class PurchaseOrder(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for values in vals_list:
+            # If no order_type is provided, try to get it from partner
+            if not values.get("order_type") and values.get("partner_id"):
+                partner = self.env["res.partner"].browse(values["partner_id"])
+                if partner.purchase_type:
+                    values["order_type"] = partner.purchase_type.id
+
             if values.get("name", "/") == "/" and values.get("order_type"):
                 purchase_type = self.env["purchase.order.type"].browse(
                     values["order_type"]


### PR DESCRIPTION
It happens that when the PO is generated by a replenishment rule, the "order_type" value is not defined, so it takes a random sequence to generate the PO, and not the sequence defined on the PO type set for the partner of the PO.