### PR TITLE
[19.0][FIX] purchase_order_line_description: repair tour selectors

### DIFF
--- a/purchase_order_line_description/static/tests/tours/purchase_order_line_description.esm.js
+++ b/purchase_order_line_description/static/tests/tours/purchase_order_line_description.esm.js
@@ -8,7 +8,7 @@ registry.category("web_tour.tours").add("purchase_order_line_description_manual_
         {
             content: "Open the purchase order line editor",
             trigger:
-                '.o_field_product_label_section_and_note_cell:contains("Purchase description for test product")',
+                '.o_field_product_label_section_and_note_cell textarea:value("Purchase description for test product")',
             run: "click",
         },
         {
@@ -24,7 +24,8 @@ registry.category("web_tour.tours").add("purchase_order_line_description_manual_
         },
         {
             content: "Wait for the line to leave inline edit mode",
-            trigger: ".o_field_product_label_section_and_note_cell:not(:has(textarea))",
+            trigger:
+                '.o_data_row:not(.o_selected_row) .o_field_product_label_section_and_note_cell textarea:value("Purchase description for test product test")',
         },
         {
             content: "Save the purchase order",


### PR DESCRIPTION
https://github.com/odoo/odoo/commit/21ee46537433c3fe398789af05b6304e82c78ca5
narrowed the readonly label branch to locked or cancelled orders, so a draft
order line now renders its description in a textarea instead of a text div.
The tour matched on text content, which a textarea value never exposes, so
`test_manual_description_edit_keeps_product_name_hidden_tour` has failed on
every 19.0 build since 2026-09-03, whatever the PR under test contains.
