### PR TITLE
[FIX] purchase_request: render HTML notification body correctly

### DIFF
--- a/purchase_request/__manifest__.py
+++ b/purchase_request/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Purchase Request",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
-    "version": "19.0.1.0.1",
+    "version": "19.0.1.0.2",
     "summary": "Use this module to have notification of requirements of "
     "materials and/or external services and keep track of such "
     "requirements.",

--- a/purchase_request/i18n/purchase_request.pot
+++ b/purchase_request/i18n/purchase_request.pot
@@ -4,30 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 19.0\n"
+"Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-29 20:25+0000\n"
+"PO-Revision-Date: 2026-06-29 20:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: purchase_request
-#. odoo-python
-#: code:addons/purchase_request/models/purchase_order.py:0
-msgid ""
-"<li><b>%(prl_name)s</b>: Ordered quantity %(prl_qty)s %(prl_uom)s, Planned "
-"date %(prl_date_planned)s</li>"
-msgstr ""
-
-#. module: purchase_request
-#. odoo-python
-#: code:addons/purchase_request/models/purchase_request_allocation.py:0
-msgid ""
-"<li><b>%(product_name)s</b>: Received quantity %(product_qty)s "
-"%(product_uom)s</li>"
-msgstr ""
 
 #. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.report_purchase_request
@@ -482,7 +468,9 @@ msgstr ""
 
 #. module: purchase_request
 #: model:ir.model.fields,help:purchase_request.field_purchase_request__message_has_error
+#: model:ir.model.fields,help:purchase_request.field_purchase_request__message_has_sms_error
 #: model:ir.model.fields,help:purchase_request.field_purchase_request_line__message_has_error
+#: model:ir.model.fields,help:purchase_request.field_purchase_request_line__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
 msgstr ""
 
@@ -660,6 +648,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/purchase_request/models/purchase_order.py:0
 msgid "Order confirmation %(po_name)s for your Request %(pr_name)s"
+msgstr ""
+
+#. module: purchase_request
+#. odoo-python
+#: code:addons/purchase_request/models/purchase_order.py:0
+msgid ""
+"Ordered quantity %(prl_qty)s %(prl_uom)s, Planned date %(prl_date_planned)s"
 msgstr ""
 
 #. module: purchase_request
@@ -1015,6 +1010,12 @@ msgid "Received quantity"
 msgstr ""
 
 #. module: purchase_request
+#. odoo-python
+#: code:addons/purchase_request/models/purchase_request_allocation.py:0
+msgid "Received quantity %(product_qty)s %(product_uom)s"
+msgstr ""
+
+#. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_form
 msgid "Reject"
 msgstr ""
@@ -1122,6 +1123,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request__activity_user_id
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request_line__activity_user_id
 msgid "Responsible User"
+msgstr ""
+
+#. module: purchase_request
+#: model:ir.model.fields,field_description:purchase_request.field_purchase_request__message_has_sms_error
+#: model:ir.model.fields,field_description:purchase_request.field_purchase_request_line__message_has_sms_error
+msgid "SMS Delivery error"
 msgstr ""
 
 #. module: purchase_request

--- a/purchase_request/models/purchase_order.py
+++ b/purchase_request/models/purchase_order.py
@@ -19,24 +19,27 @@ class PurchaseOrder(models.Model):
             po_name=self.name,
             pr_name=request.name,
         )
