### PR TITLE
[18.0][IMP] purchase_request: Store the purchased_qty field.

### DIFF
--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -94,6 +94,7 @@ class PurchaseRequestLine(models.Model):
         string="RFQ/PO Qty",
         digits="Product Unit of Measure",
         compute="_compute_purchased_qty",
+        store=True,
     )
     purchase_lines = fields.Many2many(
         comodel_name="purchase.order.line",
@@ -298,6 +299,12 @@ class PurchaseRequestLine(models.Model):
             requests.check_auto_reject()
         return res
 
+    @api.depends(
+        "purchase_lines",
+        "purchase_lines.order_id.state",
+        "purchase_lines.product_uom",
+        "purchase_lines.product_qty",
+    )
     def _compute_purchased_qty(self):
         for rec in self:
             rec.purchased_qty = 0.0


### PR DESCRIPTION
I don’t see a reason to keep this field non-stored, and I think it could be a good idea to store it. What do you think?
@victoralmau @pedrobaeza could you please review this?