### PR TITLE
[FIX]purchase_order_type: PO type in res_partner_view

### DIFF
--- a/purchase_order_type/__manifest__.py
+++ b/purchase_order_type/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Purchase Order Type",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.1.1",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Purchase Management",

--- a/purchase_order_type/views/res_partner_view.xml
+++ b/purchase_order_type/views/res_partner_view.xml
@@ -4,14 +4,11 @@
         <field name="name">res.partner.purchase_type.form</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="priority">99</field>
         <field name="arch" type="xml">
-            <page name="sales_purchases" position="inside">
-                <field name="supplier_rank" invisible="1" />
-                <group colspan="2" col="2" invisible="supplier_rank == 0">
-                    <separator string="Purchase Order Type" colspan="2" />
-                    <field name="purchase_type" />
-                </group>
-            </page>
+            <group name="purchase" position="inside">
+                <field name="purchase_type" />
+            </group>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
There are two main changes on this PR:

1.     Remove the supplier rank != 0 condition for visibility of the purchase_type field. The field was invisible when you create a new partner or try to set an old partner as a customer.
2. Relocate the field in view. It is more clear and organized if the PO type field is inside the purchase page.
<img width="1111" height="784" alt="image" src="https://github.com/user-attachments/assets/16a51422-0c20-4643-a7dc-4a44ac6b1d8f" />
