### PR TITLE
[18.0][IMP] purchase_exception: Use hook to popup exception after rollback

### DIFF
--- a/purchase_exception/models/purchase.py
+++ b/purchase_exception/models/purchase.py
@@ -47,9 +47,12 @@ class PurchaseOrder(models.Model):
         if orders:
             orders._check_exception()
 
+    def _must_popup_exception(self):
+        return True
+
     def button_confirm(self):
         if self.detect_exceptions() and not self.ignore_exception:
-            return self._popup_exceptions()
+            return self.action_popup_exceptions()
         return super().button_confirm()
 
     def button_draft(self):

--- a/purchase_exception/models/purchase_line.py
+++ b/purchase_exception/models/purchase_line.py
@@ -24,3 +24,7 @@ class PurchaseOrderLine(models.Model):
     def _detect_exceptions(self, rule):
         records = super()._detect_exceptions(rule)
         return records.mapped("order_id")
+
+    def _detect_exception_get_exc_class_values(self):
+        res = super()._detect_exception_get_exc_class_values()
+        return dict(res, target_model="purchase.order")

--- a/purchase_exception/tests/test_purchase_exception.py
+++ b/purchase_exception/tests/test_purchase_exception.py
@@ -7,12 +7,17 @@ from datetime import datetime
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
 from odoo.addons.base.tests.common import BaseCommon
+from odoo.addons.base_exception.tests.common import (
+    patch_base_exception_method_env,
+    swallow_base_exception_error,
+)
 
 
 class TestPurchaseException(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, test_base_exception=True))
         # Useful models
         cls.PurchaseOrder = cls.env["purchase.order"]
         cls.PurchaseOrderLine = cls.env["purchase.order.line"]
@@ -71,6 +76,8 @@ class TestPurchaseException(BaseCommon):
             ],
         }
 
+    @patch_base_exception_method_env
+    @swallow_base_exception_error
     def test_purchase_order_exception(self):
         self.exception_noemail.active = True
         self.exception_qtycheck.active = True

--- a/purchase_order_approval_block/tests/test_po_approval_block_reason.py
+++ b/purchase_order_approval_block/tests/test_po_approval_block_reason.py
@@ -1,10 +1,16 @@
 # Copyright 2017 ForgeFlow S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from odoo.addons.base_exception.tests.common import (
+    patch_base_exception_method_env,
+    swallow_base_exception_error,
+)
+
 from .test_purchase_order_approval_block import TestPurchaseOrderApprovalBlock
 
 
 class TestPoApprovalBlockReason(TestPurchaseOrderApprovalBlock):
+    @patch_base_exception_method_env
     def test_po_approval_block_manual_release(self):
         """Confirming the Blocked PO"""
         # Create a PO
@@ -25,6 +31,8 @@ class TestPoApprovalBlockReason(TestPurchaseOrderApprovalBlock):
         # The PO is approved
         self.assertEqual(purchase.state, "purchase")
 
+    @patch_base_exception_method_env
+    @swallow_base_exception_error
     def test_po_approval_block_to_approve_release_01(self):
         # Create a PO
         purchase = self._create_purchase(
@@ -54,6 +62,8 @@ class TestPoApprovalBlockReason(TestPurchaseOrderApprovalBlock):
 
         self.assertEqual(purchase.state, "purchase")
 
+    @patch_base_exception_method_env
+    @swallow_base_exception_error
     def test_po_approval_block_to_approve_release_02(self):
         # Create a PO
         purchase = self._create_purchase(

--- a/purchase_order_approval_block/tests/test_purchase_order_approval_block.py
+++ b/purchase_order_approval_block/tests/test_purchase_order_approval_block.py
@@ -10,6 +10,7 @@ from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 class TestPurchaseOrderApprovalBlock(TransactionCase):
     def setUp(self):
         super().setUp()
+        self.env = self.env(context=dict(self.env.context, test_base_exception=True))
         self.users_obj = self.env["res.users"]
         self.po_obj = self.env["purchase.order"]
         self.po_block_obj = self.env["purchase.approval.block.reason"]

--- a/purchase_request_exception/models/purchase_request.py
+++ b/purchase_request_exception/models/purchase_request.py
@@ -36,9 +36,11 @@ class PurchaseRequest(models.Model):
         if self.state == "to_approve":
             self.ignore_exception = False
 
+    def _must_popup_exception(self):
+        return True
+
     def button_to_approve(self):
-        if self.detect_exceptions() and not self.ignore_exception:
-            return self._popup_exceptions()
+        self.detect_exceptions()
         return super().button_to_approve()
 
     def button_draft(self):

--- a/purchase_request_exception/models/purchase_request_line.py
+++ b/purchase_request_exception/models/purchase_request_line.py
@@ -22,3 +22,7 @@ class PurchaseRequestLine(models.Model):
     def _detect_exceptions(self, rule):
         records = super()._detect_exceptions(rule)
         return records.mapped("request_id")
+
+    def _detect_exception_get_exc_class_values(self):
+        res = super()._detect_exception_get_exc_class_values()
+        return dict(res, target_model="purchase.request")

--- a/purchase_request_exception/tests/test_purchase_request_exception.py
+++ b/purchase_request_exception/tests/test_purchase_request_exception.py
@@ -7,12 +7,17 @@ from odoo import Command
 from odoo.tests.common import TransactionCase
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
+from odoo.addons.base_exception.tests.common import (
+    patch_base_exception_method_env,
+    swallow_base_exception_error,
+)
+
 
 class TestPurchaseRequestException(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
+        cls.env = cls.env(context=dict(cls.env.context, test_base_exception=True))
         # Useful models
         cls.PurchaseRequest = cls.env["purchase.request"]
         cls.PurchaseRequestLine = cls.env["purchase.request.line"]
@@ -49,6 +54,8 @@ class TestPurchaseRequestException(TransactionCase):
             ],
         }
 
+    @patch_base_exception_method_env
+    @swallow_base_exception_error
     def test_purchase_request_exception(self):
         self.exception_noapprover.active = True
         self.exception_qtycheck.active = True


### PR DESCRIPTION
With OCA/server-tools#3590 changing the way exceptions are detected, the error raising doesn't allow to call `_popup_exception` as we used to, but we can use the new hook to have the popup displayed smoothly.

Depends on:
 - [ ] https://github.com/OCA/server-tools/pull/3590