### PR TITLE
[18.0][FIX] purchase_request: delete search/groupby analytic_distribution

### DIFF
--- a/purchase_request/views/purchase_request_line_view.xml
+++ b/purchase_request/views/purchase_request_line_view.xml
@@ -220,10 +220,6 @@
                     domain="[('purchase_state','=','done')]"
                     help="At least a PO has been completed"
                 />
-                <field
-                    name="analytic_distribution"
-                    groups="analytic.group_analytic_accounting"
-                />
                 <field name="cancelled" invisible="1" />
                 <filter
                     name="request_state_draft"
@@ -314,13 +310,6 @@
                         string="Request status"
                         domain="[]"
                         context="{'group_by':'request_state'}"
-                    />
-                    <filter
-                        name="group_analytic_distribution"
-                        string="Analytic Distribution"
-                        domain="[]"
-                        context="{'group_by':'analytic_distribution'}"
-                        groups="analytic.group_analytic_accounting"
                     />
                     <filter
                         name="purchase_status"


### PR DESCRIPTION
This PR delete search / groupby analytic_distribution because core odoo is not supported.

Step to test:
1. Go to Purchase Requests > Purchase Requests > Purchase Request Lines
2. Group by `Analytic Distribution`, it throw error
```
RPC_ERROR

Odoo Server Error

Occured on localhost:18069 on model purchase.request.line on 2026-03-02 08:50:11 GMT

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2166, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 157, in retrying
    result = func()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2133, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2381, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/web/controllers/dataset.py", line 36, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "/opt/odoo/auto/addons/web/models/models.py", line 246, in web_read_group
    groups = self._web_read_group(domain, fields, groupby, limit, offset, orderby, lazy)
  File "/opt/odoo/auto/addons/web/models/models.py", line 272, in _web_read_group
    groups = self.read_group(domain, fields, groupby, offset=offset, limit=limit,
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 2893, in read_group
    rows = self._read_group(domain, annotated_groupby.values(), annotated_aggregates.values(), offset=offset, limit=limit, order=orderby)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 2010, in _read_group
    groupby_terms: dict[str, SQL] = {
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 2011, in <dictcomp>
    spec: self._read_group_groupby(spec, query)
  File "/opt/odoo/auto/addons/mail/models/mail_activity_mixin.py", line 256, in _read_group_groupby
    return super()._read_group_groupby(groupby_spec, query)
  File "/opt/odoo/auto/addons/analytic/models/analytic_mixin.py", line 121, in _read_group_groupby
    self._get_count_id(query),
  File "/opt/odoo/auto/addons/analytic/models/analytic_mixin.py", line 148, in _get_count_id
    raise ValueError(f"{query.table} does not support analytic_distribution grouping.")
ValueError: purchase_request_line does not support analytic_distribution grouping.

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (http://localhost:18069/web/assets/2ea729d/web.assets_web.min.js:3174:165)
        at XMLHttpRequest.<anonymous> (http://localhost:18069/web/assets/2ea729d/web.assets_web.min.js:3179:13)

```
3. Search name with analytic_distribution is not working too