### PR TITLE
[18.0][FIX] purchase_deposit: fixes account.tax access error in a multi com…

### DIFF
--- a/purchase_deposit/wizard/purchase_make_invoice_advance.py
+++ b/purchase_deposit/wizard/purchase_make_invoice_advance.py
@@ -56,7 +56,9 @@ class PurchaseAdvancePaymentInv(models.TransientModel):
     def _compute_deposit_account_id(self):
         product = self.purchase_deposit_product_id
         self.deposit_account_id = product.property_account_expense_id
-        self.deposit_taxes_id = product.supplier_taxes_id
+        self.deposit_taxes_id = product.supplier_taxes_id.filtered(
+            lambda tx: tx.company_id == self.env.company
+        )
 
     def _prepare_deposit_val(self, order, po_line, amount):
         account_id = False


### PR DESCRIPTION
…pany environment

Solves access error when creating a Deposit invoice, because it was getting all the product taxes of the existing companies.

Cherry-picked from https://github.com/OCA/purchase-workflow/pull/2867