### PR TITLE
[FIX] purchase_request: do not close allocations on locked orders

### DIFF
--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -85,7 +85,7 @@ class PurchaseRequestAllocation(models.Model):
     )
     def _compute_open_product_qty(self):
         for rec in self:
-            if rec.purchase_state in ["cancel", "done"]:
+            if rec.purchase_state == "cancel":
                 rec.open_product_qty = 0.0
             else:
                 rec.open_product_qty = (

--- a/purchase_request/tests/test_purchase_request_allocation.py
+++ b/purchase_request/tests/test_purchase_request_allocation.py
@@ -327,6 +327,57 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
             ].requested_product_uom_qty,
         )
 
+    def test_purchase_request_stock_allocation_locked_po(self):
+        """A locked purchase order must not close the allocation.
+
+        With ``po_lock = 'lock'`` the order reaches state ``done`` as soon as it
+        is approved. In Odoo that state means "Locked", a modification lock, not
+        a completion: receipts still happen afterwards. The allocation has to
+        stay open so the incoming quantity is allocated and the requester is
+        notified.
+        """
+        self.env.company.po_lock = "lock"
+        purchase_request = self.purchase_request.create(
+            {
+                "picking_type_id": self.env.ref("stock.picking_type_in").id,
+                "requested_by": SUPERUSER_ID,
+            }
+        )
+        purchase_request_line = self.purchase_request_line.create(
+            {
+                "request_id": purchase_request.id,
+                "product_id": self.product_product.id,
+                "product_uom_id": self.env.ref("uom.product_uom_unit").id,
+                "product_qty": 10.0,
+            }
+        )
+        purchase_request.button_approved()
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line.id],
+        ).create({"supplier_id": self.env.ref("base.res_partner_1").id})
+        wiz_id.make_purchase_order()
+        purchase = purchase_request_line.purchase_lines[0].order_id
+        purchase.button_confirm()
+        self.assertEqual(purchase.state, "done")
+
+        allocation = purchase_request_line.purchase_request_allocation_ids[0]
+        self.assertEqual(allocation.open_product_qty, 10.0)
+
+        picking = purchase.picking_ids[0]
+        picking.move_line_ids[0].write({"quantity": 10.0})
+        picking.button_validate()
+
+        self.assertEqual(allocation.allocated_product_qty, 10.0)
+        self.assertEqual(purchase_request_line.qty_done, 10.0)
+        self.assertTrue(
+            purchase_request.message_ids.filtered(
+                lambda m: m.subtype_id
+                == self.env.ref("purchase_request.mt_request_picking_done")
+            ),
+            "The requester was not notified of the receipt.",
+        )
+
     def test_purchase_request_stock_allocation_unlink(self):
         product = self.env.ref("product.product_product_6")
         product.uom_po_id = self.env.ref("uom.product_uom_dozen")


### PR DESCRIPTION
### Problem

`purchase.request.allocation._compute_open_product_qty` zeroes the open quantity when the purchase order line is in state `done`. In Odoo that state is **Locked** — a modification lock — not a completion: receipts still happen afterwards, and core itself creates and processes them for locked orders (`_create_picking` accepts `('purchase', 'done')`).

When the company has *Lock Confirmed Orders* enabled (`res.company.po_lock = 'lock'`), `button_approve` moves the order to `done` at approval time. The allocation is therefore closed before any receipt can happen, and:

- `stock.move.line.allocate()` never allocates the incoming quantity, so no receipt message is posted and the requester is never notified;
- `qty_done` and `qty_in_progress` stay at 0 on the request line, which then shows nothing received and everything still pending, forever;
- `stock.move.copy_data()` filters allocations on `open_product_qty`, so backorders are created without allocations.

For a database with that setting on, the allocation and notification feature is effectively dead. Nothing fails and nothing is logged.

### This is a regression

The exact same one line change was already requested and merged once:

- #1419 reported it on 12.0, naming `po_lock`. A maintainer asked for the `if rec.purchase_state == 'cancel':` variant, and suggested mentioning that `done` does not indicate the delivery status.
- #1422 implemented it and was merged into **14.0** in May 2022.

The forward port to 15.0 brought back the version including `done`:

| Branch | `_compute_open_product_qty` |
|---|---|
| 14.0 | `if rec.purchase_state == "cancel":` |
| 15.0 → 19.0 | `if rec.purchase_state in ["cancel", "done"]:` |

So 15.0 up to 19.0 all carry the bug again. This PR restores the 14.0 behaviour on 18.0; happy to port it to the other affected branches if you want them in the same batch.

For the record on why the check existed at all: it was introduced in 39273052 for **service** lines only, where the purchase order line is the only available signal, and extended to stock backed allocations by 587c260b while splitting the models into separate files.

### Fix

`cancel` is the only state that really means nothing else will be allocated. Once a receipt completes, `allocated_product_qty` reaches `requested_product_uom_qty` and the open quantity becomes 0 on its own, so no shortcut on `done` is needed. Keeping the open quantity positive on a locked order is also what `copy_data` needs in order to carry the remainder over to a backorder.

### Test plan

The new test covers the locked order flow, which no existing test exercised because `po_lock` defaults to `edit`. Before the change it fails:

```
FAIL: TestPurchaseRequestToRfq.test_purchase_request_stock_allocation_locked_po
    self.assertEqual(allocation.open_product_qty, 10.0)
AssertionError: 0.0 != 10.0
```

After it, the whole module suite passes on 18.0:

```
odoo.tests.result: 0 failed, 0 error(s) of 30 tests
```

### Out of scope

`purchase_request_line._compute_purchase_state` and `_purchase_request_line_check` read `done` the same way, which is what raises "The purchase has already been completed" when generating a second RFQ for a request line of a locked order. That reading is asserted by an existing test, so changing it is a separate discussion and is deliberately left untouched here.
