### PR TITLE
[19.0][FIX] sale_purchase_force_vendor: Hide vendor_id_domain field in the form view

### DIFF
--- a/sale_purchase_force_vendor/views/sale_order_view.xml
+++ b/sale_purchase_force_vendor/views/sale_order_view.xml
@@ -22,7 +22,7 @@
             </xpath>
             <xpath expr="//field[@name='order_line']/form/group" position="inside">
                 <group string="Vendor" name="vendor">
-                    <field name="vendor_id_domain" column_invisible="1" />
+                    <field name="vendor_id_domain" invisible="1" />
                     <field
                         name="vendor_id"
                         domain="vendor_id_domain"


### PR DESCRIPTION
Hide `vendor_id_domain` field in the form view

<img width="551" height="216" alt="ejemplo" src="https://github.com/user-attachments/assets/4086ca57-c278-4047-8aad-5fbaddaca263" />

Please @Andrii9090-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT61965