### PR TITLE
[FIX] purchase_request: handle move_dest_ids as False in Odoo 18

### DIFF
--- a/purchase_request/models/stock_rule.py
+++ b/purchase_request/models/stock_rule.py
@@ -22,7 +22,7 @@ class StockRule(models.Model):
             "product_qty": procurement_uom_po_qty,
             "request_id": request_id.id,
             "move_dest_ids": [
-                (4, x.id) for x in procurement.values.get("move_dest_ids", [])
+                (4, x.id) for x in (procurement.values.get("move_dest_ids") or [])
             ],
             "orderpoint_id": procurement.values.get("orderpoint_id", False)
             and procurement.values.get("orderpoint_id").id,

--- a/purchase_request/tests/test_purchase_request_procurement.py
+++ b/purchase_request/tests/test_purchase_request_procurement.py
@@ -167,3 +167,30 @@ class TestPurchaseRequestProcurement(common.TransactionCase):
         move4 = self._procurement_group_run("Split", self.product_1, 10)
         self.assertEqual(move4.created_purchase_request_line_id.request_id, pr)
         self.assertEqual(pr.origin, "Test Origin, Test, Split")
+
+    def test_procurement_without_move_dest_ids(self):
+        """Test that procurement works when move_dest_ids is False/None.
+
+        This tests the fix for issue #2927 where move_dest_ids could be
+        a boolean False in Odoo 18 instead of an empty list, causing
+        TypeError: 'bool' object is not iterable
+        """
+        move = self.env["stock.move"].create(
+            {
+                "reservation_date": fields.Datetime.now(),
+                "location_dest_id": self.customer_location.id,
+                "location_id": self.location.id,
+                "name": self.product_1.name,
+                "origin": "Test Move Dest Ids",
+                "procure_method": "make_to_order",
+                "product_id": self.product_1.id,
+                "product_uom": self.product_1.uom_id.id,
+                "product_uom_qty": 5,
+                "route_ids": [(4, self.route_buy.id)],
+                # Explicitly set move_dest_ids to False (simulating Odoo 18 edge case)
+                "move_dest_ids": [(5, 0, 0)],
+            }
+        )
+        # This should not raise TypeError: 'bool' object is not iterable
+        move._action_confirm()
+        self.assertTrue(move.created_purchase_request_line_id)


### PR DESCRIPTION
## Description

In Odoo 18, `procurement.values.get('move_dest_ids')` can return `False` (boolean) instead of an empty list when no destination moves exist.

The previous code used `get('move_dest_ids', [])` which only uses the default when the key doesn't exist, not when it's explicitly `False`.

This causes: `TypeError: 'bool' object is not iterable`

## Fix

Changed line 25 in `purchase_request/models/stock_rule.py` from:
```python
(4, x.id) for x in procurement.values.get("move_dest_ids", [])
```

to:
```python
(4, x.id) for x in (procurement.values.get("move_dest_ids") or [])
```

This ensures we always have an iterable list.

## Related Issue

Closes https://github.com/OCA/purchase-workflow/issues/2927

---

I am a contributor from the SMWLAB community and this is my first OCA PR. Please review!