### PR TITLE
[16.0][FIX] purchase_order_approved: skip purchase amount validation if it was already approved

### DIFF
--- a/purchase_order_approved/models/purchase_order.py
+++ b/purchase_order_approved/models/purchase_order.py
@@ -29,6 +29,13 @@ class PurchaseOrder(models.Model):
     def button_release(self):
         return super(PurchaseOrder, self).button_approve()
 
+    def _approval_allowed(self):
+        # Skip first approval if PO is already approved
+        res = super()._approval_allowed()
+        if self.state == "approved":
+            return True
+        return res
+
     def button_approve(self, force=False):
         two_steps_purchase_approval_ids = []
         for rec in self:

--- a/purchase_order_approved/tests/test_purchase_order.py
+++ b/purchase_order_approved/tests/test_purchase_order.py
@@ -117,3 +117,45 @@ class TestPurchaseOrder(TransactionCase):
         self.supplier.purchase_requires_second_approval = "always"
         self.purchase_order.button_approve()
         self.assertEqual(self.purchase_order.state, "approved")
+
+    def test_06(self):
+        """
+        Data:
+            * one draft PO (amount_total = 1000)
+            * supplier configured with purchase request second approval
+            set to 'always'
+            * company configured with two-step validation and a low threshold
+            * a purchase user (not a manager) and a purchase manager
+        Test Case:
+            * purchase user confirms the PO (goes to 'to approve')
+            * manager approves the PO (goes to 'approved')
+            * purchase user releases the PO via button_release
+        Expected result:
+            * PO is in state 'purchase' because _approval_allowed returns
+              True for 'approved' state
+        """
+        purchase_user = self.env["res.users"].create(
+            {
+                "name": "Purchase User",
+                "login": "purchase_user_test",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [self.env.ref("purchase.group_purchase_user").id],
+                    )
+                ],
+            }
+        )
+        self.purchase_order.company_id.po_double_validation = "two_step"
+        self.purchase_order.company_id.po_double_validation_amount = 0.0
+        self.supplier.purchase_requires_second_approval = "always"
+        # Purchase user confirms → PO goes to 'to approve'
+        self.purchase_order.with_user(purchase_user).button_confirm()
+        self.assertEqual(self.purchase_order.state, "to approve")
+        # Manager approves → PO goes to 'approved' (two-step from module)
+        self.purchase_order.button_approve()
+        self.assertEqual(self.purchase_order.state, "approved")
+        # Purchase user releases → PO goes to 'purchase'
+        self.purchase_order.with_user(purchase_user).button_release()
+        self.assertEqual(self.purchase_order.state, "purchase")


### PR DESCRIPTION
When using Odoo standard PO amount validation, the check is done on button_approve. If we are using this module, when doing the button_release the amount validation has already been approved before, so we need to prevent it from being done again. Otherwise, purchase user can't do the release.

CC @HviorForgeFlow @rousseldenis @lmignon 