### PR TITLE
[18.0][IMP] Add the support for synchronization of other fields from PO lines to supplierinfo, like discount (from module purchase_discount) from #2685

### DIFF
--- a/purchase_order_supplierinfo_update/models/purchase_order.py
+++ b/purchase_order_supplierinfo_update/models/purchase_order.py
@@ -26,7 +26,8 @@ class PurchaseOrderLine(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if vals.get("price_unit") or vals.get("discount"):
+        sync_fields = self._get_synch_fields_line_to_supplierinfo()
+        if vals.get("price_unit") or any(key in sync_fields for key in vals.keys()):
             self.update_supplierinfo_price()
         return res
 
@@ -70,5 +71,14 @@ class PurchaseOrderLine(models.Model):
         # Set price
         if new_seller_price != seller.price:
             seller.sudo().price = new_seller_price
-        if self.discount != seller.discount:
-            seller.sudo().discount = self.discount
+
+        sync_fields = self._get_synch_fields_line_to_supplierinfo()
+        for field in sync_fields:
+            if field in seller and field in self:
+                seller.sudo()[field] = self[field]
+
+    def _get_synch_fields_line_to_supplierinfo(self):
+        sync_fields = ["discount"]
+        if "triple.discount.mixin" in self.env:
+            sync_fields += ["discount1", "discount2", "discount3"]
+        return sync_fields


### PR DESCRIPTION
This PR is a forward-port of #2685 from v16 to v18.0

The original commits have been squashed into a single commit to maintain a clean history. The code has also been adapted to work with the Odoo 18.0 API and the recent structural changes of the module in this version.

Original PR: OCA/purchase-workflow#2685