### PR TITLE
[FIX] purchase_discount: match SQL constraint with Postgres format

### DIFF
--- a/purchase_discount/models/product_supplierinfo.py
+++ b/purchase_discount/models/product_supplierinfo.py
@@ -25,7 +25,7 @@ class ProductSupplierInfo(models.Model):
     _sql_constraints = [
         (
             "discount_limit",
-            "CHECK (discount <= 100.0)",
+            "CHECK ((discount <= 100.0))",
             "Supplier discount must be lower than 100%.",
         )
     ]


### PR DESCRIPTION
Odoo drops and recreates constraints if the Python definition does not exactly match the definition returned by PostgreSQL. Because PostgreSQL normalizes the expression to include extra parentheses, the previous definition 'CHECK (discount <= 100.0)' caused a mismatch.

This mismatch led to a DuplicateObject exception during module update because the drop constraint operation was skipped or failed silently and the subsequent add constraint operation failed, raising a WARNING in the logs and failing strict CI checks.

By matching the exact string returned by PostgreSQL, we prevent Odoo from attempting to recreate the constraint on every registry initialization.