### PR TITLE
[19.0][IMP] purchase_order_line_menu: add analytic_distribution on line

### DIFF
--- a/purchase_order_line_menu/views/purchase_order_line_views.xml
+++ b/purchase_order_line_menu/views/purchase_order_line_views.xml
@@ -26,6 +26,12 @@
             </xpath>
             <xpath expr="//field[@name='product_id']" position="after">
                 <field name="product_type" optional="hide" />
+                <field
+                    name="analytic_distribution"
+                    widget="analytic_distribution"
+                    optional="hide"
+                    groups="analytic.group_analytic_accounting"
+                />
             </xpath>
             <xpath expr="//field[@name='product_qty']" position="after">
                 <field name="qty_invoiced" optional="hide" />


### PR DESCRIPTION
This PR cherry-pick from https://github.com/OCA/purchase-workflow/pull/3129

Add analytic on purchase line menu
<img width="1417" height="525" alt="Screenshot 2026-08-27 210249" src="https://github.com/user-attachments/assets/24439b53-7fad-42d3-a3f0-fa5f4aca1c6c" />
