### PR TITLE
[17.0][FIX] purchase_advance_payment_line: _check_amount constrains fields

### DIFF
--- a/purchase_advance_payment_line/models/account_payment_line.py
+++ b/purchase_advance_payment_line/models/account_payment_line.py
@@ -12,10 +12,6 @@ class AccountPaymentLine(models.Model):
         string="Purchase Order",
         check_company=True,
     )
-    purchase_amount_residual = fields.Float(
-        related="purchase_id.amount_residual",
-        store=True,
-    )
     payment_mode_id = fields.Many2one(
         related="order_id.payment_mode_id",
         store=True,
@@ -61,7 +57,7 @@ class AccountPaymentLine(models.Model):
                 vals["order_id"] = order.id
         return super().create(vals_list)
 
-    @api.constrains("currency_id", "amount_currency", "purchase_amount_residual")
+    @api.constrains("amount_currency")
     def _check_amount(self):
         for pline in self.filtered("purchase_id"):
             if pline.currency_id.compare_amounts(pline.amount_currency, 0.0) <= 0:
@@ -70,7 +66,7 @@ class AccountPaymentLine(models.Model):
                 )
             if (
                 pline.currency_id.compare_amounts(
-                    pline.amount_currency, pline.purchase_amount_residual
+                    pline.amount_currency, pline.purchase_id.amount_residual
                 )
                 > 0
             ):

--- a/purchase_advance_payment_line/tests/test_purchase_advance_payment_line.py
+++ b/purchase_advance_payment_line/tests/test_purchase_advance_payment_line.py
@@ -131,14 +131,14 @@ class TestPurchaseAdvancePaymentLine(common.TransactionCase):
         action = self.purchase_order.action_view_ongoing_payment_lines()
         self.assertEqual(action["view_mode"], "form")
 
-    def test_06_check_amount_positive(self):
+    def test_06_check_amount_create_non_positive(self):
         """A non-positive amount raises a ValidationError."""
         with self.assertRaisesRegex(
             ValidationError, "Amount of advance must be positive"
         ):
             self._create_payment_line(0.0)
 
-    def test_07_check_amount_exceeds_residual(self):
+    def test_07_check_amount_create_exceeds_residual(self):
         """An amount exceeding the purchase order residual raises a ValidationError."""
         with self.assertRaisesRegex(
             ValidationError,
@@ -148,7 +148,32 @@ class TestPurchaseAdvancePaymentLine(common.TransactionCase):
                 self.purchase_order.amount_residual + 1,
             )
 
-    def test_08_prepare_account_payment_vals_includes_purchase_id(self):
+    def test_08_check_amount_write_non_positive(self):
+        """Updating amount_currency to a non-positive value raises a ValidationError."""
+        pline = self._create_payment_line(100.0)
+        with self.assertRaisesRegex(
+            ValidationError, "Amount of advance must be positive"
+        ):
+            pline.write({"amount_currency": 0.0})
+
+    def test_09_check_amount_write_exceeds_residual(self):
+        """Updating amount_currency beyond the residual raises a ValidationError."""
+        pline = self._create_payment_line(100.0)
+        amount_currency = self.purchase_order.amount_residual + 1
+        with self.assertRaisesRegex(
+            ValidationError,
+            "Amount of advance is greater than residual amount on purchase",
+        ):
+            pline.write({"amount_currency": amount_currency})
+
+    def test_10_check_amount_write_valid(self):
+        """Updating amount_currency to a valid value within residual succeeds."""
+        pline = self._create_payment_line(100.0)
+        amount_currency = self.purchase_order.amount_residual - 1
+        pline.write({"amount_currency": amount_currency})
+        self.assertEqual(pline.amount_currency, amount_currency)
+
+    def test_11_prepare_account_payment_vals_includes_purchase_id(self):
         """_prepare_account_payment_vals includes purchase_id when set."""
         pline = self._create_payment_line(100.0)
         vals = pline._prepare_account_payment_vals()


### PR DESCRIPTION
Trigger `account.payment.line::_check_amount()` ony when `amount_currency` is modified.

`@api.constrains` is triggered whenever a dependent field is recomputed, including background recomputations of `amount_residual` on the purchase order. This causes false-positive `ValidationErrors` on already-saved valid payment lines.

Validation should only fires when a payment line is created or when its `amount_currency` is modified.