### PR TITLE
[19.0][FIX] purchase_partner_incoterm: set default incoterm on replenishmen…

### DIFF
--- a/purchase_partner_incoterm/models/__init__.py
+++ b/purchase_partner_incoterm/models/__init__.py
@@ -1,2 +1,3 @@
 from . import purchase_order
 from . import res_partner
+from . import stock_rule

--- a/purchase_partner_incoterm/models/stock_rule.py
+++ b/purchase_partner_incoterm/models/stock_rule.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _prepare_purchase_order(self, company_id, origins, values):
+        vals = super()._prepare_purchase_order(company_id, origins, values)
+        partner = self.env["res.partner"].browse(vals["partner_id"])
+        if not partner:
+            return vals
+        commercial_partner = partner.commercial_partner_id
+        vals["incoterm_id"] = commercial_partner.purchase_incoterm_id.id
+        vals["incoterm_address_id"] = commercial_partner.purchase_incoterm_address_id.id
+        vals["incoterm_location"] = commercial_partner.purchase_incoterm_location
+        return vals

--- a/purchase_partner_incoterm/tests/test_purchase_partner_incoterm.py
+++ b/purchase_partner_incoterm/tests/test_purchase_partner_incoterm.py
@@ -1,3 +1,4 @@
+from odoo import fields
 from odoo.tests.common import TransactionCase
 
 
@@ -56,3 +57,46 @@ class TestPurchasePartnerIncoterm(TransactionCase):
             self.purchase_order.incoterm_location,
             self.partner.purchase_incoterm_location,
         )
+
+    def test_prepare_purchase_order_from_stock_rule_sets_incoterm_fields(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Product Test",
+                "type": "consu",
+            }
+        )
+        supplier = self.env["product.supplierinfo"].create(
+            {
+                "partner_id": self.partner.id,
+                "product_tmpl_id": product.product_tmpl_id.id,
+                "min_qty": 1.0,
+                "delay": 1,
+                "price": 10.0,
+            }
+        )
+        stock_rule = self.env["stock.rule"].search(
+            [
+                ("action", "=", "buy"),
+                ("company_id", "=", self.env.company.id),
+                ("picking_type_id", "!=", False),
+            ],
+            limit=1,
+        )
+        self.assertTrue(stock_rule, "Expected at least one buy stock rule")
+
+        values = [
+            {
+                "supplier": supplier,
+                "date_planned": fields.Datetime.to_string(fields.Datetime.now()),
+                "reference_ids": self.env["stock.reference"],
+            }
+        ]
+        po_vals = stock_rule._prepare_purchase_order(
+            self.env.company,
+            ["Test Origin"],
+            values,
+        )
+
+        self.assertEqual(po_vals.get("incoterm_id"), self.incoterm.id)
+        self.assertEqual(po_vals.get("incoterm_address_id"), self.incoterm_address.id)
+        self.assertEqual(po_vals.get("incoterm_location"), "Test Location")


### PR DESCRIPTION
…t RFQs

POs created from stock rules (replenishment/scheduler) bypass onchange_partner_id, so incoterm_id, incoterm_address_id, and incoterm_location were not populated.