### PR TITLE
[19.0][FIX] purchase_deposit: load a chart template in tests

### DIFF
--- a/purchase_deposit/tests/test_purchase_deposit.py
+++ b/purchase_deposit/tests/test_purchase_deposit.py
@@ -11,6 +11,12 @@ class TestPurchaseDeposit(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # A chart of accounts is required: accounts and taxes cannot be
+        # created on a company without one.
+        if not cls.env.company.chart_template:
+            cls.env["account.chart.template"].try_loading(
+                "generic_coa", company=cls.env.company, install_demo=False
+            )
         cls.product_model = cls.env["product.product"]
         cls.account_model = cls.env["account.account"]
         cls.invoice_model = cls.env["account.move"]


### PR DESCRIPTION
## Problem

`TestPurchaseDeposit.setUpClass` creates an `account.account` and an `account.tax`. On a database where no chart of accounts has been loaded yet, there is no `account.tax.group` and no fiscal country on the company, so the tax cannot be created:

```
psycopg2.errors.NotNullViolation: null value in column "tax_group_id" of relation "account_tax" violates not-null constraint
```

This happens on any freshly initialized database without demo data, for instance a new build on a hosting platform that installs the module from scratch. Chart templates are only auto-loaded after the module loading phase, so the tests run before any chart is available.

## Fix

Load `generic_coa` in `setUpClass` when the company has no chart template yet. Databases that already have a chart (a real database, or the OCA CI with demo data) are untouched by the guard.

Same fix as #3159 for `purchase_advance_payment`.

## Test

- Fresh database, `-i purchase_deposit --test-enable --without-demo=all`: 5/5 green (fails in `setUpClass` without the patch).
- Database with a chart already loaded: 5/5 green, unchanged.