### PR TITLE
[FIX] purchase_deposit: convert deposit amounts to the order currency

### DIFF
--- a/purchase_deposit/models/account_move.py
+++ b/purchase_deposit/models/account_move.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Quartile Limited (https://www.quartile.co)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import fields, models
 
 
 class AccountMove(models.Model):
@@ -12,6 +12,14 @@ class AccountMove(models.Model):
         for line in self.line_ids:
             if not line.purchase_line_id.is_deposit:
                 continue
+            order = line.purchase_line_id.order_id
             line.purchase_line_id.taxes_id = line.tax_ids
-            line.purchase_line_id.price_unit = line.price_unit
+            # The bill may be issued in a currency other than the order one.
+            line.purchase_line_id.price_unit = line.currency_id._convert(
+                line.price_unit,
+                order.currency_id,
+                order.company_id,
+                line.move_id.invoice_date or fields.Date.context_today(self),
+                round=False,
+            )
         return res

--- a/purchase_deposit/tests/__init__.py
+++ b/purchase_deposit/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import test_purchase_deposit
+from . import test_purchase_deposit_multicurrency

--- a/purchase_deposit/tests/test_purchase_deposit_multicurrency.py
+++ b/purchase_deposit/tests/test_purchase_deposit_multicurrency.py
@@ -1,0 +1,88 @@
+# Copyright 2026 ADHOC SA (https://www.adhoc.com.ar)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import Command, fields
+
+from odoo.addons.base.tests.common import BaseCommon
+
+
+class TestPurchaseDepositMultiCurrency(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Order currency worth 1000 times the company one
+        cls.order_currency = cls.env["res.currency"].create(
+            {
+                "name": "PDX",
+                "symbol": "PDX",
+                "rate_ids": [
+                    Command.create(
+                        {
+                            "name": "2020-01-01",
+                            "rate": 0.001,
+                            "company_id": cls.env.company.id,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.account_expense = cls.env["account.account"].search(
+            [("account_type", "=", "expense")], limit=1
+        )
+        cls.deposit_product = cls._create_service("Purchase Deposit")
+        product = cls._create_service("Test Product")
+        cls.po = cls.env["purchase.order"].create(
+            {
+                "partner_id": cls.env["res.partner"].create({"name": "Vendor"}).id,
+                "currency_id": cls.order_currency.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "product_uom": product.uom_id.id,
+                            "name": product.name,
+                            "price_unit": 100.0,
+                            "product_qty": 10.0,
+                            "date_planned": fields.Datetime.now(),
+                        },
+                    )
+                ],
+            }
+        )
+        cls.po.button_confirm()
+
+    @classmethod
+    def _create_service(cls, name):
+        return cls.env["product.product"].create(
+            {
+                "name": name,
+                "type": "service",
+                "purchase_method": "purchase",
+                "property_account_expense_id": cls.account_expense.id,
+            }
+        )
+
+    def test_deposit_billed_in_another_currency(self):
+        """Posting a bill must not leak its currency figure into the order."""
+        self.env["purchase.advance.payment.inv"].with_context(
+            active_id=self.po.id,
+            active_ids=self.po.ids,
+            active_model="purchase.order",
+        ).create(
+            {
+                "advance_payment_method": "fixed",
+                "amount": 300.0,
+                "purchase_deposit_product_id": self.deposit_product.id,
+            }
+        ).create_invoices()
+        deposit_line = self.po.order_line.filtered("is_deposit")
+        self.assertEqual(deposit_line.price_unit, 300.0)
+
+        # The vendor bills the deposit in the company currency instead
+        bill = self.po.invoice_ids
+        bill.invoice_date = fields.Date.today()
+        bill.currency_id = self.env.company.currency_id
+        bill.invoice_line_ids.price_unit = 300000.0
+        bill.action_post()
+
+        self.assertEqual(deposit_line.price_unit, 300.0)


### PR DESCRIPTION
## What

`action_post` copies the deposit amount from the vendor bill back into the purchase
order line. When the bill is issued in a currency other than the order one the figure
was copied **verbatim**, so an order in a strong currency ended up with a deposit line
holding the nominal of a weak one — three orders of magnitude off, in the case that
brought us here.

This converts it to the order currency, at the bill date.

## Why it matters beyond the wrong figure

The deposit line's `price_unit` is not only informative: it is the amount deducted from
the final bill (`_prepare_account_move_line` puts the deposit line in with
`quantity = -qty_invoiced`), and on 18.0 it is also what the wizard compares against the
order total. So a bill figure landing there unconverted both corrupts the deduction and,
on 18.0, makes any further deposit on that order impossible.

Deposits billed in the order currency are unaffected: the conversion rate is exactly 1.

## Test plan

`test_deposit_billed_in_another_currency`: an order in a currency worth 1000x the
company one, a deposit of 300, and a bill edited to the company currency for 300,000.
Without the fix the order line ends up at `300000.0`; with it, at `300.0`.

Full suite green (7 tests on 18.0, 6 on 19.0).
