### PR TITLE
[18.0][FIX] purchase_allowed_product: avoid parent in line form

### DIFF
--- a/purchase_allowed_product/views/account_move_views.xml
+++ b/purchase_allowed_product/views/account_move_views.xml
@@ -32,10 +32,10 @@
             <field name="product_id" position="attributes">
                 <attribute name="context">
                     {
-                    'restrict_supplier_id': parent.partner_id,
+                    'restrict_supplier_id': move_id.partner_id,
                     'use_only_supplied_product':
-                        parent.move_type in ('in_invoice', 'in_refund', 'in_receipt')
-                        and parent.use_only_supplied_product
+                        move_id.move_type in ('in_invoice', 'in_refund', 'in_receipt')
+                        and move_id.use_only_supplied_product
                 }</attribute>
             </field>
         </field>


### PR DESCRIPTION
This fixes the standalone form crash in when the field context is evaluated without an x2many parent scope.

Cause
- the inherited standalone form view used in the context
- standalone move line forms do not define, so the web client raised 
Solution
- replace references with in the standalone move line form view
- add a regression test asserting the merged form architecture uses and no longer references 

Refs #3070