### PR TITLE
[19.0][FIX] purchase_request: handle False move_dest_ids in procurement values

### DIFF
--- a/purchase_request/models/stock_rule.py
+++ b/purchase_request/models/stock_rule.py
@@ -23,7 +23,7 @@ class StockRule(models.Model):
             "product_qty": procurement_uom_po_qty,
             "request_id": request_id.id,
             "move_dest_ids": [
-                (4, x.id) for x in procurement.values.get("move_dest_ids", [])
+                (4, x.id) for x in (procurement.values.get("move_dest_ids") or [])
             ],
             "orderpoint_id": procurement.values.get("orderpoint_id", False)
             and procurement.values.get("orderpoint_id").id,


### PR DESCRIPTION
## Summary

- `dict.get("move_dest_ids", [])` only falls back to `[]` when the key is **absent** from the dict. Odoo stores empty relational fields as `False`, so when the key is present with value `False` the default is bypassed and iterating over `False` raises `TypeError: 'bool' object is not iterable`.
- Fixed by switching to `(procurement.values.get("move_dest_ids") or [])`, which handles both the absent-key and `False`-value cases — matching the pattern already used by `purchase_stock` core for the same field.

Fixes #2985