-        message = f"<h3>{title}</h3><ul>"
-        message += self.env._(
+        intro = self.env._(
             "The following requested items from Purchase Request %(pr_name)s "
             "have now been confirmed in Purchase Order %(po_name)s:",
             po_name=self.name,
             pr_name=request.name,
         )
+        message = Markup("<h3>{}</h3>{}<ul>").format(title, intro)
 
         for line in request_dict.values():
-            message += self.env._(
-                "<li><b>%(prl_name)s</b>: Ordered quantity %(prl_qty)s %(prl_uom)s, "
-                "Planned date %(prl_date_planned)s</li>",
-                prl_name=html_escape(line["name"]),
+            line_text = self.env._(
+                "Ordered quantity %(prl_qty)s %(prl_uom)s, "
+                "Planned date %(prl_date_planned)s",
                 prl_qty=line["product_qty"],
                 prl_uom=line["product_uom"],
                 prl_date_planned=line["date_planned"],
             )
-        message += "</ul>"
+            message += Markup("<li><b>{}</b>: {}</li>").format(
+                html_escape(line["name"]),
+                line_text,
+            )
+        message += Markup("</ul>")
         return message
 
     def _purchase_request_confirm_message(self):
@@ -62,7 +65,7 @@ class PurchaseOrder(models.Model):
                     request, requests_dict[request_id]
                 )
                 request.message_post(
-                    body=Markup(message),
+                    body=message,
                     subtype_id=self.env.ref(
                         "purchase_request.mt_request_po_confirmed"
                     ).id,

--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -96,21 +96,20 @@ class PurchaseRequestAllocation(models.Model):
 
     @api.model
     def _purchase_request_confirm_done_message_content(self, message_data):
-        message = ""
-        message += self.env._(
+        message_body = self.env._(
             "From last reception this quantity has been "
             "allocated to this purchase request"
         )
-        message += "<ul>"
-        message += self.env._(
-            "<li><b>%(product_name)s</b>: "
-            "Received quantity %(product_qty)s %(product_uom)s</li>",
-            product_name=html_escape(message_data["product_name"]),
+        line_text = self.env._(
+            "Received quantity %(product_qty)s %(product_uom)s",
             product_qty=message_data["product_qty"],
             product_uom=message_data["product_uom"],
         )
-        message += "</ul>"
-        return message
+        product_line = Markup("<ul><li><b>{}</b>: {}</li></ul>").format(
+            html_escape(message_data["product_name"]),
+            line_text,
+        )
+        return Markup("{}{}").format(message_body, product_line)
 
     def _prepare_message_data(self, po_line, request, allocated_qty):
         return {
@@ -130,6 +129,6 @@ class PurchaseRequestAllocation(models.Model):
             message_data = self._prepare_message_data(po_line, request, allocated_qty)
             message = self._purchase_request_confirm_done_message_content(message_data)
             request.message_post(
-                body=Markup(message),
+                body=message,
                 subtype_id=self.env.ref("mail.mt_note").id,
             )


### PR DESCRIPTION
## Problem

When a purchase order created from a purchase request is confirmed, the
notification posted on the request showed its HTML tags (`<h3>`, `<ul>`,
`<li>`) as **literal text** instead of rendered markup. Reproducible on a
real v19 database; the same broken email reached the user who approved the
request.

## Root cause

`PurchaseOrder._purchase_request_confirm_message_content` built the body as a
plain `str` and passed `html_escape(line["name"])` — which returns a
`Markup` — as an argument to `self.env._()`.

In Odoo 19, `Environment._` escapes the **entire** translated string whenever
any of its arguments is a `Markup`:

```python
# odoo/tools/translate.py
if any(isinstance(a, Markup) for a in args.values()):
    translation = escape(translation)
```

So the surrounding `<h3>/<ul>/<li>` markup got escaped together with the
value, and rendered as text.

`PurchaseRequestAllocation._purchase_request_confirm_done_message_content`
had the exact same pattern (HTML in the msgid + `html_escape()` argument to
`self.env._()`) and is fixed here too.

## Fix

Build the body with `Markup(...).format(...)` from the start, keep the
translatable strings free of HTML, and apply `html_escape()` outside of
`self.env._()` — mirroring the existing
`_purchase_request_confirm_done_message_content` method which already does it
correctly. The redundant `Markup(message)` wrap at the call sites is dropped
since the builders now return `Markup`.

Translatable terms (`.pot`) updated accordingly: the HTML is no longer part
of the msgids.

## Notes

- No functional/data change; output is identical HTML, now rendered instead
  of escaped.
- Version bumped to `19.0.1.0.2`.
