### PR TITLE
[18.0][FIX] purchase_request_substate: active demo false

### DIFF
--- a/purchase_request_substate/demo/purchase_request_substate_demo.xml
+++ b/purchase_request_substate/demo/purchase_request_substate_demo.xml
@@ -5,11 +5,13 @@
         <field name="name">To Verify</field>
         <field name="sequence">1</field>
         <field name="target_state_value_id" ref="target_state_value_to_approve" />
+        <field name="active" eval="False" />
     </record>
     <record id="base_substate_checked" model="base.substate">
         <field name="name">Checked</field>
         <field name="sequence">2</field>
         <field name="target_state_value_id" ref="target_state_value_to_approve" />
+        <field name="active" eval="False" />
     </record>
     <record id="base_substate_verified" model="base.substate">
         <field name="name">Verified</field>
@@ -19,5 +21,6 @@
             name="mail_template_id"
             ref="purchase_request_substate.mail_template_data_purchase_request_substate_verified"
         />
+        <field name="active" eval="False" />
     </record>
 </odoo>


### PR DESCRIPTION
### Fix `purchase_request_substate` in version 18.0

Updated `purchase_request_substate_demo.xml` to restore `active=False` on the demo substate record.
This change aligns the demo data with the behavior in version 15.0, where the record was defined as inactive by default.
