### PR TITLE
[FIX] purchase_order_line_description: adapt the tour to the new label DOM

### DIFF
--- a/purchase_order_line_description/static/tests/tours/purchase_order_line_description.esm.js
+++ b/purchase_order_line_description/static/tests/tours/purchase_order_line_description.esm.js
@@ -8,7 +8,7 @@ registry.category("web_tour.tours").add("purchase_order_line_description_manual_
         {
             content: "Open the purchase order line editor",
             trigger:
-                '.o_field_product_label_section_and_note_cell:contains("Purchase description for test product")',
+                '.o_field_product_label_section_and_note_cell:has(textarea:value("Purchase description for test product"))',
             run: "click",
         },
         {
@@ -24,7 +24,7 @@ registry.category("web_tour.tours").add("purchase_order_line_description_manual_
         },
         {
             content: "Wait for the line to leave inline edit mode",
-            trigger: ".o_field_product_label_section_and_note_cell:not(:has(textarea))",
+            trigger: ".o_list_renderer:not(:has(.o_selected_row))",
         },
         {
             content: "Save the purchase order",


### PR DESCRIPTION
## What

Adapts the `purchase_order_line_description_manual_edit` tour to the current DOM of
`product_label_section_and_note_field`. Test-only change, no runtime code touched.

## Why

Since [odoo/odoo#285946](https://github.com/odoo/odoo/pull/285946) the read-only label
of the field is rendered as cell text only when the label is *actually* read-only:

```diff
-  <div t-if="props.readonly" ... t-out="label"/>
+  <div t-if="this.labelIsReadonly" ... t-out="label"/>
```

and `labelIsReadonly` requires the parent record to be cancelled, posted or locked. On
an open purchase order it never is, so the description now lives in the **value of a
textarea** for the whole life of the order, instead of as text in the cell.

Two steps of the tour relied on the old DOM and time out against current 19.0:

- step 1 matched the description with `:contains()`, which matches text content and not
  input values;
- step 4 detected the end of the inline edition by waiting for the textarea to
  disappear, and it no longer disappears.

So the tour fails at step 1 after a 10s timeout, and `test with Odoo` / `test with OCB`
are red on every open PR of the 19.0 branch, not only on the ones touching this module.

## Fix

Match the textarea value for the first step, and watch the selected row to know the
line left inline edit mode.

## Test plan

Reproduced and verified locally, running the module's test suite against two different
core revisions:

| core 19.0 | tour before | tour after |
|---|---|---|
| `5587c47a865` (6 Aug, before the core change) | SUCCEEDED | SUCCEEDED |
| `e809d194b88` (9 Sep, current) | FAILED at step 1/6, `Element ... has not been found. TIMEOUT step failed to complete within 10000 ms` | SUCCEEDED, `0 failed, 0 error(s) of 3 tests` |

The python assertions around the tour are untouched, so the test still checks that the
line description really ends up edited and that the product name stays out of it.
