### PR TITLE
[18][FIX] purchase_security: Avoid write in not stored compute field

### DIFF
--- a/purchase_security/models/purchase_order.py
+++ b/purchase_security/models/purchase_order.py
@@ -27,7 +27,7 @@ class PurchaseOrder(models.Model):
         is_user_id_editable = self.env.user.has_group(
             "purchase.group_purchase_manager"
         ) or not self.env.user.has_group("purchase_security.group_purchase_own_orders")
-        self.write({"is_user_id_editable": is_user_id_editable})
+        self.is_user_id_editable = is_user_id_editable
 
     @api.depends("user_id")
     def _compute_team_id(self):


### PR DESCRIPTION
The write could causes issues for a user with readonly rights on purchase orders.
The `self.is_user_id_editable = is_user_id_editable` is working for multiple PO in recordset, maybe it would be cleaner to loop anyway, I can change this if needed.

@joao-p-marques @pilarvargas-tecnativa @dalonsod @Deriman-Alonso @bguillot 