### PR TITLE
[FIX] purchase_request: bind name before use in onchange_product_id

### DIFF
--- a/purchase_request/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request/wizard/purchase_request_line_make_purchase_order.py
@@ -383,8 +383,9 @@ class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):
     @api.onchange("product_id")
     def onchange_product_id(self):
         if self.product_id:
-            if not self.keep_description:
-                name = self.product_id.name
+            # Always bind ``name`` to avoid UnboundLocalError when
+            # ``keep_description`` is set.
+            name = self.name if self.keep_description else self.product_id.name
             code = self.product_id.code
             sup_info_id = self.env["product.supplierinfo"].search(
                 [


### PR DESCRIPTION
## Bug

`onchange_product_id` on the make-purchase-order wizard item raised
`UnboundLocalError: cannot access local variable 'name'` when
`keep_description` was set.

`name` was only assigned inside `if not self.keep_description:`, so when
`keep_description` is `True` it stayed unbound and was then read:

- on the supplier-info branch, `f"[...] {p_name if p_name else name}"`,
  when the matched `product.supplierinfo` had no `product_name`;
- and by the final `if name:` guard when there was no supplier info and
  the product had no internal reference.

## Fix

Always bind `name`: keep the description already provided on the wizard
line when `keep_description` is set, otherwise fall back to the product
name. Behaviour for `keep_description = False` is unchanged.

## Test

Added `test_onchange_product_id_keep_description`: a product without an
internal reference plus a `product.supplierinfo` with an empty
`product_name`, `keep_description=True`, then calls the onchange. It
raises `UnboundLocalError` on the previous code and passes with the fix.
