### PR TITLE
[19.0][FIX] purchase_force_invoiced: handle batch invoice creation

### DIFF
--- a/purchase_force_invoiced/model/purchase_order.py
+++ b/purchase_force_invoiced/model/purchase_order.py
@@ -25,6 +25,12 @@ class PurchaseOrder(models.Model):
         return res
 
     def action_create_invoice(self, attachment_ids=False):
-        if self.force_invoiced:
+        orders_to_invoice = self.env["purchase.order"]
+        for order in self:
+            if not order.force_invoiced:
+                orders_to_invoice |= order
+        if not orders_to_invoice:
             return {"type": "ir.actions.act_window_close"}
-        return super().action_create_invoice(attachment_ids=attachment_ids)
+        return super(PurchaseOrder, orders_to_invoice).action_create_invoice(
+            attachment_ids=attachment_ids
+        )


### PR DESCRIPTION

## Description

Avoid reading `force_invoiced` directly on a multi-record purchase order recordset when creating vendor bills.

The method now preserves the standard multi-record behavior of `purchase.order.action_create_invoice` while skipping purchase orders that have been manually marked as fully billed.


### Issue

When creating vendor bills from multiple purchase orders at once, the module may raise an `Expected singleton` error.

This happens because `action_create_invoice` reads `self.force_invoiced` directly, which only works when `self` contains a single purchase order. In batch flows, `self` can contain several purchase orders.
### Error
File "/opt/odoo/src/odoo/odoo/addons/web/controllers/[dataset.py](http://dataset.py/)", line 38, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/src/odoo/odoo/odoo/service/[model.py](http://model.py/)", line 97, in call_kw
    result = method(recs, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/src/oca/purchase-workflow/purchase_force_invoiced/model/[purchase_order.py](http://purchase_order.py/)", line 28, in action_create_invoice
    if self.force_invoiced:
       ^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/src/odoo/odoo/odoo/orm/[fields.py](http://fields.py/)", line 1659, in __get__
    record.ensure_one()
  File "/opt/odoo/src/odoo/odoo/odoo/orm/[models.py](http://models.py/)", line 5940, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: purchase.order(9433, 9409)

### Proposed fix

Filter out purchase orders marked as `force_invoiced` before delegating to the standard `action_create_invoice` implementation.

If all selected purchase orders are marked as forced invoiced, the action simply closes without creating a bill, preserving the module's intended behavior.

### Steps to reproduce

1. Install `purchase_force_invoiced`.
2. Create or use two purchase orders that can be invoiced.
3. Mark one of them as forced invoiced.
4. Select both purchase orders from the list view.
5. Trigger the vendor bill creation action.

Before this fix, Odoo raises an `Expected singleton` error.

After this fix, the forced invoiced purchase order is skipped and the regular purchase order can still be billed.
