### PR TITLE
[IMP]purchase_order_type:improve in view

### DIFF
--- a/purchase_order_type/__manifest__.py
+++ b/purchase_order_type/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Purchase Order Type",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Purchase Management",

--- a/purchase_order_type/views/res_partner_view.xml
+++ b/purchase_order_type/views/res_partner_view.xml
@@ -4,14 +4,11 @@
         <field name="name">res.partner.purchase_type.form</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="priority">99</field>
         <field name="arch" type="xml">
-            <page name="sales_purchases" position="inside">
-                <field name="supplier_rank" invisible="1" />
-                <group colspan="2" col="2" invisible="supplier_rank == 0">
-                    <separator string="Purchase Order Type" colspan="2" />
-                    <field name="purchase_type" />
-                </group>
-            </page>
+            <group name="purchase" position="inside">
+                <field name="purchase_type" />
+            </group>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Small improvement to reduce the number of groups in Vendors.
I used the field’s priority so it appears at the end of the group.

<img width="1850" height="932" alt="Azure-Interior-12-16-2025_11_29_AM" src="https://github.com/user-attachments/assets/a23e276a-8b5b-415b-b98a-f37fe66e4243" />

