### PR TITLE
[16.0][FIX] purchase_request: set name explicitly in _prepare_purchase_order_line

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -164,7 +164,9 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         min_qty = item.line_id._get_supplier_min_qty(product, po.partner_id)
         qty = max(qty, min_qty)
         date_required = item.line_id.date_required
+        name = self._get_purchase_line_name(po, item)
         return {
+            "name": name,
             "order_id": po.id,
             "product_id": product.id,
             "product_uom": product.uom_po_id.id or product.uom_id.id,
@@ -194,10 +196,9 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
     @api.model
     def _get_order_line_search_domain(self, order, item):
         vals = self._prepare_purchase_order_line(order, item)
-        name = self._get_purchase_line_name(order, item)
         order_line_data = [
             ("order_id", "=", order.id),
-            ("name", "=", name),
+            ("name", "=", vals["name"]),
             ("product_id", "=", item.product_id.id),
             ("product_uom", "=", vals["product_uom"]),
             ("analytic_distribution", "=?", item.line_id.analytic_distribution),


### PR DESCRIPTION
Create purchase order line with explicit name from a purchase request to avoid conflicts with other modules like purchaser_order_line_description, and keep search compatibility to find candidates to merge with the name.

Fixes CI from https://github.com/OCA/purchase-workflow/pull/2864

@chienandalu @rafaelbn 