### PR TITLE
[18.0][FIX] purchase_security: Prevent an access error when selecting a product in a purchase order

### DIFF
--- a/purchase_security/models/__init__.py
+++ b/purchase_security/models/__init__.py
@@ -1,4 +1,5 @@
 from . import ir_rule
+from . import product_supplierinfo
 from . import purchase_order
 from . import purchase_team
 from . import res_partner

--- a/purchase_security/models/product_supplierinfo.py
+++ b/purchase_security/models/product_supplierinfo.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SupplierInfo(models.Model):
+    _inherit = "product.supplierinfo"
+
+    def _get_filtered_supplier(self, company_id, product_id, params=False):
+        """To avoid confusion with the _compute_domain() method in ir.rule linked to
+        product.supplierinfo, we will filter the records in this method.
+        If the user does not have "advanced permissions" (condition), we will
+        retrieve the records using sudo() and then filter them by the partners we have
+        obtained—that is, those to which the user has access
+        """
+        user = self.env.user
+        group1 = "purchase_security.group_purchase_own_orders"
+        group3 = "purchase.group_purchase_manager"
+        condition = (
+            not self.env.su and user.has_group(group1) and not user.has_group(group3)
+        )
+        _self = self.sudo() if condition else self
+        sellers = super(SupplierInfo, _self)._get_filtered_supplier(
+            company_id=company_id, product_id=product_id, params=params
+        )
+        if condition:
+            partners = self.env["res.partner"].search(
+                [("id", "in", sellers.partner_id.ids)]
+            )
+            sellers = sellers.filtered(lambda x: x.partner_id in partners)
+        return sellers

--- a/purchase_security/tests/test_access_rights.py
+++ b/purchase_security/tests/test_access_rights.py
@@ -3,25 +3,17 @@
 # Copyright 2023 Tecnativa - Pedro M. Baeza
 # Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
-from odoo.tests import Form, common, new_test_user
+from odoo import Command
+from odoo.tests import Form, new_test_user
 from odoo.tests.common import users
 
+from odoo.addons.base.tests.common import BaseCommon
 
-class TestPurchaseOrderSecurity(common.TransactionCase):
+
+class TestPurchaseOrderSecurity(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(
-            context=dict(
-                cls.env.context,
-                mail_create_nolog=True,
-                mail_create_nosubscribe=True,
-                mail_notrack=True,
-                no_reset_password=True,
-                tracking_disable=True,
-            )
-        )
         # Teams
         cls.team1 = cls.env["purchase.team"].create({"name": "Team1"})
         cls.team2 = cls.env["purchase.team"].create({"name": "Team2"})
@@ -67,6 +59,34 @@ class TestPurchaseOrderSecurity(common.TransactionCase):
         cls.user_without_groups = new_test_user(cls.env, login="without_groups")
         # Partner for the POs
         cls.partner_po = cls.env["res.partner"].create({"name": "PO Partner"})
+        cls.partner_po_with_po_user = cls.env["res.partner"].create(
+            {
+                "name": "PO Partner (with purchase_user_id)",
+                "purchase_user_id": cls.user_po_manager.id,
+            }
+        )
+        # Product
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test product",
+                "seller_ids": [
+                    Command.create(
+                        {
+                            "partner_id": cls.partner_po_with_po_user.id,
+                            "min_qty": 1,
+                            "sequence": 10,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "partner_id": cls.partner_po.id,
+                            "min_qty": 2,
+                            "sequence": 20,
+                        }
+                    ),
+                ],
+            }
+        )
         # Purchase Order
         cls.orders = cls.env["purchase.order"].create(
             (
@@ -375,3 +395,19 @@ class TestPurchaseOrderSecurity(common.TransactionCase):
         self._check_permission(self.user_without_groups, False, True)
         self._check_permission(self.user_without_groups, self.team1, True)
         self._check_permission(self.user_without_groups, self.team2, True)
+
+    @users("group_purchase_own_orders")
+    def test_product_supplierinfo_access_01(self):
+        order_form = Form(self.env["purchase.order"])
+        with order_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+        self.assertTrue(line_form.product_id)
+        self.assertEqual(line_form.product_qty, 2)
+
+    @users("po_manager")
+    def test_product_supplierinfo_access_02(self):
+        order_form = Form(self.env["purchase.order"])
+        with order_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+        self.assertTrue(line_form.product_id)
+        self.assertEqual(line_form.product_qty, 1)


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/purchase-workflow/pull/2994

Prevent an access error when selecting a product in a purchase order

Fixes #2905 

Please @pedrobaeza and @dalonsod can you review it?

@Tecnativa