### PR TITLE
[18.0][FW][IMP] purchase_order_approved: show PO name in approved state

### DIFF
--- a/purchase_no_rfq/reports/purchase_order_template.xml
+++ b/purchase_no_rfq/reports/purchase_order_template.xml
@@ -9,9 +9,9 @@
             expr="//t[@t-if=&quot;o.state in ['draft', 'sent', 'to approve']&quot;]"
             position="replace"
         >
-            <h2 t-if="o.state in ['draft', 'sent', 'to approve']">Purchase Order #<span
+            <t t-if="o.state in ['draft', 'sent', 'to approve']">Purchase Order #<span
                 t-field="o.name"
-            /></h2>
+            /></t>
         </xpath>
     </template>
 </odoo>

--- a/purchase_order_approved/__manifest__.py
+++ b/purchase_order_approved/__manifest__.py
@@ -15,5 +15,6 @@
         "views/res_partner.xml",
         "views/purchase_order_view.xml",
         "views/res_config_view.xml",
+        "reports/purchase_order_template.xml",
     ],
 }

--- a/purchase_order_approved/reports/purchase_order_template.xml
+++ b/purchase_order_approved/reports/purchase_order_template.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template
+        id="report_purchaseorder_document"
+        inherit_id="purchase.report_purchaseorder_document"
+        priority="200"
+    >
+        <xpath
+            expr="//t[@t-if=&quot;o.state in ['draft', 'sent', 'to approve']&quot;]"
+            position="attributes"
+        >
+            <attribute
+                name="t-if"
+            >o.state in ['draft', 'sent', 'to approve', 'approved']</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
FW of https://github.com/OCA/purchase-workflow/pull/3086

Had to fix purchase_no_rfq as it was keeping the h2 tag from previous version. In v18: https://github.com/odoo/odoo/blob/18.0/addons/purchase/report/purchase_order_templates.xml#L24