### PR TITLE
[FIX] purchase_deposit: convert deposit amounts to the order currency

### DIFF
--- a/purchase_deposit/models/account_move.py
+++ b/purchase_deposit/models/account_move.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Quartile Limited (https://www.quartile.co)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import fields, models
 
 
 class AccountMove(models.Model):
@@ -12,6 +12,14 @@ class AccountMove(models.Model):
         for line in self.line_ids:
             if not line.purchase_line_id.is_deposit:
                 continue
+            order = line.purchase_line_id.order_id
             line.purchase_line_id.tax_ids = line.tax_ids
-            line.purchase_line_id.price_unit = line.price_unit
+            # The bill may be issued in a currency other than the order one.
+            line.purchase_line_id.price_unit = line.currency_id._convert(
+                line.price_unit,
+                order.currency_id,
+                order.company_id,
+                line.move_id.invoice_date or fields.Date.context_today(self),
+                round=False,
+            )
         return res

--- a/purchase_deposit/tests/test_purchase_deposit.py
+++ b/purchase_deposit/tests/test_purchase_deposit.py
@@ -2,7 +2,7 @@
 # Copyright 2019 Ecosoft Co., Ltd., Kitti U. <kittiu@ecosoft.co.th>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import Form, TransactionCase
 
@@ -205,3 +205,36 @@ class TestPurchaseDeposit(TransactionCase):
         deposit_line = self.po.order_line.filtered(lambda p: p.is_deposit)
         self.assertEqual(deposit_line.price_unit, 500.0)
         self.assertEqual(deposit_line.tax_ids.id, self.tax.id)
+
+    def test_deposit_billed_in_another_currency(self):
+        """Posting a bill must not leak its currency figure into the order."""
+        # An order currency worth 1000 times the company one
+        self.po.currency_id = self.env["res.currency"].create(
+            {
+                "name": "PDX",
+                "symbol": "PDX",
+                "rate_ids": [
+                    Command.create(
+                        {
+                            "name": "2020-01-01",
+                            "rate": 0.001,
+                            "company_id": self.env.company.id,
+                        },
+                    )
+                ],
+            }
+        )
+        f = self.create_advance_payment_form()
+        f.advance_payment_method = "fixed"
+        f.amount = 300.0
+        f.deposit_account_id = self.account_deposit
+        f.save().create_invoices()
+        deposit_line = self.po.order_line.filtered("is_deposit")
+        self.assertEqual(deposit_line.price_unit, 300.0)
+        # The vendor bills the deposit in the company currency instead
+        bill = self.po.invoice_ids
+        bill.invoice_date = fields.Date.today()
+        bill.currency_id = self.env.company.currency_id
+        bill.invoice_line_ids.price_unit = 300000.0
+        bill.action_post()
+        self.assertEqual(deposit_line.price_unit, 300.0)


### PR DESCRIPTION
## What

`action_post` copies the deposit amount from the vendor bill back into the purchase
order line. When the bill is issued in a currency other than the order one the figure
was copied **verbatim**, so an order in a strong currency ended up with a deposit line
holding the nominal of a weak one — three orders of magnitude off, in the case that
brought us here.

This converts it to the order currency, at the bill date.

## Why it matters beyond the wrong figure

The deposit line's `price_unit` is not only informative: it is the amount deducted from
the final bill (`_prepare_account_move_line` puts the deposit line in with
`quantity = -qty_invoiced`), and on 18.0 it is also what the wizard compares against the
order total. So a bill figure landing there unconverted both corrupts the deduction and,
on 18.0, makes any further deposit on that order impossible.

Deposits billed in the order currency are unaffected: the conversion rate is exactly 1.

## Test plan

`test_deposit_billed_in_another_currency`: an order in a currency worth 1000x the
company one, a deposit of 300, and a bill edited to the company currency for 300,000.
Without the fix the order line ends up at `300000.0`; with it, at `300.0`.

Full suite green (7 tests on 18.0, 6 on 19.0).
