### PR TITLE
[FIX] purchase_last_price_info: filter last purchase

### DIFF
--- a/purchase_last_price_info/models/product_product.py
+++ b/purchase_last_price_info/models/product_product.py
@@ -48,14 +48,16 @@ class ProductProduct(models.Model):
     @api.depends("last_purchase_line_ids.state")
     def _compute_last_purchase_line_id(self):
         for item in self:
-            item.last_purchase_line_id = fields.first(
-                item.last_purchase_line_ids.sudo().filtered_domain(
-                    [
-                        ("state", "in", ["purchase", "done"]),
-                        ("company_id", "in", self.env.companies.ids),
-                    ]
-                )
+            candidate_lines = item.last_purchase_line_ids.sudo().filtered_domain(
+                [
+                    ("state", "in", ["purchase", "done"]),
+                    ("company_id", "in", self.env.companies.ids),
+                ]
             )
+            sorted_lines = candidate_lines.sorted(
+                key=lambda r: (r.date_order, r.id), reverse=True
+            )
+            item.last_purchase_line_id = fields.first(sorted_lines)
 
     @api.depends("last_purchase_line_id")
     def _compute_last_purchase_line_id_info(self):

--- a/purchase_last_price_info/models/product_template.py
+++ b/purchase_last_price_info/models/product_template.py
@@ -48,14 +48,16 @@ class ProductTemplate(models.Model):
     @api.depends("last_purchase_line_ids.state")
     def _compute_last_purchase_line_id(self):
         for item in self:
-            item.last_purchase_line_id = fields.first(
-                item.last_purchase_line_ids.sudo().filtered_domain(
-                    [
-                        ("state", "in", ["purchase", "done"]),
-                        ("company_id", "in", self.env.companies.ids),
-                    ]
-                )
+            candidate_lines = item.last_purchase_line_ids.sudo().filtered_domain(
+                [
+                    ("state", "in", ["purchase", "done"]),
+                    ("company_id", "in", self.env.companies.ids),
+                ]
             )
+            sorted_lines = candidate_lines.sorted(
+                key=lambda r: (r.date_order, r.id), reverse=True
+            )
+            item.last_purchase_line_id = fields.first(sorted_lines)
 
     @api.depends("last_purchase_line_id")
     def _compute_last_purchase_line_id_info(self):

--- a/purchase_last_price_info/tests/test_purchase_last_price_info.py
+++ b/purchase_last_price_info/tests/test_purchase_last_price_info.py
@@ -127,6 +127,10 @@ class TestPurchaseLastPriceInfo(common.TransactionCase):
                 ]
             )
         )
+        last_purchase_line = self.product1.last_purchase_line_id
+        last_purchase_line_tmp = self.product1.product_tmpl_id.last_purchase_line_id
+        self.assertNotEqual(first_order_line, last_purchase_line)
+        self.assertEqual(last_purchase_line, last_purchase_line_tmp)
         self.assertNotEqual(
             first_order_line.date_order,
             self.product1.last_purchase_date,
@@ -134,6 +138,10 @@ class TestPurchaseLastPriceInfo(common.TransactionCase):
         expected_date = datetime.datetime(2001, 1, 1, 0, 0)
         self.assertEqual(
             expected_date,
+            self.product1.last_purchase_date,
+        )
+        self.assertEqual(
+            last_purchase_line.date_order,
             self.product1.last_purchase_date,
         )
         expected_price = 10.0

--- a/purchase_last_price_info/tests/test_purchase_last_price_info.py
+++ b/purchase_last_price_info/tests/test_purchase_last_price_info.py
@@ -2,6 +2,8 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import datetime
+
 import odoo.tests.common as common
 from odoo import fields
 
@@ -16,6 +18,16 @@ class TestPurchaseLastPriceInfo(common.TransactionCase):
         self.purchase_model = self.env["purchase.order"]
         self.purchase_line_model = self.env["purchase.order.line"]
         self.product = self.env.ref("product.consu_delivery_01")
+        self.product1 = self.env["product.product"].create(
+            {
+                "name": "Test product",
+                "type": "consu",
+                "standard_price": 10.0,
+                "list_price": 20.0,
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "uom_po_id": self.env.ref("uom.product_uom_unit").id,
+            }
+        )
         self.partner = self.env.ref("base.res_partner_1")
         # Create custom rates to currency + currency_extra
         self._create_currency_rate(self.currency, "2000-01-01", 1.0)
@@ -57,7 +69,7 @@ class TestPurchaseLastPriceInfo(common.TransactionCase):
         self.assertEqual(self.product.last_purchase_price_currency, 1.0)
 
     def test_purchase_last_price_info_new_order(self):
-        purchase_order = self.purchase_model.create(
+        purchase_order1 = self.purchase_model.create(
             {
                 "date_order": "2000-01-01",
                 "currency_id": self.currency_extra.id,
@@ -67,30 +79,72 @@ class TestPurchaseLastPriceInfo(common.TransactionCase):
                         0,
                         0,
                         {
-                            "product_id": self.product.id,
-                            "product_uom": self.product.uom_id.id,
-                            "price_unit": self.product.standard_price,
-                            "name": self.product.name,
+                            "product_id": self.product1.id,
+                            "product_uom": self.product1.uom_id.id,
+                            "price_unit": self.product1.standard_price,
+                            "name": self.product1.name,
                             "date_planned": fields.Datetime.now(),
                             "product_qty": 1,
+                            "sequence": 1,
                         },
                     )
                 ],
             }
         )
