### PR TITLE
[17.0][FIX] purchase_order_secondary_unit: TestPurchaseOrderSecondaryUnit set up class

### DIFF
--- a/purchase_order_secondary_unit/tests/test_purchase_order_secondary_unit.py
+++ b/purchase_order_secondary_unit/tests/test_purchase_order_secondary_unit.py
@@ -19,6 +19,7 @@ class TestPurchaseOrderSecondaryUnit(TransactionCase):
         product_form.name = "Test"
         product_form.uom_id = cls.product_uom_kg
         product_form.uom_po_id = cls.product_uom_kg
+        product_form.default_code = "123456"
         cls.product = product_form.save()
         # Set a secondary unit on the template of the previously created product
         with Form(cls.product.product_tmpl_id) as template_form:


### PR DESCRIPTION
When running tests on the _TestPurchaseOrderSecondaryUnit_ class setup, the following error occurs:

```
AssertionError: default_code is a required field 
({'required': 'True', 'readonly': 'False', 'invisible': 'False', 'column_invisible': 'False'})
```