### PR TITLE
[16.0][IMP] purchase_order_line_deep_sort: create records in batch

### DIFF
--- a/purchase_order_line_deep_sort/models/purchase_order.py
+++ b/purchase_order_line_deep_sort/models/purchase_order.py
@@ -63,18 +63,20 @@ class PurchaseOrder(models.Model):
             self._sort_purchase_line()
         return res
 
-    @api.model
-    def create(self, values):
-        purchase = super().create(values)
-        purchase._sort_purchase_line()
-        return purchase
+    @api.model_create_multi
+    def create(self, vals_list):
+        purchases = super().create(vals_list)
+        for purchase in purchases:
+            purchase._sort_purchase_line()
+        return purchases
 
 
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
-    @api.model
-    def create(self, vals):
-        line = super().create(vals)
-        line.order_id._sort_purchase_line()
-        return line
+    @api.model_create_multi
+    def create(self, vals_list):
+        lines = super().create(vals_list)
+        for order in lines.mapped("order_id"):
+            order._sort_purchase_line()
+        return lines


### PR DESCRIPTION
create() on both purchase.order and purchase.order.line was decorated with @api.model, which makes the ORM split every batched create into one call per record. Converted both to @api.model_create_multi and sort each created order once, so batched imports/EDI/order generation keep a single create() call instead of N.