### PR TITLE
[19.0][FIX] purchase_request: prevent double-counting of purchase request line quantities in PO lines

### DIFF
--- a/purchase_request/models/purchase_request_line.py
+++ b/purchase_request/models/purchase_request_line.py
@@ -359,11 +359,12 @@ class PurchaseRequestLine(models.Model):
             supplierinfo_min_qty = self._get_supplier_min_qty(
                 po_line.product_id, po_line.order_id.partner_id
             )
-
-        rl_qty = 0.0
-        # Recompute quantity by adding existing running procurements.
-        for rl in po_line.purchase_request_lines:
-            rl_qty += rl.product_uom_id._compute_quantity(rl.product_qty, purchase_uom)
+        # At this point, the current request_line is already linked to the po_line
+        unique_rls = po_line.purchase_request_lines.exists()
+        rl_qty = sum(
+            rl.product_uom_id._compute_quantity(rl.product_qty, purchase_uom)
+            for rl in unique_rls
+        )
         qty = max(rl_qty, supplierinfo_min_qty)
         return qty
 

--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -252,7 +252,6 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             if available_po_lines and not item.keep_description:
                 new_pr_line = False
                 po_line = available_po_lines[0]
-                po_line.purchase_request_lines = [(4, line.id)]
                 po_line.move_dest_ids |= line.move_dest_ids
                 po_line_product_uom_qty = po_line.product_uom_id._compute_quantity(
                     po_line.product_uom_qty, alloc_uom
@@ -286,6 +285,9 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
             # we enforce to save the datetime value in the current tz of the user
             date_planned = self._get_date_with_user_tz(date_required)
             po_line.write({"product_qty": new_qty, "date_planned": date_planned})
+            # Now link the PR line to the PO line (if not already linked)
+            if line.id not in po_line.purchase_request_lines.ids:
+                po_line.purchase_request_lines = [(4, line.id)]
             res.append(purchase.id)
 
         purchase_requests = self.item_ids.mapped("request_id")


### PR DESCRIPTION
- This PR fixes a bug where purchase order line quantities were over-counted by 1 when converting purchase  requests to RFQs/POs.

- The wizard now links the purchase request line to the PO line only after the correct quantity is calculated and written, preventing double-counting.
- The _calc_new_qty method now simply sums all linked lines, matching Odoo 19.0 core logic.

The test cases are failing in the following PRs: https://github.com/OCA/purchase-workflow/pull/2996, https://github.com/OCA/purchase-workflow/pull/2997, https://github.com/OCA/purchase-workflow/pull/2998.