### PR TITLE
[16.0][FIX] purchase_request: do not close allocations on locked orders

### DIFF
--- a/purchase_request/models/purchase_request_allocation.py
+++ b/purchase_request/models/purchase_request_allocation.py
@@ -82,7 +82,7 @@ class PurchaseRequestAllocation(models.Model):
     )
     def _compute_open_product_qty(self):
         for rec in self:
-            if rec.purchase_state in ["cancel", "done"]:
+            if rec.purchase_state == "cancel":
                 rec.open_product_qty = 0.0
             else:
                 rec.open_product_qty = (

--- a/purchase_request/tests/test_purchase_request_allocation.py
+++ b/purchase_request/tests/test_purchase_request_allocation.py
@@ -326,6 +326,58 @@ class TestPurchaseRequestToRfq(common.TransactionCase):
             ].requested_product_uom_qty,
         )
 
+    def test_purchase_request_stock_allocation_locked_po(self):
+        """A locked purchase order must not close the allocation.
+
+        With ``po_lock = 'lock'`` the order reaches state ``done`` as soon as it
+        is approved. In Odoo that state means "Locked", a modification lock, not
+        a completion: receipts still happen afterwards. The allocation has to
+        stay open so the incoming quantity is allocated and the requester is
+        notified.
+        """
+        self.env.company.po_lock = "lock"
+        purchase_request = self.purchase_request.create(
+            {
+                "picking_type_id": self.env.ref("stock.picking_type_in").id,
+                "requested_by": SUPERUSER_ID,
+            }
+        )
+        purchase_request_line = self.purchase_request_line.create(
+            {
+                "request_id": purchase_request.id,
+                "product_id": self.product_product.id,
+                "product_uom_id": self.env.ref("uom.product_uom_unit").id,
+                "product_qty": 10.0,
+            }
+        )
+        purchase_request.button_approved()
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[purchase_request_line.id],
+        ).create({"supplier_id": self.env.ref("base.res_partner_1").id})
+        wiz_id.make_purchase_order()
+        purchase = purchase_request_line.purchase_lines[0].order_id
+        purchase.order_line.price_unit = 100.0
+        purchase.button_confirm()
+        self.assertEqual(purchase.state, "done")
+
+        allocation = purchase_request_line.purchase_request_allocation_ids[0]
+        self.assertEqual(allocation.open_product_qty, 10.0)
+
+        picking = purchase.picking_ids[0]
+        picking.move_line_ids[0].write({"qty_done": 10.0})
+        picking.button_validate()
+
+        self.assertEqual(allocation.allocated_product_qty, 10.0)
+        self.assertEqual(purchase_request_line.qty_done, 10.0)
+        self.assertTrue(
+            purchase_request.message_ids.filtered(
+                lambda m: m.subtype_id
+                == self.env.ref("purchase_request.mt_request_picking_done")
+            ),
+            "The requester was not notified of the receipt.",
+        )
+
     def test_purchase_request_stock_allocation_unlink(self):
         product = self.env.ref("product.product_product_6")
         product.uom_po_id = self.env.ref("uom.product_uom_dozen")


### PR DESCRIPTION
Fix forwarded from 18.0 to 16.0

Original pull request (18.0): https://github.com/OCA/purchase-workflow/pull/3160

`done` on a purchase order means "Locked", a modification lock, not a
completion, so a locked order must not close the allocation. See the original
PR for the full analysis and the regression history (#1419, #1422).

Tested locally on a 16.0 database: the added test fails before the fix
(`AssertionError: 0.0 != 10.0` on `open_product_qty`) and the whole
`purchase_request` suite passes after it (30 tests, 0 failed, 0 errors).