-        purchase_order.button_confirm()
-        self.assertEqual(
-            fields.Datetime.from_string(purchase_order.date_order).date(),
-            fields.Datetime.from_string(self.product.last_purchase_date).date(),
+        purchase_order2 = self.purchase_model.create(
+            {
+                "date_order": "2001-01-01",
+                "currency_id": self.currency_extra.id,
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product1.id,
+                            "product_uom": self.product1.uom_id.id,
+                            "price_unit": self.product1.standard_price,
+                            "name": self.product1.name,
+                            "date_planned": fields.Datetime.now(),
+                            "product_qty": 1,
+                            "sequence": 9999,
+                        },
+                    )
+                ],
+            }
         )
-        first_order_line = fields.first(purchase_order.order_line)
-        self.assertEqual(first_order_line.price_unit, self.product.last_purchase_price)
+        purchase_order1.button_confirm()
+        purchase_order2.button_confirm()
         self.assertEqual(
-            first_order_line.currency_id,
-            self.product.last_purchase_currency_id,
+            purchase_order2.date_order,
+            self.product1.last_purchase_date,
         )
-        self.assertEqual(self.product.last_purchase_currency_id, self.currency_extra)
-        self.assertEqual(self.product.last_purchase_price_currency, 2.0)
-        self.assertEqual(self.partner, self.product.last_purchase_supplier_id)
-        purchase_order.button_cancel()
-        self.assertEqual(purchase_order.state, "cancel")
+        first_order_line = fields.first(
+            self.product1.last_purchase_line_ids.sudo().filtered_domain(
+                [
+                    ("state", "in", ["purchase", "done"]),
+                    ("company_id", "in", self.env.companies.ids),
+                ]
+            )
+        )
+        self.assertNotEqual(
+            first_order_line.date_order,
+            self.product1.last_purchase_date,
+        )
+        expected_date = datetime.datetime(2001, 1, 1, 0, 0)
+        self.assertEqual(
+            expected_date,
+            self.product1.last_purchase_date,
+        )
+        expected_price = 10.0
+        self.assertEqual(expected_price, self.product1.last_purchase_price)
+        expected_currency = self.currency_extra
+        self.assertEqual(
+            expected_currency,
+            self.product1.last_purchase_currency_id,
+        )
+        self.assertEqual(self.product1.last_purchase_currency_id, self.currency_extra)
+        self.assertEqual(self.product1.last_purchase_price_currency, 2.0)
+        self.assertEqual(self.partner, self.product1.last_purchase_supplier_id)
+        purchase_order2.button_cancel()
+        self.assertEqual(purchase_order2.state, "cancel")


### PR DESCRIPTION
### [FIX] purchase_last_price_info: filter last purchase

A change has been made to how the last purchase date was filtered, as in some cases it was not taking the last date but the first, so I have modified how the date is filtered.

The `type` "product" has been changed to "consu" as done in [1].

X-original-commit: 9a727e62199ff2d5f2201de93d1e60dddb497ee7

[1]: https://github.com/odoo/odoo/commit/728d9f83f6d140b57b91000f683298f1f5bd43c9

Forward-Port of https://github.com/OCA/purchase-workflow/pull/2822


**[IMP] purchase_last_price_info: Include test for last_purchase_line_id**

Including the check of the fields `last_purchase_line_id` in both product models to avoid decreasing the coverage.