### PR TITLE
[I18N] purchase_requisition_line_description: add Spanish translation

### DIFF
--- a/purchase_requisition_line_description/i18n/es.po
+++ b/purchase_requisition_line_description/i18n/es.po
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* purchase_requisition_line_description
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2026-07-17 00:00+0000\n"
+"Last-Translator: Andrés Camilo Briñez Nuñez <acbri.19@gmail.com>\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#. module: purchase_requisition_line_description
+#: model_terms:ir.ui.view,arch_db:purchase_requisition_line_description.purchase_requisition
+msgid "<strong>Description</strong>"
+msgstr "<strong>Descripción</strong>"
+
+#. module: purchase_requisition_line_description
+#: model_terms:ir.ui.view,arch_db:purchase_requisition_line_description.purchase_requisition
+msgid "<strong>Product</strong>"
+msgstr "<strong>Producto</strong>"
+
+#. module: purchase_requisition_line_description
+#: model:ir.model.fields,field_description:purchase_requisition_line_description.field_purchase_requisition_line__name
+msgid "Product Description"
+msgstr "Descripción del producto"
+
+#. module: purchase_requisition_line_description
+#: model:ir.model,name:purchase_requisition_line_description.model_purchase_requisition_line
+msgid "Purchase Requisition Line"
+msgstr "Línea de requisición de compra"

--- a/purchase_requisition_line_description/readme/CONTRIBUTORS.md
+++ b/purchase_requisition_line_description/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - Anna Janiszewska \<anna.janiszewska@camptocamp.com\>
+- Andrés Camilo Briñez Nuñez \<acbri.19@gmail.com\>


### PR DESCRIPTION
## Summary

Added Spanish (es) translation for the purchase_requisition_line_description module.

## Changes

- Added `i18n/es.po` with translations for all 4 translatable strings
- Added contributor to CONTRIBUTORS.md

## Translated strings

| English | Spanish |
|---|---|
| \<strong\>Description\</strong\> | \<strong\>Descripción\</strong\> |
| \<strong\>Product\</strong\> | \<strong\>Producto\</strong\> |
| Product Description | Descripción del producto |
| Purchase Requisition Line | Línea de requisición de compra |

## CLA

CLA signed: pending