### PR TITLE
[19.0][FIX] purchase_order_line_description: preserve manual descriptions

### DIFF
--- a/purchase_order_line_description/__manifest__.py
+++ b/purchase_order_line_description/__manifest__.py
@@ -8,4 +8,12 @@
     "website": "https://github.com/OCA/purchase-workflow",
     "license": "AGPL-3",
     "depends": ["purchase"],
+    "assets": {
+        "web.assets_backend": [
+            "purchase_order_line_description/static/src/js/purchase_product_field.esm.js",
+        ],
+        "web.assets_tests": [
+            "purchase_order_line_description/static/tests/tours/*.js",
+        ],
+    },
 }

--- a/purchase_order_line_description/static/description/index.html
+++ b/purchase_order_line_description/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>Purchase order line description</title>
 <style type="text/css">
 
 /*

--- a/purchase_order_line_description/static/src/js/purchase_product_field.esm.js
+++ b/purchase_order_line_description/static/src/js/purchase_product_field.esm.js
@@ -1,0 +1,14 @@
+/* Copyright 2026 Moduon
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+
+import {ProductLabelSectionAndNoteField} from "@account/components/product_label_section_and_note_field/product_label_section_and_note_field";
+import {patch} from "@web/core/utils/patch";
+
+patch(ProductLabelSectionAndNoteField.prototype, {
+    parseLabel(value) {
+        if (this.props.record.resModel === "purchase.order.line") {
+            return value || "";
+        }
+        return super.parseLabel(value);
+    },
+});

--- a/purchase_order_line_description/static/tests/tours/purchase_order_line_description.esm.js
+++ b/purchase_order_line_description/static/tests/tours/purchase_order_line_description.esm.js
@@ -1,0 +1,39 @@
+/* Copyright 2026 Moduon
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+
+import {registry} from "@web/core/registry";
+
+registry.category("web_tour.tours").add("purchase_order_line_description_manual_edit", {
+    steps: () => [
+        {
+            content: "Open the purchase order line editor",
+            trigger:
+                '.o_field_product_label_section_and_note_cell:contains("Purchase description for test product")',
+            run: "click",
+        },
+        {
+            content: "Edit the purchase order line description",
+            trigger:
+                ".o_selected_row .o_field_product_label_section_and_note_cell textarea",
+            run: "edit Purchase description for test product test",
+        },
+        {
+            content: "Save the edited purchase order line",
+            trigger: ".oe_subtotal_footer",
+            run: "click",
+        },
+        {
+            content: "Wait for the line to leave inline edit mode",
+            trigger: ".o_field_product_label_section_and_note_cell:not(:has(textarea))",
+        },
+        {
+            content: "Save the purchase order",
+            trigger: ".o_form_status_indicator .o_form_button_save:visible",
+            run: "click",
+        },
+        {
+            content: "Wait for the purchase order to save",
+            trigger: ".o_form_status_indicator_buttons.invisible:not(:visible)",
+        },
+    ],
+});

--- a/purchase_order_line_description/tests/__init__.py
+++ b/purchase_order_line_description/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_purchase_order_line_description
+from . import test_purchase_order_line_description_ui

--- a/purchase_order_line_description/tests/test_purchase_order_line_description_ui.py
+++ b/purchase_order_line_description/tests/test_purchase_order_line_description_ui.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Moduon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.fields import Command
+from odoo.tests import HttpCase, tagged
+from odoo.tests.common import new_test_user
+
+
+@tagged("post_install", "-at_install")
+class TestPurchaseOrderLineDescriptionUi(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tour_user = new_test_user(
+            cls.env,
+            login="pol_description_tour_user",
+            groups="purchase.group_purchase_user",
+            context={"no_reset_password": True, "mail_create_nosubscribe": True},
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
+        # Resolve compatibility with purchase.order.type in tours
+        if "purchase.order.type" in cls.env:
+            cls.partner.purchase_type = cls.env["purchase.order.type"].search(
+                [], limit=1
+            )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test product",
+                "description_purchase": "Purchase description for test product",
+            }
+        )
+        cls.purchase_order = (
+            cls.env["purchase.order"]
+            .with_user(cls.tour_user)
+            .create(
+                {
+                    "partner_id": cls.partner.id,
+                    "order_line": [Command.create({"product_id": cls.product.id})],
+                }
+            )
+        )
+
+    def test_manual_description_edit_keeps_product_name_hidden_tour(self):
+        self.assertEqual(
+            self.purchase_order.order_line.name,
+            self.product.description_purchase,
+        )
+
+        self.start_tour(
+            f"/odoo/purchase-orders/{self.purchase_order.id}",
+            "purchase_order_line_description_manual_edit",
+            login="pol_description_tour_user",
+        )
+
+        self.purchase_order.order_line.invalidate_recordset(["name"])
+        self.assertEqual(
+            self.purchase_order.order_line.name,
+            f"{self.product.description_purchase} test",
+        )


### PR DESCRIPTION
The purchase line widget re-added the product name when users edited a line description, even though this module deliberately uses only the purchase description:

- Keep manually entered purchase descriptions unchanged and
- Added a regression tour.

https://www.loom.com/share/bd1acbb99f7943458eefcaa00df311f1

please review @yajo @fcvalgar 

twin PR: 

- https://github.com/OCA/sale-workflow/pull/4437

cc @moduon MT-15180