### PR TITLE
[18.0][FIX] product_supplierinfo_purchase_contact: use valid supplier contact by date

### DIFF
--- a/product_supplierinfo_purchase_contact/models/stock_rule.py
+++ b/product_supplierinfo_purchase_contact/models/stock_rule.py
@@ -1,19 +1,42 @@
 # Copyright 2024 Tecnativa - Carolina Fernandez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import models
+from odoo import fields, models
 
 
 class StockRule(models.Model):
     _inherit = "stock.rule"
 
     def _make_po_get_domain(self, company_id, values, partner):
-        if values.get("supplier") and values["supplier"].purchase_partner_id:
-            partner = values["supplier"].purchase_partner_id
+        if values.get("supplier"):
+            purchase_partner = self._get_valid_purchase_partner(values["supplier"])
+            if purchase_partner:
+                partner = purchase_partner
         return super()._make_po_get_domain(company_id, values, partner)
 
     def _prepare_purchase_order(self, company_id, origins, values):
         res = super()._prepare_purchase_order(company_id, origins, values)
         values = values[0]
-        if "supplier" in values and values["supplier"].purchase_partner_id:
-            res["partner_id"] = values["supplier"].purchase_partner_id.id
+        if "supplier" in values:
+            purchase_partner = self._get_valid_purchase_partner(values["supplier"])
+            if purchase_partner:
+                res["partner_id"] = purchase_partner.id
         return res
+
+    def _get_valid_purchase_partner(self, supplier):
+        today = fields.Date.today()
+        valid = supplier.search(
+            [
+                ("partner_id", "=", supplier.partner_id.id),
+                ("product_tmpl_id", "=", supplier.product_tmpl_id.id),
+                ("purchase_partner_id", "!=", False),
+                "|",
+                ("date_start", "=", False),
+                ("date_start", "<=", today),
+                "|",
+                ("date_end", "=", False),
+                ("date_end", ">=", today),
+            ],
+            order="date_start desc",
+            limit=1,
+        )
+        return valid.purchase_partner_id if valid else supplier.purchase_partner_id

--- a/product_supplierinfo_purchase_contact/tests/test_stock_rule.py
+++ b/product_supplierinfo_purchase_contact/tests/test_stock_rule.py
@@ -2,11 +2,13 @@
 # Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import Command
+from odoo.tests import tagged
 from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import BaseCommon
 
 
+@tagged("post_install", "-at_install")
 class TestStockRule(BaseCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
When generating a purchase order via replenishment, the module was using the `purchase_partner_id` directly from `values['supplier']`. This value is set by Odoo core's `_run_buy`, which can fall back to a seller without date filtering, resulting in an expired supplier info line being used instead of the currently valid one.

Added `_get_valid_purchase_partner` to search for the currently valid `product.supplierinfo` line by date, and used it in both `_make_po_get_domain` and `_prepare_purchase_order` instead of accessing `purchase_partner_id` directly.

@Tecnativa TT61329
@christian-ramos-tecnativa @pedrobaeza 