### PR TITLE
[18.0][FIX] purchase_blanket_order: add company_id filter to eligible BO lines domain

### DIFF
--- a/purchase_blanket_order/models/purchase_order.py
+++ b/purchase_blanket_order/models/purchase_order.py
@@ -104,6 +104,11 @@ class PurchaseOrderLine(models.Model):
             ("remaining_qty", ">=", base_qty),
             ("currency_id", "=", self.order_id.currency_id.id),
             ("order_id.state", "=", "open"),
+            (
+                "company_id",
+                "in",
+                [False, self.order_id.company_id.id],
+            ),
         ]
         if self.order_id.partner_id:
             filters.append(("partner_id", "=", self.order_id.partner_id.id))

--- a/purchase_blanket_order/tests/test_purchase_order.py
+++ b/purchase_blanket_order/tests/test_purchase_order.py
@@ -215,3 +215,36 @@ class TestPurchaseOrder(common.TransactionCase):
         # change partner of the PO line
         with self.assertRaises(ValidationError):
             po.write({"partner_id": self.partner_2})
+
+    def test_get_eligible_bo_lines_domain_company_filter(self):
+        """Domain must include company_id to prevent cross-company leakage."""
+        blanket_order = self.create_blanket_order_01()
+        blanket_order.sudo().action_confirm()
+        po = self.purchase_order_obj.create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_qty": 5.0,
+                            "product_uom": self.product.uom_po_id.id,
+                            "date_planned": date.today(),
+                            "price_unit": 10.0,
+                        },
+                    )
+                ],
+            }
+        )
+        po_line = po.order_line[0]
+        domain = po_line._get_eligible_bo_lines_domain(5.0)
+        self.assertIn(
+            ("company_id", "in", [False, po.company_id.id]),
+            domain,
+        )
+        # Ensure other expected filters are still present
+        self.assertIn(("product_id", "=", self.product.id), domain)
+        self.assertIn(("order_id.state", "=", "open"), domain)


### PR DESCRIPTION
Fixes #2958

In multi-company environments, _get_eligible_bo_lines_domain did not filter by company_id. This could match blanket order lines from other companies or raise AccessError when the other company was not active.

Changes:
- Add ('company_id', 'in', [False, self.order_id.company_id.id]) to the domain
- Supports shared/global blanket orders (company_id=False)
- Add test asserting company_id appears in the returned domain