### PR TITLE
[FIX] purchase_deposit: remove the deposit over total check

### DIFF
--- a/purchase_deposit/tests/test_purchase_deposit.py
+++ b/purchase_deposit/tests/test_purchase_deposit.py
@@ -199,14 +199,3 @@ class TestPurchaseDeposit(TransactionCase):
         deposit_line = self.po.order_line.filtered(lambda p: p.is_deposit)
         self.assertEqual(deposit_line.price_unit, 500.0)
         self.assertEqual(deposit_line.taxes_id.id, self.tax.id)
-
-    def test_not_allow_deposit_greater_than_po_total(self):
-        self.assertEqual(len(self.po.order_line), 1)
-        # We create invoice from expense
-        f = self.create_advance_payment_form()
-        f.advance_payment_method = "fixed"
-        wizard = f.save()
-        wizard.amount = 5000.0
-        wizard.deposit_account_id = self.account_deposit
-        with self.assertRaises(UserError):
-            wizard.create_invoices()

--- a/purchase_deposit/wizard/purchase_make_invoice_advance.py
+++ b/purchase_deposit/wizard/purchase_make_invoice_advance.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from odoo import Command, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, float_compare
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
 
 class PurchaseAdvancePaymentInv(models.TransientModel):
@@ -171,29 +171,6 @@ class PurchaseAdvancePaymentInv(models.TransientModel):
             amount = self.amount
             if self.advance_payment_method == "percentage":  # Case percent
                 amount = self.amount / 100 * order.amount_untaxed
-            # calculate all deposit lines
-            sum_deposit = (
-                sum(
-                    line.price_unit
-                    for line in order.order_line
-                    if (line.is_deposit and line.invoice_lines)
-                )
-                or 0.00
-            )
-            if (
-                float_compare(
-                    sum_deposit + amount,
-                    order.amount_total,
-                    precision_rounding=order.currency_id.rounding,
-                )
-                > 0
-            ):
-                raise UserError(
-                    self.env._(
-                        "The amount to be registered as deposit can't be "
-                        f"greater than total amount of {order.name}."
-                    )
-                )
             if product.purchase_method != "purchase":
                 raise UserError(
                     self.env._(


### PR DESCRIPTION
## What

Removes the "deposit can't be greater than the PO total" check added to the advance
payment wizard in #2788 (18.0 only), together with its test.

## Why

The check refuses legitimate deposits, and there is no way around it from the UI.

**1. The two sides of the comparison are not the same base.** It sums the deposit
lines' `price_unit`, which is tax excluded, and compares it against
`order.amount_total`, which is tax included. The effective ceiling therefore depends on
whether the order carries taxes: the untaxed total on a tax exempt order, the tax
included total on a taxed one. Deposit lines also carry `product_qty = 0`, so they never
contribute to `amount_total` themselves.

**2. On a multi-currency order the sum it compares has no single right value.** When the
order is in a foreign currency and the vendor bills the deposits in the company
currency, each deposit line holds an amount converted from the bill. Whichever rate that
conversion uses, the sum cannot serve as a hard limit:

- at each bill's own date (what the module does, see #3141) the amount left to bill on
  the order floats with the exchange rate. An order advanced in fixed instalments of the
  company currency stops adding up, and the last instalment is refused even though every
  single amount is right.
- at the order's own rate (`purchase.order.currency_rate`, the basis of
  `amount_total_cc`) a fully advanced order does add up — but only while that rate is
  still meaningful. On an order paid over a year or more in a high-inflation company
  currency, the order rate is stale and it inflates every later deposit instead.

I measured both bases against a set of real orders: each one unblocks some and blocks
others, several by a wide margin. That is not a bug in either conversion — an exchange
difference on a prepayment is real and has to be recognised somewhere. But it has to be
recognised in the accounting of the bills, not charged against a commercial control that
then refuses the operation.

**3. The error is not diagnosable.** The message states neither the amounts nor the
currency, so the user cannot tell how much room is left. It also builds its msgid with
an f-string inside `self.env._()`, which makes the msgid dynamic and the string
untranslatable.

Whether the sum of the deposits may exceed the order total is a business decision that
depends on the deployment (price revisions after a deposit, exchange rate drift,
deliberate over-advance). 16.0, 17.0 and 19.0 do not have this check, so removing it
also brings 18.0 back in line with the other branches.

cc @TheerayutEncoder, author of #2788.

## Test plan

- `test_not_allow_deposit_greater_than_po_total` is removed, since it asserts exactly
  the behaviour being dropped.
- Remaining suite green: `0 failed, 0 error(s) of 5 tests`.
- Discriminating check: restoring the removed test on top of this commit fails with
  `AssertionError: UserError not raised`, confirming the check is effectively gone and
  nothing else was reintroducing it.
