### PR TITLE
[19.0][FIX] purchase_advance_payment: load a chart template in tests

### DIFF
--- a/purchase_advance_payment/tests/test_purchase_advance_payment.py
+++ b/purchase_advance_payment/tests/test_purchase_advance_payment.py
@@ -13,6 +13,12 @@ class TestPurchaseAdvancePayment(BaseCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        # A chart of accounts is required: taxes, journals and outstanding
+        # accounts cannot be created on a company without one.
+        if not cls.env.company.chart_template:
+            cls.env["account.chart.template"].try_loading(
+                "generic_coa", company=cls.env.company, install_demo=False
+            )
 
         # Partners
         cls.res_partner_1 = cls.env["res.partner"].create({"name": "Wood Corner"})


### PR DESCRIPTION
## Problem

`TestPurchaseAdvancePayment.setUpClass` creates an `account.tax`. On a database where no chart of accounts has been loaded yet, there is no `account.tax.group` and no fiscal country on the company, so the record cannot be created:

```
psycopg2.errors.NotNullViolation: null value in column "tax_group_id" of relation "account_tax" violates not-null constraint
```

This happens on any freshly initialized database without demo data, for instance a new build on a hosting platform that installs the module from scratch. Chart templates are only auto-loaded after the module loading phase, so the tests run before any chart is available.

The payment tests have the same underlying need: without a chart, `account.payment.create` raises `No outstanding account could be found to make the payment`.

## Fix

Load `generic_coa` in `setUpClass` when the company has no chart template yet. Databases that already have a chart (a real database, or the OCA CI with demo data) are untouched by the guard.

## Test

- Fresh database, `-i purchase_advance_payment --test-enable --without-demo=all`: 12/12 green (fails on `tax_group_id` without the patch).
- Database with a chart already loaded: 12/12 green, unchanged.