### PR TITLE
[18.0][FIX] purchase_order_secondary_unit: revert report features requiring unmerged dependency

### DIFF
--- a/purchase_order_secondary_unit/reports/purchase_order_templates.xml
+++ b/purchase_order_secondary_unit/reports/purchase_order_templates.xml
@@ -6,64 +6,16 @@
     >
         <!-- Header data -->
         <th name="th_quantity" position="before">
-            <th
-                name="th_secondary_unit"
-                class="text-end"
-                t-if="not o.company_id.hide_secondary_uom_column(o)"
-            >
+            <th name="th_secondary_unit" class="text-end">
                 <strong>Second Qty</strong>
             </th>
         </th>
         <!-- Content data -->
         <xpath expr="//span[@t-field='line.product_qty']/.." position="before">
-            <td
-                id="secondary_unit"
-                class="text-end"
-                t-if="not o.company_id.hide_secondary_uom_column(o)"
-            >
+            <td id="secondary_unit" class="text-end">
                 <span t-field="line.secondary_uom_qty" />
                 <span t-field="line.secondary_uom_id" />
             </td>
-        </xpath>
-        <!-- Quantity: hide primary when secondary is prioritized -->
-        <xpath expr="//span[@t-field='line.product_qty']" position="attributes">
-            <attribute
-                name="t-if"
-            >line.get_secondary_uom_display_mode() != 'secondary'</attribute>
-        </xpath>
-        <xpath expr="//span[@t-field='line.product_uom.name']" position="attributes">
-            <attribute
-                name="t-if"
-            >line.get_secondary_uom_display_mode() != 'secondary'</attribute>
-        </xpath>
-        <!-- Quantity: add secondary qty ('secondary' mode) -->
-        <xpath expr="//span[@t-field='line.product_uom.name']" position="after">
-            <t t-if="line.get_secondary_uom_display_mode() == 'secondary'">
-                <span t-field="line.secondary_uom_qty" />
-                <span t-field="line.secondary_uom_id.name" />
-            </t>
-        </xpath>
-        <!-- Quantity: add secondary qty ('both' mode) -->
-        <xpath expr="//span[@t-field='line.product_qty']/.." position="inside">
-            <t t-if="line.get_secondary_uom_display_mode() == 'both'">
-                <br />
-                <span class="text-muted">
-                    (<span t-field="line.secondary_uom_qty" />
-                    <span
-                    t-field="line.secondary_uom_id.name"
-                    groups="uom.group_uom"
-                />)
-                </span>
-            </t>
-        </xpath>
-        <!-- Unit price: hide primary ('secondary' mode) -->
-        <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
-            <attribute
-                name="t-if"
-            >line.get_secondary_uom_display_mode() != 'secondary'</attribute>
-        </xpath>
-        <xpath expr="//span[@t-field='line.price_unit']" position="after">
-            <t t-call="purchase_order_secondary_unit.purchase_uom_price" />
         </xpath>
     </template>
 </odoo>

--- a/purchase_order_secondary_unit/reports/purchase_quotation_templates.xml
+++ b/purchase_order_secondary_unit/reports/purchase_quotation_templates.xml
@@ -4,57 +4,18 @@
         id="report_purchasequotation_document"
         inherit_id="purchase.report_purchasequotation_document"
     >
-        <!-- Header: Second Qty column (hidden when hide_secondary_uom_column() is True) -->
+        <!-- Header data -->
         <th name="th_quantity" position="before">
-            <th
-                name="secondary_unit"
-                class="text-end"
-                t-if="not o.company_id.hide_secondary_uom_column(o)"
-            >
+            <th name="secondary_unit" class="text-end">
                 <strong>Second Qty</strong>
             </th>
         </th>
-        <!-- Content: Second Qty cell (hidden when hide_secondary_uom_column is True) -->
+        <!-- Content data -->
         <xpath expr="//span[@t-field='order_line.product_qty']/.." position="before">
-            <td
-                id="secondary_unit"
-                class="text-end"
-                t-if="not o.company_id.hide_secondary_uom_column(o)"
-            >
+            <td id="secondary_unit" class="text-end">
                 <span t-field="order_line.secondary_uom_qty" />
                 <span t-field="order_line.secondary_uom_id" />
             </td>
-        </xpath>
-        <!-- Quantity: hide primary when secondary is prioritized -->
-        <xpath expr="//span[@t-field='order_line.product_qty']" position="attributes">
-            <attribute
-                name="t-if"
-            >order_line.get_secondary_uom_display_mode() != 'secondary'</attribute>
-        </xpath>
-        <xpath expr="//span[@t-field='order_line.product_uom']" position="attributes">
-            <attribute
-                name="t-if"
-            >order_line.get_secondary_uom_display_mode() != 'secondary'</attribute>
-        </xpath>
-        <!-- Quantity: add secondary qty ('secondary' mode) -->
-        <xpath expr="//span[@t-field='order_line.product_uom']" position="after">
-            <t t-if="order_line.get_secondary_uom_display_mode() == 'secondary'">
-                <span t-field="order_line.secondary_uom_qty" />
-                <span t-field="order_line.secondary_uom_id.name" />
-            </t>
-        </xpath>
-        <!-- Quantity: add secondary qty ('both' mode) -->
-        <xpath expr="//span[@t-field='order_line.product_qty']/.." position="inside">
-            <t t-if="order_line.get_secondary_uom_display_mode() == 'both'">
-                <br />
-                <span class="text-muted">
-                    (<span t-field="order_line.secondary_uom_qty" />
-                    <span
-                    t-field="order_line.secondary_uom_id.name"
-                    groups="uom.group_uom"
-                />)
-                </span>
-            </t>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Since many implementations are getting hit by report crashes while OCA/product-attribute#2211 has yet to be merged... :sweat:

Partially revert a1eea87f for purchase order and quotation report templates. The reverted portions rely on methods
(hide_secondary_uom_column, get_secondary_uom_display_mode) introduced by OCA/product-attribute#2211, which is not yet merged. Without that dependency, the reports would crash when printing.

The secondary quantity column is kept but the conditional visibility and display mode logic are removed until the dependency is available.

@qrtl
