### PR TITLE
[IMP] `purchase_order_weight_volume`: resolve total UoM via standard helper

### DIFF
--- a/purchase_order_weight_volume/models/purchase_order.py
+++ b/purchase_order_weight_volume/models/purchase_order.py
@@ -71,25 +71,12 @@ class PurchaseOrder(models.Model):
 
     @api.depends("order_line.product_uom_qty", "order_line.product_id")
     def _compute_total_physical_properties(self):
-        default_weight_uom = (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param("product_default_weight_uom_id")
-        )
-        default_volume_uom = (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param("product_default_volume_uom_id")
-        )
-
         for po in self:
             po.total_weight = 0
             po.total_volume = 0
-            if default_weight_uom:
-                po.total_weight_uom_id = int(default_weight_uom)
-            if default_volume_uom:
-                po.total_volume_uom_id = int(default_volume_uom)
-            if po.company_id.display_order_weight_in_po and po.total_weight_uom_id:
+            po.total_weight_uom_id = self.env["product.template"]._get_weight_uom_id_from_ir_config_parameter()
+            po.total_volume_uom_id = self.env["product.template"]._get_volume_uom_id_from_ir_config_parameter()
+            if po.company_id.display_order_weight_in_po:
                 po.total_weight = sum(po.mapped("order_line.line_weight"))
-            if po.company_id.display_order_volume_in_po and po.total_volume_uom_id:
+            if po.company_id.display_order_volume_in_po:
                 po.total_volume = sum(po.mapped("order_line.line_volume"))


### PR DESCRIPTION
`total_weight_uom_id` / `total_volume_uom_id` were read directly as a raw `uom.uom` id from the `ir.config_parameter` keys `product_default_weight_uom_id` / `product_default_volume_uom_id`. These parameters are only meaningful when the module `product_logistics_uom` (not in dependencies of the current module) is installed. If it is not installed, or was installed and later removed, the parameters can be missing, stale, or point to an orphaned/incompatible UoM. Since `uom.uom._compute_quantity()` does not validate that a conversion happens between compatible units, this could silently produce incorrect totals (e.g. a weight expressed in kg on the lines summed and displayed as if it were in ml on the total).

The line weight/volume UoM already resolves through `product.template._get_weight_uom_id_from_ir_config_parameter()` / `_get_volume_uom_id_from_ir_config_parameter()`, the standard Odoo helper that reads the same parameters through `product_logistics_uom`'s override when installed, and safely falls back to kg/m3 otherwise. Use the same helper for the PO total, so lines and total are always expressed in compatible UoMs.

This changes almost nothing in practice: if `product_logistics_uom` is installed and correctly configured, the helper returns the exact same UoM the raw parameter already pointed to. Whether the total is displayed at all is untouched: it can still be disabled entirely through the existing `display_order_weight_in_po` / `display_order_volume_in_po` company settings, as before.