### PR TITLE
[18.0][FIX] purchase_all_shipments: list only pickings of the reception chain

### DIFF
--- a/purchase_all_shipments/models/__init__.py
+++ b/purchase_all_shipments/models/__init__.py
@@ -1,1 +1,2 @@
 from . import purchase_order
+from . import stock_move

--- a/purchase_all_shipments/models/purchase_order.py
+++ b/purchase_all_shipments/models/purchase_order.py
@@ -19,11 +19,10 @@ class PurchaseOrder(models.Model):
 
     def _compute_all_pickings(self):
         for rec in self:
-            groups = rec.mapped("picking_ids.group_id")
-            all_picking_ids = self.env["stock.picking"].search(
-                [("group_id", "in", groups.ids)]
+            moves = rec.order_line.move_ids
+            rec.all_picking_ids = (
+                rec.picking_ids | moves._get_reception_chain_moves().picking_id
             )
-            rec.all_picking_ids = all_picking_ids
 
     def action_view_all_pickings(self):
         return self._get_action_view_all_pickings(self.all_picking_ids)

--- a/purchase_all_shipments/models/stock_move.py
+++ b/purchase_all_shipments/models/stock_move.py
@@ -1,0 +1,18 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_reception_chain_moves(self):
+        """Recursively get the destination moves that continue the reception.
+
+        Moves pushed by the reception route are part of it, while moves pulled
+        by the demand of another document are not.
+        """
+        res = self.move_dest_ids.filtered(lambda m: m.rule_id.action == "push")
+        if res:
+            res |= res._get_reception_chain_moves()
+        return res

--- a/purchase_all_shipments/tests/test_three_step_reception.py
+++ b/purchase_all_shipments/tests/test_three_step_reception.py
@@ -29,6 +29,21 @@ class TestThreeStepReception(TransactionCase):
         self.po._compute_all_picking_count()
         self.assertEqual(3, self.po.all_picking_count)
 
+    def test_picking_of_other_document_excluded(self):
+        self.po.button_confirm()
+        other_picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.wh.out_type_id.id,
+                "location_id": self.wh.lot_stock_id.id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+                "group_id": self.po.group_id.id,
+            }
+        )
+        self.po._compute_all_pickings()
+        self.po._compute_all_picking_count()
+        self.assertNotIn(other_picking, self.po.all_picking_ids)
+        self.assertEqual(1, self.po.all_picking_count)
+
     def test_action_view_all_pickings_one_step(self):
         self.po.button_confirm()
         action_data = self.po.action_view_all_pickings()


### PR DESCRIPTION
## Problem

`all_picking_ids` is computed by searching every picking that shares a procurement group with the order receipts:

```python
groups = rec.mapped("picking_ids.group_id")
all_picking_ids = self.env["stock.picking"].search([("group_id", "in", groups.ids)])
```

The procurement group identifies the demand that originated the transfers, not the document that created them. It is therefore shared whenever a purchase exists because of a sale order, which is the case with:

- dropshipping, where the `Vendors -> Customers` buy rule propagates the group of the sale order;
- purchases generated from a sale order through a make to order route.

In those cases the group also holds the pickings of the originating document, so the *All Pickings* button of a purchase order lists customer deliveries and pickings of other purchase orders.

Two examples taken from a database where this happens:

- a purchase order whose only transfer is a dropship shows 2 pickings: its dropship and the pick of the sale order that generated it;
- a purchase order with 2 receipts and 2 storage transfers of a two-step reception shows 5 pickings, the fifth one being the pick of the originating sale order, for a different partner and still pending while the purchase is fully received.

The dropship case has been there for as long as the group is propagated by the buy rule. Since [93882d69](https://github.com/odoo/odoo/commit/93882d697d0b578fc64cab6d0df8fc73463dca23), merged in 18.0 on 2026-07-30, `stock_dropshipping` also sets the group of the sale order on the receipts of any purchase order line linked to a sale order line, so regular warehouse receipts are now affected too. The field is a poor proxy for "the pickings of this purchase order", and upstream keeps making that more explicit.

## Solution

Compute the field from the receipts of the order and the moves pushed by the reception route, so only the pickings of the reception chain are listed.

Walking the chained moves is what keeps the intermediate pickings of multi-step receptions, which is the purpose of the module. Restricting the walk to moves created by a push rule is what stops it where another document pulls the goods: a move pushed by the reception route continues the reception, while a move pulled by the demand of a sale order belongs to that sale order.

Filtering by operation type instead would not work, because the intermediate picking of a multi-step reception and the pick of an outgoing delivery are both internal transfers.

## Tests

Added a test asserting that a picking of another document sharing the procurement group is not listed. The existing multi-step reception tests are unchanged and still pass.
