### PR TITLE
[19.0][IMP] purchase_partner_incoterm: add default purchase incoterm location

### DIFF
--- a/purchase_partner_incoterm/models/purchase_order.py
+++ b/purchase_partner_incoterm/models/purchase_order.py
@@ -19,4 +19,7 @@ class PurchaseOrder(models.Model):
         self.incoterm_address_id = (
             self.partner_id.commercial_partner_id.purchase_incoterm_address_id
         )
+        self.incoterm_location = (
+            self.partner_id.commercial_partner_id.purchase_incoterm_location
+        )
         return res

--- a/purchase_partner_incoterm/models/res_partner.py
+++ b/purchase_partner_incoterm/models/res_partner.py
@@ -16,10 +16,14 @@ class ResPartner(models.Model):
         ondelete="restrict",
         string="Default Purchase Incoterm Address",
     )
+    purchase_incoterm_location = fields.Char(
+        string="Default Purchase Incoterm Location",
+    )
 
     @api.model
     def _commercial_fields(self):
         return super()._commercial_fields() + [
             "purchase_incoterm_address_id",
             "purchase_incoterm_id",
+            "purchase_incoterm_location",
         ]

--- a/purchase_partner_incoterm/tests/test_purchase_partner_incoterm.py
+++ b/purchase_partner_incoterm/tests/test_purchase_partner_incoterm.py
@@ -30,6 +30,7 @@ class TestPurchasePartnerIncoterm(TransactionCase):
                 "name": "Test Partner",
                 "purchase_incoterm_id": cls.incoterm.id,
                 "purchase_incoterm_address_id": cls.incoterm_address.id,
+                "purchase_incoterm_location": "Test Location",
             }
         )
 
@@ -50,4 +51,8 @@ class TestPurchasePartnerIncoterm(TransactionCase):
         self.assertEqual(
             self.purchase_order.incoterm_address_id,
             self.partner.purchase_incoterm_address_id,
+        )
+        self.assertEqual(
+            self.purchase_order.incoterm_location,
+            self.partner.purchase_incoterm_location,
         )

--- a/purchase_partner_incoterm/views/partner_view.xml
+++ b/purchase_partner_incoterm/views/partner_view.xml
@@ -8,6 +8,7 @@
             <group name="purchase" position="inside">
                 <field name="purchase_incoterm_id" readonly="parent_id" />
                 <field name="purchase_incoterm_address_id" readonly="parent_id" />
+                <field name="purchase_incoterm_location" readonly="parent_id" />
             </group>
         </field>
     </record>


### PR DESCRIPTION
Add purchase_incoterm_location to res.partner to define a default incoterm location for purchases. It maps to incoterm_location on purchase.order.