### PR TITLE
[18.0][FIX] purchase_order_secondary_unit: remove hide_secondary_uom_column from portal

### DIFF
--- a/purchase_order_secondary_unit/views/purchase_order_portal_templates.xml
+++ b/purchase_order_secondary_unit/views/purchase_order_portal_templates.xml
@@ -26,18 +26,12 @@
             expr="//table[@id='purchase_order_table']//thead//th[normalize-space()='Quantity']"
             position="before"
         >
-            <th
-                class="text-end"
-                t-if="not order.company_id.hide_secondary_uom_column(order)"
-            >
+            <th class="text-end">
                 <strong>Second Qty</strong>
             </th>
         </xpath>
         <xpath expr="//td[@id='product_name']" position="after">
-            <td
-                class="text-end"
-                t-if="not order.company_id.hide_secondary_uom_column(order)"
-            >
+            <td class="text-end">
                 <span t-field="line.secondary_uom_qty" />
                 <span t-field="line.secondary_uom_id.name" groups="uom.group_uom" />
             </td>


### PR DESCRIPTION
Removes references to `hide_secondary_uom_column` from portal templates. This method was never implemented on `res.company` — it belonged to an unmerged dependency module. The same fix was already applied to the report template in commit `ff39d04d4`.

**Error**:
```
AttributeError: 'res.company' object has no attribute 'hide_secondary_uom_column'
Template: purchase.report_purchaseorder_document
```

Closes #2951