### PR TITLE
[18.0][IMP] procurement_purchase_no_grouping: Remove the default value at the category level

### DIFF
--- a/procurement_purchase_no_grouping/models/product_category.py
+++ b/procurement_purchase_no_grouping/models/product_category.py
@@ -15,7 +15,6 @@ class ProductCategory(models.Model):
             ("order", "No order grouping"),
             ("product_category", "Product category grouping"),
         ],
-        default="standard",
         help="Select the behaviour for grouping procured purchases for the "
         "the products of this category:\n"
         "* Standard grouping (default): Procurements will generate "


### PR DESCRIPTION
To allow using the default setting at the company level. If a user wants to set a value at the category level, it will take priority, but with a default value defined here, it is impossible to use a default value at the company level. For this reason, we removed the default value at the category level.


TT61743
@Tecnativa @pedrobaeza @victoralmau could you please review this?