### PR TITLE
[17.0][FIX] purchase_order_general_discount: prevent overriding manual line discounts

### DIFF
--- a/purchase_order_general_discount/models/purchase_order.py
+++ b/purchase_order_general_discount/models/purchase_order.py
@@ -36,7 +36,7 @@ class PurchaseOrder(models.Model):
         discount_field = self.company_id.purchase_general_discount_field
         return discount_field or "discount"
 
-    @api.onchange("general_discount", "order_line")
+    @api.onchange("general_discount")
     def onchange_general_discount(self):
         discount_field = self._get_general_discount_field()
         self.mapped("order_line").update({discount_field: self.general_discount})

--- a/purchase_order_general_discount/tests/test_purchase_order_general_discount.py
+++ b/purchase_order_general_discount/tests/test_purchase_order_general_discount.py
@@ -47,3 +47,29 @@ class TestPurchaseOrderLineInput(TransactionCase):
             order_form.general_discount = 10
             with order_form.order_line.edit(0) as line_form:
                 self.assertEqual(line_form.discount, 10)
+
+    def test_04_manual_line_discount_not_overwritten(self):
+        """Ensure manual line discount is not overridden by general discount onchange.
+        Scenario:
+        - Apply a general discount → it propagates to all lines.
+        - Modify the discount manually on a line.
+        - Ensure the manual value is preserved.
+        This validates that the onchange is no longer triggered on order_line changes.
+        """
+        company = self.order.company_id
+        company.purchase_general_discount_field = "discount"
+        po_form_view_xmlid = "purchase_order_general_discount.purchase_order_form"
+        with Form(self.order, po_form_view_xmlid) as order_form:
+            # Step 1: Apply global discount
+            order_form.general_discount = 10
+            # Step 2: Manually override line discount
+            with order_form.order_line.edit(0) as line_form:
+                line_form.discount = 20
+            # Step 3: Re-open line and verify value is preserved
+            with order_form.order_line.edit(0) as line_form:
+                self.assertEqual(
+                    line_form.discount,
+                    20,
+                    "Manual discount should not be overridden by general "
+                    "discount onchange",
+                )


### PR DESCRIPTION
@BinhexTeam

## Problem

When modifying discounts on purchase order lines, the onchange defined in
`purchase_order_general_discount` is triggered due to the dependency on
`order_line`.

This causes the general discount to be reapplied automatically,
overriding any manual changes performed by the user.

## Root cause

The onchange decorator includes `order_line`:

    @api.onchange("general_discount", "order_line")

This causes the method to be triggered on any modification of order lines.

## Solution

Restrict the onchange trigger to `general_discount` only.

## Result

- Changing general discount applies to all lines ✔
- Manual edits on line discounts are preserved ✔
- No unintended overwrites occur ✔

## Tests

A new test has been added to ensure that manual overrides on line discounts
are not lost after editing.

## Notes

This issue becomes especially visible when using modules such as
`purchase_triple_discount`, but can affect any module that modifies
line-level discounts.