### PR TITLE
[18.0][IMP] purchase_invoice_status_line: control policy

### DIFF
--- a/purchase_invoice_status_line/models/purchase_order_line.py
+++ b/purchase_invoice_status_line/models/purchase_order_line.py
@@ -27,7 +27,7 @@ class PurchaseOrderLine(models.Model):
         "even if some quantities are not fully invoiced. ",
     )
 
-    @api.depends("qty_invoiced", "product_qty", "force_invoiced")
+    @api.depends("qty_invoiced", "qty_to_invoice", "product_qty", "force_invoiced")
     def _compute_invoice_status(self):
         precision = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"

--- a/purchase_invoice_status_line/models/purchase_order_line.py
+++ b/purchase_invoice_status_line/models/purchase_order_line.py
@@ -27,6 +27,25 @@ class PurchaseOrderLine(models.Model):
         "even if some quantities are not fully invoiced. ",
     )
 
+    purchase_method = fields.Selection(
+        selection=[
+            ("purchase", "On ordered"),
+            ("receive", "On received"),
+        ],
+        string="Control Policy",
+        compute="_compute_purchase_method",
+        store=True,
+    )
+
+    @api.depends("product_id", "qty_to_invoice")
+    def _compute_purchase_method(self):
+        # qty_to_invoice is a dependency on purpose: changing the policy on the
+        # product does not recompute existing lines, so this snapshot is
+        # refreshed whenever invoicing is recomputed (the moment the policy is
+        # actually applied), keeping it in sync with the billing status.
+        for line in self:
+            line.purchase_method = line.product_id.purchase_method
+
     @api.depends("qty_invoiced", "qty_to_invoice", "product_qty", "force_invoiced")
     def _compute_invoice_status(self):
         precision = self.env["decimal.precision"].precision_get(

--- a/purchase_invoice_status_line/models/purchase_order_line.py
+++ b/purchase_invoice_status_line/models/purchase_order_line.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from odoo.tools import float_is_zero
+from odoo.tools import float_compare
 
 
 class PurchaseOrderLine(models.Model):
@@ -61,10 +61,9 @@ class PurchaseOrderLine(models.Model):
             if line.force_invoiced:
                 line.invoice_status = "invoiced"
                 continue
-            if float_is_zero(line.qty_to_invoice, precision_digits=precision):
-                if line.qty_invoiced >= line.product_qty:
-                    line.invoice_status = "invoiced"
-                else:
-                    line.invoice_status = "no"
-            else:
+            if float_compare(line.qty_to_invoice, 0, precision_digits=precision) > 0:
                 line.invoice_status = "to invoice"
+            elif line.qty_invoiced >= line.product_qty:
+                line.invoice_status = "invoiced"
+            else:
+                line.invoice_status = "no"

--- a/purchase_invoice_status_line/tests/test_purchase_invoice_status_line.py
+++ b/purchase_invoice_status_line/tests/test_purchase_invoice_status_line.py
@@ -93,3 +93,20 @@ class TestPurchaseInvoiceStatusLine(common.TransactionCase):
         self.assertFalse(line2.force_invoiced, "L2 should be un-forced by PO")
         self.assertEqual(line1.invoice_status, "to invoice")
         self.assertEqual(line2.invoice_status, "to invoice")
+
+    def test_purchase_method_snapshot(self):
+        po = self._create_purchase_order(self.product_received, 10)
+        line = po.order_line[0]
+        self.assertEqual(line.purchase_method, "receive")
+        self.product_received.write({"purchase_method": "purchase"})
+        self.assertEqual(
+            line.purchase_method,
+            "receive",
+            "Changing the product policy must not recompute existing lines",
+        )
+        line.write({"product_qty": 12})
+        self.assertEqual(
+            line.purchase_method,
+            "purchase",
+            "A change that recomputes invoicing must refresh the snapshot",
+        )

--- a/purchase_invoice_status_line/tests/test_purchase_invoice_status_line.py
+++ b/purchase_invoice_status_line/tests/test_purchase_invoice_status_line.py
@@ -1,6 +1,7 @@
 # Copyright 2025 ForgeFlow (http://www.forgeflow.com/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo import fields
 from odoo.tests import common
 
 
@@ -109,4 +110,24 @@ class TestPurchaseInvoiceStatusLine(common.TransactionCase):
             line.purchase_method,
             "purchase",
             "A change that recomputes invoicing must refresh the snapshot",
+        )
+
+    def test_invoice_status_over_billed(self):
+        po = self._create_purchase_order(self.product_order, 4)
+        line = po.order_line[0]
+        self.assertEqual(line.invoice_status, "to invoice")
+        po.action_create_invoice()
+        bill = po.invoice_ids
+        inv_line = bill.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.product_order
+        )
+        inv_line.write({"quantity": 6})
+        bill.write({"invoice_date": fields.Date.today()})
+        bill.action_post()
+        self.assertEqual(line.qty_invoiced, 6)
+        self.assertLess(line.qty_to_invoice, 0)
+        self.assertEqual(
+            line.invoice_status,
+            "invoiced",
+            "An over-billed line must not show Waiting Bills",
         )

--- a/purchase_invoice_status_line/views/purchase_order_line_views.xml
+++ b/purchase_invoice_status_line/views/purchase_order_line_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="product_uom" position="after">
                 <field name="state" column_invisible="1" />
+                <field name="purchase_method" optional="hide" />
                 <field name="invoice_status" />
                 <field
                     name="force_invoiced"


### PR DESCRIPTION
Adds the product Control Policy (On ordered / On received) as an optional column on the PO line, to make clear why a line is in Waiting Bills vs Nothing to Bill. The value is a stored snapshot synced with the invoicing recompute, so it stays consistent with qty_to_invoice and is not altered retroactively when the product policy changes.

Includes a minor fix: `_compute_invoice_status` was using `qty_to_invoice` without declaring the dependency.

It also fixes the billing status for over-billed lines (negative qty_to_invoice): these were wrongly shown as Waiting Bills. Now only a strictly positive qty_to_invoice shows Waiting Bills.