### PR TITLE
[19.0][MIG] purchase_rfq_number: Migration to 19.0

### DIFF
--- a/purchase_rfq_number/README.rst
+++ b/purchase_rfq_number/README.rst
@@ -108,6 +108,7 @@ Contributors
 ------------
 
 - Prapassorn Sornkaew <prapassorn.s@prothaitechnology.com>
+- Alejandro Parrales <alejandro17parrales@gmail.com>
 
 Other credits
 -------------

--- a/purchase_rfq_number/readme/CONTRIBUTORS.md
+++ b/purchase_rfq_number/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - Prapassorn Sornkaew \<prapassorn.s@prothaitechnology.com\>
+- Alejandro Parrales \<alejandro17parrales@gmail.com\>

--- a/purchase_rfq_number/static/description/index.html
+++ b/purchase_rfq_number/static/description/index.html
@@ -457,6 +457,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-5">Contributors</a></h3>
 <ul class="simple">
 <li>Prapassorn Sornkaew &lt;<a class="reference external" href="mailto:prapassorn.s&#64;prothaitechnology.com">prapassorn.s&#64;prothaitechnology.com</a>&gt;</li>
+<li>Alejandro Parrales &lt;<a class="reference external" href="mailto:alejandro17parrales&#64;gmail.com">alejandro17parrales&#64;gmail.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/purchase_rfq_number/tests/test_purchase_order.py
+++ b/purchase_rfq_number/tests/test_purchase_order.py
@@ -1,11 +1,10 @@
 # Copyright 2021 ProThai Technology Co.,Ltd. (http://prothaitechnology.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.exceptions import UserError
-from odoo.tests import TransactionCase
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestPurchaseOrder(TransactionCase):
+class TestPurchaseOrder(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -14,6 +13,7 @@ class TestPurchaseOrder(TransactionCase):
         company = cls.env.company
         company.keep_name_po = False
         company.auto_attachment_rfq = True
+        cls.partner = cls.env["res.partner"].create({"name": "RFQ Number Test Partner"})
 
     def test_enumeration(self):
         order1 = self.purchase_order_model.create({"partner_id": self.partner.id})
@@ -66,10 +66,10 @@ class TestPurchaseOrder(TransactionCase):
             ]
         )
         next_name = sequence_id.get_next_char(sequence_id.number_next_actual)
-        try:
-            order.button_confirm()
-        except UserError:  # pylint: disable=except-pass
-            pass
+        # Re-confirming an already confirmed order is a no-op in core Odoo
+        # (it doesn't raise anymore since 19.0); it must not consume/advance
+        # the purchase order sequence either.
+        order.button_confirm()
         order.update({"state": "draft"})
         # Now the RFQ can be confirmed
         order.button_confirm()


### PR DESCRIPTION
- Bump manifest version to 19.0.1.0.0 and add license 
- Adjust tests to no longer depend on demo data.
- Adjust the order re-confirmation test: in 19.0, confirming an already
  confirmed order no longer raises a UserError (new core behavior); the
  assertion was updated accordingly.
- Use BaseCommon in the tests.