### PR TITLE
[FIX] purchase_location_by_line: avoid location error on line logic

### DIFF
--- a/purchase_location_by_line/models/purchase.py
+++ b/purchase_location_by_line/models/purchase.py
@@ -50,6 +50,7 @@ class PurchaseOrderLine(models.Model):
 
     def _create_stock_moves(self, picking):
         res = super()._create_stock_moves(picking)
+        updated_pickings = self.env["stock.picking"]
         for line in self:
             default_picking_location_id = line.order_id._get_destination_location()
             default_picking_location = self.env["stock.location"].browse(
@@ -57,7 +58,16 @@ class PurchaseOrderLine(models.Model):
             )
             location = line.location_dest_id or default_picking_location
             if location:
-                line.move_ids.filtered(lambda m: m.state != "done").write(
-                    {"location_dest_id": location.id}
+                moves = line.move_ids.filtered(
+                    lambda m: m.state != "done" and (not picking or m.picking_id == picking)
                 )
+                if moves:
+                    moves.write({"location_dest_id": location.id})
+                    updated_pickings |= moves.picking_id
+        for picking_rec in updated_pickings:
+            move_locations = picking_rec.move_ids.filtered(
+                lambda m: m.state != "cancel"
+            ).mapped("location_dest_id")
+            if len(move_locations) == 1 and move_locations != picking_rec.location_dest_id:
+                picking_rec.location_dest_id = move_locations.id
         return res

--- a/purchase_location_by_line/models/purchase.py
+++ b/purchase_location_by_line/models/purchase.py
@@ -59,7 +59,8 @@ class PurchaseOrderLine(models.Model):
             location = line.location_dest_id or default_picking_location
             if location:
                 moves = line.move_ids.filtered(
-                    lambda m: m.state != "done" and (not picking or m.picking_id == picking)
+                    lambda m: m.state != "done"
+                    and (not picking or m.picking_id == picking)
                 )
                 if moves:
                     moves.write({"location_dest_id": location.id})
@@ -68,6 +69,9 @@ class PurchaseOrderLine(models.Model):
             move_locations = picking_rec.move_ids.filtered(
                 lambda m: m.state != "cancel"
             ).mapped("location_dest_id")
-            if len(move_locations) == 1 and move_locations != picking_rec.location_dest_id:
+            if (
+                len(move_locations) == 1
+                and move_locations != picking_rec.location_dest_id
+            ):
                 picking_rec.location_dest_id = move_locations.id
         return res

--- a/purchase_location_by_line/tests/test_purchase_delivery.py
+++ b/purchase_location_by_line/tests/test_purchase_delivery.py
@@ -255,3 +255,19 @@ class TestDeliverySingle(TransactionCase):
         self.assertEqual(
             self.po.order_line[0].move_ids.mapped("location_dest_id"), self.l1
         )
+
+    def test_modify_confirmed_all_lines_new_destination(self):
+        self.po.button_confirm()
+
+        # Set a new destination for all lines and force move updates.
+        self.po.order_line.write({"location_dest_id": self.l2.id})
+        for line in self.po.order_line:
+            line.write({"product_qty": line.product_qty + 1})
+
+        self.assertEqual(self.po.picking_ids.location_dest_id, self.l2)
+        self.assertEqual(
+            self.po.order_line.move_ids.filtered(lambda m: m.state != "cancel").mapped(
+                "location_dest_id"
+            ),
+            self.l2,
+        )


### PR DESCRIPTION
### Summary
Fixes purchase line location computation to avoid the error in stock picking flow.

### Version
- Target branch: 17.0
### Notes
- Minimal fix focused on `purchase_location_by_line` behavior.
- - No functional scope outside this module.