### PR TITLE
[FIX] purchase_quick : base the computation of the seller_price field on the uom_po_id of the related product.

### DIFF
--- a/purchase_quick/models/product_product.py
+++ b/purchase_quick/models/product_product.py
@@ -28,7 +28,7 @@ class ProductProduct(models.Model):
                 quantity=record.qty_to_process or 1,
                 uom_id=record.quick_uom_id,
             )
-            price_unit = record.uom_id._compute_price(
+            price_unit = record.uom_po_id._compute_price(
                 seller.price,
                 record.quick_uom_id,
             )

--- a/purchase_quick/tests/test_quick_purchase.py
+++ b/purchase_quick/tests/test_quick_purchase.py
@@ -54,6 +54,9 @@ class TestQuickPurchase(TransactionCase):
         self.assertEqual(self.product_1.seller_price, 8)
         self.product_1.quick_uom_id = self.uom_dozen
         self.assertEqual(self.product_1.seller_price, 96)
+        self.product_1.uom_po_id = self.uom_dozen
+        self.product_1.quick_uom_id = self.uom_dozen
+        self.assertEqual(self.product_1.seller_price, 8)
 
     def test_product_seller_price_with_currency(self):
         self.po.currency_id = self.env.ref("base.EUR")


### PR DESCRIPTION

Rational : if the uom_po_id is dozen and the uom of the purchase order line is also dozen, the price should be the price of the supplierinfo, without any conversion