### PR TITLE
[18.0][IMP] purchase_last_price_info: improve field name for last purchase currency rate

### DIFF
--- a/purchase_last_price_info/models/product_product.py
+++ b/purchase_last_price_info/models/product_product.py
@@ -36,11 +36,19 @@ class ProductProduct(models.Model):
         string="Last Purchase Currency",
     )
     show_last_purchase_price_currency = fields.Boolean(
-        compute="_compute_show_last_purchase_price_currency",
+        string="Show Last Purchase Price Currency",
+        related="show_last_purchase_price_currency_rate",
+    )
+    show_last_purchase_price_currency_rate = fields.Boolean(
+        compute="_compute_show_last_purchase_price_currency_rate",
     )
     last_purchase_price_currency = fields.Float(
-        string="Last currency purchase price",
-        compute="_compute_last_purchase_price_currency",
+        string="Last Purchase Price Currency",
+        related="last_purchase_price_currency_rate",
+    )
+    last_purchase_price_currency_rate = fields.Float(
+        string="Last Purchase Currency Rate",
+        compute="_compute_last_purchase_price_currency_rate",
         digits=0,
     )
 
@@ -68,10 +76,10 @@ class ProductProduct(models.Model):
             item.last_purchase_currency_id = item.last_purchase_line_id.currency_id
 
     @api.depends("last_purchase_line_id", "last_purchase_currency_id")
-    def _compute_show_last_purchase_price_currency(self):
+    def _compute_show_last_purchase_price_currency_rate(self):
         for item in self:
             last_line = item.last_purchase_line_id
-            item.show_last_purchase_price_currency = (
+            item.show_last_purchase_price_currency_rate = (
                 last_line
                 and item.last_purchase_currency_id
                 and item.last_purchase_currency_id != last_line.company_id.currency_id
@@ -79,18 +87,18 @@ class ProductProduct(models.Model):
 
     @api.depends(
         "last_purchase_line_id",
-        "show_last_purchase_price_currency",
+        "show_last_purchase_price_currency_rate",
         "last_purchase_currency_id",
         "last_purchase_date",
     )
-    def _compute_last_purchase_price_currency(self):
+    def _compute_last_purchase_price_currency_rate(self):
         for item in self:
-            if item.show_last_purchase_price_currency:
+            if item.show_last_purchase_price_currency_rate:
                 rates = item.last_purchase_currency_id._get_rates(
                     item.last_purchase_line_id.company_id, item.last_purchase_date
                 )
-                item.last_purchase_price_currency = rates.get(
+                item.last_purchase_price_currency_rate = rates.get(
                     item.last_purchase_currency_id.id
                 )
             else:
-                item.last_purchase_price_currency = 1
+                item.last_purchase_price_currency_rate = 1

--- a/purchase_last_price_info/models/product_template.py
+++ b/purchase_last_price_info/models/product_template.py
@@ -36,11 +36,19 @@ class ProductTemplate(models.Model):
         string="Last Purchase Currency",
     )
     show_last_purchase_price_currency = fields.Boolean(
-        related="product_variant_ids.show_last_purchase_price_currency",
+        string="Show Last Purchase Price Currency",
+        related="show_last_purchase_price_currency_rate",
+    )
+    show_last_purchase_price_currency_rate = fields.Boolean(
+        related="product_variant_ids.show_last_purchase_price_currency_rate",
     )
     last_purchase_price_currency = fields.Float(
-        string="Last currency purchase price",
-        related="product_variant_ids.last_purchase_price_currency",
+        string="Last Purchase Price Currency",
+        related="last_purchase_price_currency_rate",
+    )
+    last_purchase_price_currency_rate = fields.Float(
+        string="Last Purchase Currency Rate",
+        related="product_variant_ids.last_purchase_price_currency_rate",
         digits=0,
     )
 

--- a/purchase_last_price_info/tests/test_purchase_last_price_info.py
+++ b/purchase_last_price_info/tests/test_purchase_last_price_info.py
@@ -66,7 +66,7 @@ class TestPurchaseLastPriceInfo(common.TransactionCase):
             first_purchase_line.currency_id, self.product.last_purchase_currency_id
         )
         self.assertEqual(self.product.last_purchase_currency_id, self.currency)
-        self.assertEqual(self.product.last_purchase_price_currency, 1.0)
+        self.assertEqual(self.product.last_purchase_price_currency_rate, 1.0)
 
     def test_purchase_last_price_info_new_order(self):
         purchase_order1 = self.purchase_model.create(
@@ -152,7 +152,7 @@ class TestPurchaseLastPriceInfo(common.TransactionCase):
             self.product1.last_purchase_currency_id,
         )
         self.assertEqual(self.product1.last_purchase_currency_id, self.currency_extra)
-        self.assertEqual(self.product1.last_purchase_price_currency, 2.0)
+        self.assertEqual(self.product1.last_purchase_price_currency_rate, 2.0)
         self.assertEqual(self.partner, self.product1.last_purchase_supplier_id)
         purchase_order2.button_cancel()
         self.assertEqual(purchase_order2.state, "cancel")

--- a/purchase_last_price_info/views/product_views.xml
+++ b/purchase_last_price_info/views/product_views.xml
@@ -14,16 +14,19 @@
                     <field name="last_purchase_supplier_id" />
                     <field name="last_purchase_date" />
                     <field name="last_purchase_price" />
-                    <field name="show_last_purchase_price_currency" invisible="1" />
+                    <field
+                        name="show_last_purchase_price_currency_rate"
+                        invisible="1"
+                    />
                     <field
                         name="last_purchase_currency_id"
                         groups="base.group_multi_currency"
-                        invisible="not show_last_purchase_price_currency"
+                        invisible="not show_last_purchase_price_currency_rate"
                     />
                     <field
-                        name="last_purchase_price_currency"
+                        name="last_purchase_price_currency_rate"
                         groups="base.group_multi_currency"
-                        invisible="not show_last_purchase_price_currency"
+                        invisible="not show_last_purchase_price_currency_rate"
                     />
                 </group>
             </field>
@@ -43,16 +46,19 @@
                     <field name="last_purchase_supplier_id" />
                     <field name="last_purchase_date" />
                     <field name="last_purchase_price" />
-                    <field name="show_last_purchase_price_currency" invisible="1" />
+                    <field
+                        name="show_last_purchase_price_currency_rate"
+                        invisible="1"
+                    />
                     <field
                         name="last_purchase_currency_id"
                         groups="base.group_multi_currency"
-                        invisible="not show_last_purchase_price_currency"
+                        invisible="not show_last_purchase_price_currency_rate"
                     />
                     <field
-                        name="last_purchase_price_currency"
+                        name="last_purchase_price_currency_rate"
                         groups="base.group_multi_currency"
-                        invisible="not show_last_purchase_price_currency"
+                        invisible="not show_last_purchase_price_currency_rate"
                     />
                 </group>
             </field>


### PR DESCRIPTION
The field is showing the currency rate of the last purchase, the wording was a bit confusing IMHO.

In order to not mess up already existing installations, we add new fields with the right wording and keep the old ones as related to the new ones.

Also FW of https://github.com/OCA/purchase-workflow/pull/2822