### PR TITLE
[18.0][IMP] sale_purchase_force_vendor: Add Vendor filter to sale order + Add vendor_id field to sale report

### DIFF
--- a/sale_purchase_force_vendor/README.rst
+++ b/sale_purchase_force_vendor/README.rst
@@ -51,9 +51,9 @@ To configure this module, you need to:
 5. Go to *Sale -> Products -> Products*.
 6. Create a new product with the following options:
 
-   - [Puchase tab] \`Vendors\`: Set different vendors (Vendor A + Vendor
-     B).
-   - [Iventory tab] \`Routes\`: Buy and MTO
+   -  [Puchase tab] \`Vendors\`: Set different vendors (Vendor A +
+      Vendor B).
+   -  [Iventory tab] \`Routes\`: Buy and MTO
 
 Usage
 =====
@@ -61,8 +61,8 @@ Usage
 1. Go to *Sale -> Orders -> Quotations* and create a new Quotation.
 2. Create a new line with the following options:
 
-   - \`Route\`: MTO.
-   - \`Vendor\`: Vendor B.
+   -  \`Route\`: MTO.
+   -  \`Vendor\`: Vendor B.
 
 3. Confirm sale order.
 4. A new purchase order will have been created to Vendor B.
@@ -91,10 +91,10 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Víctor Martínez
-  - Pedro M. Baeza
+   -  Víctor Martínez
+   -  Pedro M. Baeza
 
 Maintainers
 -----------

--- a/sale_purchase_force_vendor/__init__.py
+++ b/sale_purchase_force_vendor/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import report

--- a/sale_purchase_force_vendor/__manifest__.py
+++ b/sale_purchase_force_vendor/__manifest__.py
@@ -12,6 +12,7 @@
     "data": [
         "views/res_config_settings_view.xml",
         "views/sale_order_view.xml",
+        "report/sale_report_views.xml",
     ],
     "maintainers": ["victoralmau"],
 }

--- a/sale_purchase_force_vendor/report/__init__.py
+++ b/sale_purchase_force_vendor/report/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_report

--- a/sale_purchase_force_vendor/report/sale_report.py
+++ b/sale_purchase_force_vendor/report/sale_report.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import fields, models
+
+
+class SaleReport(models.Model):
+    _inherit = "sale.report"
+
+    vendor_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Vendor",
+        readonly=True,
+    )
+
+    def _select_additional_fields(self):
+        res = super()._select_additional_fields()
+        res["vendor_id"] = "l.vendor_id"
+        return res
+
+    def _group_by_sale(self):
+        group_by = super()._group_by_sale()
+        group_by += ", l.vendor_id"
+        return group_by

--- a/sale_purchase_force_vendor/report/sale_report_views.xml
+++ b/sale_purchase_force_vendor/report/sale_report_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_order_product_search" model="ir.ui.view">
+        <field name="name">sale.report.search</field>
+        <field name="model">sale.report</field>
+        <field name="inherit_id" ref="sale.view_order_product_search" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="vendor_id" />
+            </field>
+            <filter name="Customer" position="after">
+                <filter
+                    string="Vendor"
+                    name="vendor"
+                    context="{'group_by':'vendor_id'}"
+                />
+            </filter>
+        </field>
+    </record>
+</odoo>

--- a/sale_purchase_force_vendor/static/description/index.html
+++ b/sale_purchase_force_vendor/static/description/index.html
@@ -399,8 +399,8 @@ Order Lines” option.</li>
 “Unarchived” MTO route.</li>
 <li>Go to <em>Sale -&gt; Products -&gt; Products</em>.</li>
 <li>Create a new product with the following options:<ul>
-<li>[Puchase tab] `Vendors`: Set different vendors (Vendor A + Vendor
-B).</li>
+<li>[Puchase tab] `Vendors`: Set different vendors (Vendor A +
+Vendor B).</li>
 <li>[Iventory tab] `Routes`: Buy and MTO</li>
 </ul>
 </li>

--- a/sale_purchase_force_vendor/views/sale_order_view.xml
+++ b/sale_purchase_force_vendor/views/sale_order_view.xml
@@ -33,4 +33,18 @@
             </xpath>
         </field>
     </record>
+    <record id="view_sales_order_filter" model="ir.ui.view">
+        <field name="name">sale.order.list.select</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sales_order_filter" />
+        <field name="arch" type="xml">
+            <field name="order_line" position="after">
+                <field
+                    name="order_line"
+                    string="Vendor"
+                    filter_domain="[('order_line.vendor_id', 'ilike', self)]"
+                />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/purchase-workflow/pull/2960

Add Vendor filter to sale order + Add vendor_id field to sale report

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT61030